### PR TITLE
Fix SSE: withCredentials for Turnpike SSO authentication

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2025,9 +2025,10 @@
                 if (token) {
                     sseUrl += '&token=' + encodeURIComponent(token);
                 }
-                console.log('[SSE] Opening EventSource:', sseUrl);
+                var sseOpts = rhIdentityMode ? { withCredentials: true } : undefined;
+                console.log('[SSE] Opening EventSource:', sseUrl, 'rhIdentityMode:', rhIdentityMode, 'withCredentials:', !!sseOpts);
                 console.log('[SSE] basePath:', basePath, 'token:', token ? 'present' : 'null');
-                sseSource = new EventSource(sseUrl);
+                sseSource = new EventSource(sseUrl, sseOpts);
                 console.log('[SSE] EventSource created, readyState:', sseSource.readyState);
 
                 // Safety timeout: if SSE hasn't connected in 5s, hide spinner and fall back


### PR DESCRIPTION
## Summary
**Root cause**: `EventSource` doesn't send cookies by default. Turnpike authenticates via SSO cookies. Without them, Turnpike redirects to the login page (302 → HTML). EventSource receives HTML instead of `text/event-stream`, stays at `readyState=0` forever.

**Fix**: `new EventSource(url, { withCredentials: true })` in rh-identity mode.

**Evidence from browser console**:
```
[SSE] EventSource created, readyState: 0
[SSE] 5s timeout fired, sseConnected: false readyState: 0
```
- `onopen` never fires, `onerror` never fires
- readyState stuck at 0 = browser waiting for valid SSE response
- Consistent with receiving HTML (login page) instead of text/event-stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)