### PR TITLE
Replace transcript streaming with 5-second polling

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -313,11 +313,9 @@ curl -X DELETE http://localhost:8080/api/v1/sessions/f47ac10b-58cc-4372-a567-0e0
 
 ### GET /api/v1/sessions/{id}/transcript
 
-Retrieve the transcript for a session.
+Retrieve the transcript for a session. Returns the full transcript as a JSON response. Skiff flushes transcript events to the database every 5 seconds, so polling this endpoint at a similar interval provides near-real-time updates for running sessions.
 
-When called with `Accept: text/event-stream` or `?stream=true`, this endpoint streams live transcript events using SSE-formatted data (`Content-Type: text/event-stream`) until the session completes or the client disconnects. Otherwise, it returns the full transcript as a static JSON response.
-
-**Static response (200):**
+**Response (200):**
 
 ```json
 {
@@ -338,50 +336,19 @@ When called with `Accept: text/event-stream` or `?stream=true`, this endpoint st
 }
 ```
 
-**SSE stream:** The endpoint returns `Content-Type: text/event-stream` with SSE-formatted data. Each event is a `data:` line containing a JSON transcript event. When the session reaches a terminal state (`completed`, `error`, `timeout`, `cancelled`), a `done` event is sent:
-
-```
-data: {"type":"assistant","content":"Reading file...","ts":"2026-03-25T14:30:05Z"}
-
-data: {"type":"tool","tool":"Read","input":{"file_path":"/src/main.go"},"ts":"2026-03-25T14:30:10Z"}
-
-event: done
-data: {"status":"completed"}
-```
-
-**Client implementation note:** Use `fetch()` + `ReadableStream` to consume this endpoint, not `EventSource`. The `EventSource` API is incompatible with the Akamai + Turnpike proxy chain used in OpenShift staging deployments. For cookie-based auth environments (e.g., Turnpike), include `credentials: 'include'` in the fetch options. If streaming is unavailable, clients should fall back to polling the static transcript endpoint every 5 seconds.
-
-```javascript
-// Recommended client pattern
-const response = await fetch(url + '?stream=true', {
-  headers: { 'Authorization': 'Bearer ' + token },
-  credentials: 'include'  // Required for cookie-based auth (Turnpike)
-});
-const reader = response.body.getReader();
-const decoder = new TextDecoder();
-while (true) {
-  const { done, value } = await reader.read();
-  if (done) break;
-  // Parse SSE-formatted lines from decoder.decode(value)
-}
-```
+**Client implementation note:** The dashboard polls this endpoint every 5 seconds while the session status is `running`, and shows a live indicator. This is the same approach used for the proxy log tab. The `?stream=true` query parameter activates an SSE endpoint on the server (returns `Content-Type: text/event-stream`), but the dashboard does not use it because both `EventSource` and `fetch()+ReadableStream` are incompatible with the Akamai + Turnpike proxy chain in OpenShift staging deployments.
 
 **Status codes:**
 
 | Code | Meaning |
 |------|---------|
-| 200  | Transcript returned (or SSE stream started) |
+| 200  | Transcript returned |
 | 404  | Session or transcript not found |
 
