### PR TITLE
Fix SSE: remove illegal Transfer-Encoding header and padding

### DIFF
--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -384,20 +384,10 @@ func (a *API) streamTranscriptSSE(w http.ResponseWriter, r *http.Request, sessio
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("X-Accel-Buffering", "no")     // Disable nginx buffering
-	w.Header().Set("Transfer-Encoding", "chunked") // Force chunked encoding through proxies
+	w.Header().Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
-
-	// Send padding blocks to force proxy buffers to flush. 3scale/Turnpike on
-	// OpenShift may buffer 16-32KB before forwarding. SSE comment lines (: prefix)
-	// are ignored by EventSource clients. Send 32KB in multiple flushes.
-	for i := 0; i < 8; i++ {
-		fmt.Fprintf(w, ": %s\n", strings.Repeat(" ", 4096))
-		flusher.Flush()
-	}
-	fmt.Fprint(w, "\n")
 	flusher.Flush()
-	log.Printf("sse: streaming transcript for session %s (client: %s, sent 32KB padding)", sessionID, r.RemoteAddr)
+	log.Printf("sse: streaming transcript for session %s (client: %s)", sessionID, r.RemoteAddr)
 
 	// Phase 1: Catch-up — send persisted events from database
 	var transcript json.RawMessage


### PR DESCRIPTION
## Summary
Remove `Transfer-Encoding: chunked` header (illegal in HTTP/2, causes browser to reject response) and the 32KB padding blocks. Go handles chunked encoding automatically.

## Test plan
- [ ] CI passes
- [ ] Deploy to staging, run long task, verify Live indicator appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)