### PR TITLE
Add autonomous developer task and alcove-developer security profile

### DIFF
--- a/.alcove/security-profiles/alcove-developer.yml
+++ b/.alcove/security-profiles/alcove-developer.yml
@@ -1,0 +1,27 @@
+name: alcove-developer
+display_name: Alcove Developer
+description: Full development lifecycle access to bmbouter/alcove — read, write, PR, merge, and release
+tools:
+  github:
+    rules:
+      - repos: ["bmbouter/alcove"]
+        operations:
+          - clone
+          - read_prs
+          - read_issues
+          - read_contents
+          - read_actions
+          - read_releases
+          - read_commits
+          - read_branches
+          - read_git
+          - push_branch
+          - create_pr_draft
+          - create_comment
+          - update_issue
+          - update_pr
+          - merge_pr
+          - delete_branch
+          - write_contents
+          - write_releases
+          - write_git

--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -1,0 +1,133 @@
+name: Autonomous Developer
+description: |
+  Triggered by new issues, reopened issues, or comments from bmbouter.
+  Plans, implements, tests, and merges changes autonomously.
+
+prompt: |
+  You are an autonomous developer for the Alcove project (bmbouter/alcove).
+  A GitHub event just occurred — either an issue was opened/reopened, or
+  bmbouter commented on an issue with new instructions.
+
+  ## Environment
+
+  You have a cloned copy of the repository. Use curl with $GITHUB_API_URL
+  and $GITHUB_TOKEN for all GitHub API calls (do NOT use the gh CLI):
+
+    curl -s -H "Authorization: token $GITHUB_TOKEN" "$GITHUB_API_URL/repos/bmbouter/alcove/..."
+
+  Write JSON payloads to files before POSTing to avoid shell escaping issues.
+
+  ## Step 1: Understand the request
+
+  Fetch all open issues and find the one that triggered this event:
+    curl -s -H "Authorization: token $GITHUB_TOKEN" \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/issues?state=open&sort=updated&direction=desc&per_page=10"
+
+  Read the issue title, body, and ALL comments. Understand what is being asked.
+
+  If the event was an issue_comment, the latest comment from bmbouter contains
+  the instructions. Read it carefully — it may refine or redirect prior work.
+
+  ## Step 2: Plan changes
+
+  Based on the issue, determine what needs to change. Alcove is a Go project
+  with these components:
+  - Bridge (cmd/bridge, internal/bridge) — REST API, scheduler, task sync
+  - Gate (cmd/gate, internal/gate) — auth proxy sidecar
+  - Skiff (cmd/skiff-init) — ephemeral worker container
+  - Dashboard (web/) — HTML/JS/CSS single-page app
+  - Docs (docs/) — markdown documentation
+  - Tests (scripts/) — bash functional test scripts
+  - Config (deploy/) — OpenShift/k8s templates
+
+  Consider ALL affected areas: Go code, API, dashboard UI, documentation,
+  functional tests, YAML task/profile definitions.
+
+  ## Step 3: Implement changes
+
+  Create a feature branch and make all changes:
+    git checkout -b issue-N-description main
+
+  Follow the codebase conventions:
+  - Go: net/http, cobra CLI, pgx/v5 for PostgreSQL, nats.go
+  - Frontend: vanilla JS (no frameworks), volume-mounted web/ directory
+  - Tests: bash scripts in scripts/ using curl against running Bridge
+  - Docs: markdown in docs/
+
+  ## Step 4: Open a Pull Request
+
+  Commit, push, and open a PR:
+    git add -A
+    Write commit message to /tmp/commit-msg.txt, then:
+    git commit -F /tmp/commit-msg.txt
+    git push origin issue-N-description
+
+  Then create the PR via API:
+    Write PR body to /tmp/pr-body.json:
+    {"title":"...","head":"issue-N-description","base":"main","body":"Fixes #N\n\n..."}
+
+    curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d @/tmp/pr-body.json \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/pulls"
+
+  Enable auto-merge on the PR:
+    curl -s -X PUT -H "Authorization: token $GITHUB_TOKEN" \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/PR_NUMBER/merge" \
+      -H "Content-Type: application/json" \
+      -d '{"merge_method":"squash","auto_merge":true}'
+
+  ## Step 5: Monitor CI
+
+  Poll the PR's check status every 30 seconds (up to 10 minutes):
+    curl -s -H "Authorization: token $GITHUB_TOKEN" \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/commits/BRANCH/status"
+
+  If checks fail:
+  1. Fetch the failed check details
+  2. Read the failure logs
+  3. Fix the issue, commit, and push to the same branch
+  4. Resume monitoring
+
+  ## Step 6: Handle blockers
+
+  If you cannot resolve an issue after 3 attempts, or if the issue requires
+  a design decision or clarification that you cannot make:
+
+  Post a comment on the issue asking bmbouter for guidance:
+    Write comment to /tmp/comment.json:
+    {"body":"@bmbouter I need your input on this issue:\n\n[describe what you need]\n\nOnce you respond, I'll continue working on this."}
+
+    curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d @/tmp/comment.json \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/issues/N/comments"
+
+  ## Important rules
+
+  - ALWAYS use curl with $GITHUB_API_URL and $GITHUB_TOKEN, never gh CLI
+  - Write JSON to files before POSTing (avoids shell escaping bugs)
+  - Keep PRs focused — one issue per PR
+  - Include tests for new functionality
+  - Update documentation when behavior changes
+  - Do not modify the changelog (that happens at release time)
+  - Reference the issue number in the PR (e.g., "Fixes #N")
+
+repo: https://github.com/bmbouter/alcove.git
+timeout: 3600
+
+profiles:
+  - alcove-developer
+
+trigger:
+  github:
+    events:
+      - issues
+      - issue_comment
+    actions:
+      - opened
+      - reopened
+      - created
+    repos:
+      - bmbouter/alcove
+    delivery_mode: polling

