### PR TITLE
Fix transcript not appearing during running sessions

### DIFF
--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -30,6 +30,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"syscall"
 	"time"
 
@@ -255,6 +256,7 @@ func runClaude(
 
 	var (
 		batch            []json.RawMessage
+		batchMu          sync.Mutex
 		artifacts        []internal.Artifact
 		lastEvent        = time.Now()
 		ticker           = time.NewTicker(walFlushInterval)
@@ -264,7 +266,7 @@ func runClaude(
 	)
 	defer ticker.Stop()
 
-	// Monitor heartbeat timeout and cancellation in a goroutine
+	// Monitor heartbeat timeout, periodic batch flush, and cancellation
 	go func() {
 		for {
 			select {
@@ -286,6 +288,13 @@ func runClaude(
 					_ = cmd.Process.Kill()
 					return
 				}
+				// Periodic flush: write buffered transcript events to the database
+				// so polling clients see data before the batch reaches 50 events.
+				batchMu.Lock()
+				if len(batch) > 0 {
+					flushBatch(lc, sessionID, &batch)
+				}
+				batchMu.Unlock()
 			}
 		}
 	}()
@@ -322,20 +331,24 @@ func runClaude(
 			continue // skip malformed lines
 		}
 
+		batchMu.Lock()
 		batch = append(batch, json.RawMessage(lineCopy))
 
 		// Flush batch when it reaches the batch size
 		if len(batch) >= walBatchSize {
 			flushBatch(lc, sessionID, &batch)
 		}
+		batchMu.Unlock()
 	}
 
 	close(doneCh)
 
 	// Flush remaining events
+	batchMu.Lock()
 	if len(batch) > 0 {
 		flushBatch(lc, sessionID, &batch)
 	}
+	batchMu.Unlock()
 
 	// Wait for process to exit
 	err = cmd.Wait()

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2018,6 +2018,19 @@
             show(loading);
         }
 
+        // If running and already streaming, don't restart — just show Live indicator
+        if (status === 'running' && sseSource && silent) {
+            showLiveIndicator();
+            return;
+        }
+
+        // If running and this is a silent refresh (polling), just fetch transcript data
+        if (status === 'running' && !sseSource && silent) {
+            showLiveIndicator();
+            fetchTranscript(id, content, loading);
+            return;
+        }
+
         // If running, try fetch-based streaming first
         if (status === 'running') {
             stopSSE();


### PR DESCRIPTION
## Summary
**Root cause**: Skiff's transcript batch only flushed to the database every 50 events or at session end. The 5-second flush timer existed but was never used for flushing — only for heartbeat timeout. Polling clients read from the DB and saw nothing until the session completed.

**Fix**: Use the existing 5-second ticker to also flush the transcript batch to the database. Add mutex for concurrent access protection.

Also fixes the client to not abort streaming on polling refresh, and shows Live indicator during polling fallback.

## Test plan
- [ ] CI passes
- [ ] Local dev: streaming still works in real-time
- [ ] Staging: transcript appears within 5 seconds of first output, Live indicator shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)