### PR TITLE
Fix transcript polling after stream ends through proxy

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2124,10 +2124,13 @@
                     }
                 }
 
-                hideLiveIndicator();
-                return; // Stream completed normally
+                // Stream ended — clear sseSource so polling can take over
+                sseSource = null;
+                console.log('[STREAM] Stream ended, falling back to polling');
+                // Don't return — fall through to fetchTranscript for current data
 
             } catch (streamErr) {
+                sseSource = null;
                 console.log('[STREAM] Streaming failed, using polling fallback:', streamErr.message);
                 // Fall through to polling
             }


### PR DESCRIPTION
## Summary
On staging, the fetch stream connects but closes immediately (proxy doesn't hold SSE connections). The client treated this as "streaming active" and never polled the DB for transcript data.

**Fix**: Clear `sseSource` when the stream ends so the 5-second polling refresh fetches transcript from the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)