--- a/.alcove/tasks/issue-triage.yml
+++ b/.alcove/tasks/issue-triage.yml
@@ -1,33 +1,44 @@
 name: Issue Triage
 description: |
-  Analyze newly opened GitHub issues and provide an initial triage assessment
-  including severity, component, and suggested labels.
+  Analyze newly opened GitHub issues and post a triage assessment comment.
 
 prompt: |
-  A new issue was opened on the Alcove GitHub repository. Read the issue
-  and provide a triage assessment:
+  A new issue was opened on bmbouter/alcove. Triage it and post a comment.
 
-  1. Summarize the issue in 1-2 sentences
-  2. Suggest a severity level (critical, high, medium, low)
-  3. Identify which component(s) are affected (Bridge, Skiff, Gate, Hail,
-     Ledger, Dashboard, CLI, Docs)
-  4. Suggest appropriate labels
-  5. If the issue is a bug, suggest initial debugging steps
-  6. If the issue is a feature request, note any related existing features
+  Use curl with $GITHUB_API_URL and $GITHUB_TOKEN for all GitHub API calls:
+
+  Step 1: Fetch the most recently updated open issue:
+    curl -s -H "Authorization: token $GITHUB_TOKEN" \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/issues?state=open&sort=updated&direction=desc&per_page=1"
+
+  Step 2: Read the issue title and body. Assess:
+    1. Severity (critical, high, medium, low)
+    2. Component(s) affected: Bridge, Gate, Skiff, Dashboard, Docs, CLI, Tests
+    3. Suggested labels
+    4. If bug: initial debugging steps
+    5. If feature: related existing features
+
+  Step 3: Post a triage comment (write JSON to file first):
+    cat > /tmp/triage.json << 'JSONEOF'
+    {"body":"## Triage Assessment\n\n**Severity:** ...\n**Components:** ...\n**Suggested labels:** ...\n\n### Analysis\n..."}
+    JSONEOF
+
+    curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d @/tmp/triage.json \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/issues/ISSUE_NUMBER/comments"
 
   Be concise and actionable. Focus on helping maintainers prioritize.
 
 repo: https://github.com/bmbouter/alcove.git
+timeout: 300
 
 profiles:
-  - alcove-reader
-
-schedule:
-  cron: "*/15 * * * *"
-  enabled: false
+  - alcove-developer
 
 trigger:
   github:
     events: [issues]
     actions: [opened]
     repos: [bmbouter/alcove]
+    delivery_mode: polling


### PR DESCRIPTION
## Summary

- **autonomous-dev.yml**: New task triggered on issues opened/reopened and bmbouter comments. Autonomously plans, implements, tests, opens PRs, monitors CI, fixes failures, and merges. Asks bmbouter for input when stuck.
- **issue-triage.yml**: Updated with explicit `$GITHUB_API_URL` / `$GITHUB_TOKEN` curl instructions and `alcove-developer` profile.
- **alcove-developer.yml**: New full-lifecycle security profile — clone, read, push, PR create/update/merge, comment, release, branch delete.

## Test plan

- [ ] CI passes
- [ ] After merge and sync: verify both tasks appear in dashboard
- [ ] Verify alcove-developer profile appears on Security page
- [ ] Test by opening an issue on bmbouter/alcove

🤖 Generated with [Claude Code](https://claude.com/claude-code)