### PR TITLE
Fix empty proxy logs on short-lived tasks

### DIFF
--- a/cmd/gate/main.go
+++ b/cmd/gate/main.go
@@ -68,8 +68,9 @@ func main() {
 		log.Printf("gate: WARNING — GATE_LEDGER_URL is empty, proxy logs will NOT be sent")
 	}
 
-	// Start periodic log flushing to Ledger (every 30 seconds)
-	proxy.StartLogFlusher(30 * time.Second)
+	// Start periodic log flushing to Ledger (every 5 seconds).
+	// Short interval ensures logs are captured even for fast-completing tasks.
+	proxy.StartLogFlusher(5 * time.Second)
 
 	server := &http.Server{
 		Addr:         ":8443",
@@ -93,7 +94,15 @@ func main() {
 	<-ctx.Done()
 	log.Println("gate: shutting down...")
 
-	// Stop the log flusher (triggers final flush)
+	// Flush remaining proxy logs synchronously before stopping the server.
+	// This ensures logs are delivered even for short-lived tasks.
+	entries := proxy.FlushLogs()
+	if len(entries) > 0 {
+		log.Printf("gate: final flush of %d proxy log entries", len(entries))
+		proxy.SendLogs(entries)
+	}
+
+	// Stop the periodic log flusher goroutine.
 	proxy.Stop()
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/internal/gate/proxy.go
+++ b/internal/gate/proxy.go
@@ -673,13 +673,13 @@ func (p *Proxy) StartLogFlusher(interval time.Duration) {
 			case <-ticker.C:
 				entries := p.FlushLogs()
 				if len(entries) > 0 {
-					p.sendLogsToLedger(entries)
+					p.SendLogs(entries)
 				}
 			case <-p.stopChan:
 				// Final flush
 				entries := p.FlushLogs()
 				if len(entries) > 0 {
-					p.sendLogsToLedger(entries)
+					p.SendLogs(entries)
 				}
 				return
 			}
@@ -692,8 +692,8 @@ func (p *Proxy) Stop() {
 	close(p.stopChan)
 }
 
-// sendLogsToLedger sends proxy log entries to the Ledger service.
-func (p *Proxy) sendLogsToLedger(entries []internal.ProxyLogEntry) {
+// SendLogs sends proxy log entries to the Ledger service.
+func (p *Proxy) SendLogs(entries []internal.ProxyLogEntry) {
 	if p.config.LedgerURL == "" {
 		log.Printf("gate: GATE_LEDGER_URL is empty — cannot send %d proxy log entries", len(entries))
 		return


### PR DESCRIPTION
## Summary
Root cause: Gate's 30-second flush interval meant tasks completing in < 30s never flushed proxy logs. On Kubernetes, the container was killed before the async shutdown flush completed.

**Fix:**
- Reduce flush interval from 30s to 5s
- Flush remaining logs synchronously during shutdown before stopping the server
- Export `SendLogs` method for direct synchronous calls

## Test plan
- [ ] CI passes
- [ ] Deploy to staging, run a short task, verify proxy log appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)