-**curl examples:**
+**curl example:**
 
 ```bash
-# Static fetch
 curl http://localhost:8080/api/v1/sessions/$SESSION_ID/transcript \
-  -H "Authorization: Bearer $TOKEN"
-
-# Live SSE stream
-curl -N http://localhost:8080/api/v1/sessions/$SESSION_ID/transcript?stream=true \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/docs/design/architecture-decisions.md
+++ b/docs/design/architecture-decisions.md
@@ -187,15 +187,18 @@ claude \
 | Manual cancel | Bridge sends cancel via NATS topic `tasks.<id>.cancel`; init sends `SIGTERM` |
 | Heartbeat timeout | Init monitors stream-json stdout; 10 min silence triggers `SIGTERM` |
 
-### 10. Session Transcript Streaming
+### 10. Session Transcript Delivery
 
-**Decision**: Real-time streaming with local write-ahead log.
+**Decision**: Write-ahead log with periodic flush to database; dashboard uses polling.
 
 1. Init process reads Claude Code's NDJSON stdout line-by-line
 2. Each event is written to local WAL (`/tmp/alcove-transcript-<id>.jsonl`)
-3. Events are batched and sent to Ledger via HTTP
+3. Events are flushed to the database every 5 seconds via HTTP POST
 4. On exit, final reconciliation flushes any unsent events
 5. Pod `terminationGracePeriodSeconds: 60` allows flush to complete
+6. Dashboard polls `GET /api/v1/sessions/{id}/transcript` every 5 seconds
+   (same approach as proxy log). Client-side streaming (EventSource and
+   fetch+ReadableStream) was removed due to Akamai/Turnpike incompatibility.
 
 ### 11. Vertex AI Credentials
 

--- a/docs/design/implementation-status.md
+++ b/docs/design/implementation-status.md
@@ -16,7 +16,7 @@ all resolved decisions.
 | Controller | **Bridge** | REST API, dashboard, task dispatch, scheduler, admin settings, security profile builder |
 | Worker | **Skiff** | Ephemeral Claude Code execution |
 | Auth Proxy | **Gate** | Sidecar proxy: token swap, LLM API proxy, SCM proxy (`/github/`, `/gitlab/`), scope enforcement, MCP tool configs |
-| Message Bus | **Hail** | NATS-based status, transcript streaming, cancellation |
+| Message Bus | **Hail** | NATS-based status, transcript ingestion, cancellation |
 | Session Store | **Ledger** | PostgreSQL session records, transcripts, proxy logs |
 
 ## What's Built (Phase 1 — functional)
@@ -79,7 +79,7 @@ alcove/
 ├── web/
 │   ├── index.html              ✅ Dashboard SPA shell with all page views, setup checklist
 │   ├── css/style.css           ✅ Dark theme dashboard styles
-│   └── js/app.js               ✅ Full SPA: login, task list with pagination, new task form with profile selection, live transcript viewer (fetch + ReadableStream with polling fallback), proxy log viewer, providers page, security profiles page, MCP tools page, schedules with NLP cron input, admin settings, user management, guided setup checklist, contextual warnings
+│   └── js/app.js               ✅ Full SPA: login, task list with pagination, new task form with profile selection, live transcript viewer (5-second polling from database), proxy log viewer, providers page, security profiles page, MCP tools page, schedules with NLP cron input, admin settings, user management, guided setup checklist, contextual warnings
 ├── build/
 │   ├── Containerfile.bridge    ✅ Multi-stage (golang:1.25 → ubi9/ubi)
 │   ├── Containerfile.gate      ✅ Multi-stage (golang:1.25 → ubi9-minimal)
@@ -133,11 +133,12 @@ alcove/
 
 2. **Dashboard Frontend** — Full SPA in `web/` with login form, task list with
    status filters, search, and pagination, new task form with provider and profile
-   selection and debug toggle, task detail view with live transcript streaming
-   (fetch + ReadableStream with catch-up + live, fallback to polling) and proxy log tabs, providers page, security profiles
-   page, MCP tools page, schedules page with NLP-style cron input, admin settings
-   page (system LLM shown as read-only status), user management page, guided
-   setup checklist with contextual warnings. Dark theme.
+   selection and debug toggle, task detail view with live transcript viewer
+   (5-second polling from database, same as proxy log) and proxy log tabs,
+   providers page, security profiles page, MCP tools page, schedules page with
+   NLP-style cron input, admin settings page (system LLM shown as read-only
+   status), user management page, guided setup checklist with contextual
+   warnings. Live indicator shown while session status is 'running'. Dark theme.
 
 3. **Ledger Ingestion API** — Bridge serves POST endpoints for transcript, status,
    and proxy-log ingestion:
@@ -192,17 +193,15 @@ alcove/
     `GH_HOST`, `GLAB_HOST`, `GATE_CREDENTIAL_URL`, `GIT_SSH_COMMAND`, etc.) are
     injected by Bridge when the task scope includes a `github` or `gitlab` service.
 
-11. **Real-Time Transcript Streaming** — Skiff publishes transcript events to NATS
-    via `hail.PublishTranscript()`. Bridge subscribes to the NATS subject for the
-    session and streams events to the dashboard via SSE. The SSE endpoint implements
-    catch-up + live: on connect, it sends all persisted transcript events from the
-    database, then subscribes to NATS for live events. Status updates are also
-    streamed so the client detects session completion. The dashboard uses
-    `fetch()` + `ReadableStream` for real-time streaming (not `EventSource`, which
-    is incompatible with the Akamai + Turnpike proxy chain used on OpenShift
-    staging). If streaming is unavailable, the client automatically falls back to
-    5-second polling. This approach works on both local dev and OpenShift staging.
-    Auth supports query-param token fallback for SSE connections.
+11. **Transcript Viewing** — Skiff flushes transcript events to the database
+    every 5 seconds via `POST /api/v1/sessions/{id}/transcript`. The dashboard
+    polls `GET /api/v1/sessions/{id}/transcript` every 5 seconds (same approach
+    as proxy log). A live indicator is shown while the session status is
+    'running'. Client-side streaming (EventSource and fetch+ReadableStream)
+    was removed due to incompatibility with the Akamai + Turnpike proxy chain
+    used on OpenShift staging. The `?stream=true` SSE endpoint still exists on
+    the server but is not used by the dashboard. This polling approach works
+    reliably on both local dev and OpenShift staging.
 
 12. **Security Profiles** — Named, reusable bundles of tool + repo + operation
     permissions. Supports multi-rule per-repo operation scoping (each rule specifies

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -52,7 +52,6 @@
     // ---------------------
     let refreshInterval = null;
     let durationInterval = null;
-    let sseSource = null;
     let currentSessionId = null;
     let currentPage = 1;
     const perPage = 15;
@@ -1796,12 +1795,6 @@
             loadTranscript(id, session.status);
             loadProxyLog(id);
 
-            // Hide live indicator for completed sessions
-            if (session.status !== 'running') {
-                hideLiveIndicator();
-                stopSSE();
-            }
-
             // Auto-refresh while running
             if (session.status === 'running') {
                 stopRefresh();
@@ -2018,164 +2011,45 @@
             show(loading);
         }
 
-        // If running and already streaming, don't restart — just show Live indicator
-        if (status === 'running' && sseSource && silent) {
-            showLiveIndicator();
-            return;
-        }
-
-        // If running and this is a silent refresh (polling), just fetch transcript data
-        if (status === 'running' && !sseSource && silent) {
-            showLiveIndicator();
-            fetchTranscript(id, content, loading);
-            return;
-        }
-
-        // If running, try fetch-based streaming first
+        // Show Live indicator while session is running
         if (status === 'running') {
-            stopSSE();
-
-            try {
-                const streamUrl = basePath + '/api/v1/sessions/' + id + '/transcript?stream=true';
-                const fetchOpts = { credentials: 'include' };
-                const token = localStorage.getItem('alcove_token');
-                if (token) {
-                    fetchOpts.headers = { 'Authorization': 'Bearer ' + token };
-                }
-                console.log('[STREAM] Starting fetch stream:', streamUrl);
-
-                const streamController = new AbortController();
-                fetchOpts.signal = streamController.signal;
-
-                // Store controller so stopSSE() can abort it
-                sseSource = { close: function() { streamController.abort(); } };
-
-                const response = await fetch(streamUrl, fetchOpts);
-
-                if (!response.ok) {
-                    console.log('[STREAM] Fetch failed:', response.status);
-                    throw new Error('Stream fetch failed');
-                }
-
-                if (!response.body) {
-                    console.log('[STREAM] No ReadableStream support, falling back to polling');
-                    throw new Error('No ReadableStream');
-                }
-
-                console.log('[STREAM] Connected, content-type:', response.headers.get('content-type'));
-                hide(loading);
-                showLiveIndicator();
-
-                const reader = response.body.getReader();
-                const decoder = new TextDecoder();
-                let buffer = '';
-
-                try {
-                    while (true) {
-                        const { done, value } = await reader.read();
-                        if (done) {
-                            console.log('[STREAM] Stream ended');
-                            break;
-                        }
-
-                        buffer += decoder.decode(value, { stream: true });
-                        const lines = buffer.split('\n');
-                        buffer = lines.pop(); // Keep incomplete line
-
-                        for (const line of lines) {
-                            const trimmed = line.trim();
-                            if (!trimmed || trimmed.startsWith(':')) continue; // Skip empty lines and SSE comments
-
-                            if (trimmed.startsWith('data: ')) {
-                                const data = trimmed.slice(6);
-                                try {
-                                    const ev = JSON.parse(data);
-                                    if (ev.status === 'completed' || ev.status === 'error' ||
-                                        ev.status === 'timeout' || ev.status === 'cancelled') {
-                                        // Session done
-                                        hideLiveIndicator();
-                                        stopSSE();
-                                        // Reload full session after delay
-                                        setTimeout(function() {
-                                            loadTranscript(id, ev.status);
-                                            loadProxyLog(id);
-                                        }, 2000);
-                                        return;
-                                    }
-                                    const isAtBottom = content.scrollHeight - content.scrollTop - content.clientHeight < 50;
-                                    appendTranscriptEvent(content, ev);
-                                    if (isAtBottom) content.scrollTop = content.scrollHeight;
-                                } catch (e) {
-                                    // Non-JSON data line
-                                    appendTranscriptEvent(content, { type: 'system', content: data });
-                                }
-                            } else if (trimmed.startsWith('event: done')) {
-                                // SSE done event — next data line has the status
-                                continue;
-                            } else if (trimmed.startsWith('event: status')) {
-                                // SSE status event — next data line has the update
-                                continue;
-                            }
-                        }
-                    }
-                } catch (readErr) {
-                    if (readErr.name !== 'AbortError') {
-                        console.log('[STREAM] Read error:', readErr.message);
-                    }
-                }
-
-                // Stream ended — clear sseSource so polling can take over
-                sseSource = null;
-                console.log('[STREAM] Stream ended, falling back to polling');
-                // Don't return — fall through to fetchTranscript for current data
-
-            } catch (streamErr) {
-                sseSource = null;
-                console.log('[STREAM] Streaming failed, using polling fallback:', streamErr.message);
-                // Fall through to polling
-            }
+            showLiveIndicator();
+        } else {
+            hideLiveIndicator();
         }
 
-        // Polling fallback (also used for completed sessions)
-        fetchTranscript(id, content, loading);
-    }
-
-    async function fetchTranscript(id, content, loading) {
         try {
             const resp = await api('GET', '/api/v1/sessions/' + id + '/transcript');
             hide(loading);
 
             if (!resp.ok) {
-                content.innerHTML = '<div class="empty-state"><p>No transcript available.</p></div>';
+                if (!silent) {
+                    content.innerHTML = '<div class="transcript-system">No transcript available.</div>';
+                }
                 return;
             }
 
             const data = await resp.json();
-            let events = Array.isArray(data) ? data : (data.events || data.transcript || []);
+            const events = Array.isArray(data) ? data : (data.transcript || data.events || []);
 
             if (events.length === 0) {
-                content.innerHTML = '<div class="empty-state"><p>No transcript events yet.</p></div>';
+                if (!silent) {
+                    content.innerHTML = '<div class="transcript-system">Waiting for output...</div>';
+                }
                 return;
             }
 
+            // Re-render all events (simple and reliable)
             content.innerHTML = '';
-
-            const MAX_EVENTS = 500;
-            if (events.length > MAX_EVENTS) {
-                const notice = document.createElement('div');
-                notice.className = 'empty-state';
-                notice.innerHTML = '<p>Showing last ' + MAX_EVENTS + ' of ' + events.length + ' events.</p>';
-                content.appendChild(notice);
-                events = events.slice(-MAX_EVENTS);
+            for (var i = 0; i < events.length; i++) {
+                appendTranscriptEvent(content, events[i]);
             }
-
-            events.forEach((ev) => appendTranscriptEvent(content, ev));
-            // Auto-scroll to bottom for completed sessions
+            // Auto-scroll to bottom
             content.scrollTop = content.scrollHeight;
         } catch (err) {
             hide(loading);
-            if (err.message !== 'unauthorized') {
-                content.innerHTML = '<div class="empty-state"><p>Failed to load transcript.</p></div>';
+            if (err.message !== 'unauthorized' && !silent) {
+                content.innerHTML = '<div class="transcript-system" style="color:var(--status-error)">Failed to load transcript.</div>';
             }
         }
     }
@@ -2517,11 +2391,7 @@
     }
 
     function stopSSE() {
-        if (sseSource) {
-            sseSource.close();
-            sseSource = null;
-        }
-        hideLiveIndicator();
+        // No-op: streaming removed, transcript uses polling
     }
 
     // ---------------------


### PR DESCRIPTION
## Summary
Remove all streaming code. Transcript now polls the database every 5 seconds, exactly like proxy log — which works perfectly on both local dev and staging.

**Why streaming failed on staging:** `fetch()` to the SSE endpoint hangs forever through Akamai/Turnpike. The proxy holds the connection but never delivers response headers to the browser. Eight releases (v0.4.2-v0.4.11) tried to fix this. Polling is the correct solution.

## Test plan
- [ ] CI passes
- [ ] Local dev: transcript appears within 5 seconds, Live indicator shows
- [ ] Staging: transcript appears within 5 seconds, Live indicator shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)