### PR TITLE
Add diagnostic logging for proxy log delivery

### DIFF
--- a/cmd/gate/main.go
+++ b/cmd/gate/main.go
@@ -62,6 +62,12 @@ func main() {
 
 	proxy := gate.NewProxy(cfg)
 
+	if cfg.LedgerURL != "" {
+		log.Printf("gate: proxy log target: %s/api/v1/sessions/%s/proxy-log", cfg.LedgerURL, cfg.SessionID)
+	} else {
+		log.Printf("gate: WARNING — GATE_LEDGER_URL is empty, proxy logs will NOT be sent")
+	}
+
 	// Start periodic log flushing to Ledger (every 30 seconds)
 	proxy.StartLogFlusher(30 * time.Second)
 

--- a/internal/gate/proxy.go
+++ b/internal/gate/proxy.go
@@ -695,6 +695,7 @@ func (p *Proxy) Stop() {
 // sendLogsToLedger sends proxy log entries to the Ledger service.
 func (p *Proxy) sendLogsToLedger(entries []internal.ProxyLogEntry) {
 	if p.config.LedgerURL == "" {
+		log.Printf("gate: GATE_LEDGER_URL is empty — cannot send %d proxy log entries", len(entries))
 		return
 	}
 
@@ -721,13 +722,14 @@ func (p *Proxy) sendLogsToLedger(entries []internal.ProxyLogEntry) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Printf("gate: failed to send proxy log to ledger: %v", err)
+		log.Printf("gate: failed to send proxy log to %s: %v", url, err)
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
-		log.Printf("gate: ledger proxy-log POST returned HTTP %d", resp.StatusCode)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		log.Printf("gate: ledger proxy-log POST to %s returned HTTP %d: %s", url, resp.StatusCode, string(body))
 	} else {
 		log.Printf("gate: flushed %d proxy log entries to ledger", len(entries))
 	}


### PR DESCRIPTION
## Summary
- Log `GATE_LEDGER_URL` at Gate startup to identify misconfiguration
- Log the full URL on POST failures for debugging connectivity
- Warn when `GATE_LEDGER_URL` is empty (entries silently dropped)

Investigating empty proxy logs on staging (OpenShift).

## Test plan
- [ ] CI passes
- [ ] Deploy to staging and check Gate logs for proxy log target URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)