### PR TITLE
Release v0.4.2 changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,12 @@
 All notable changes to Alcove are documented here. This project uses
 [Semantic Versioning](https://semver.org/).
 
+## v0.4.2
+
+### Bug Fixes
+- Fix empty proxy logs on short-lived tasks: reduced Gate flush interval from
+  30s to 5s and added synchronous flush on shutdown before container exits.
+
 ## v0.4.1
 
 ### Bug Fixes


### PR DESCRIPTION
Changelog for v0.4.2 — fix empty proxy logs.