### PR TITLE
Add label-based trigger filtering for event-triggered tasks

### DIFF
--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -10,18 +10,11 @@ prompt: |
 
   ## Security Check (MUST DO FIRST)
 
-  Before taking ANY action, you must verify two things:
+  If the event was an issue_comment, verify the comment author is "bmbouter".
+  If the comment is from anyone else, do nothing and exit immediately.
 
-  1. Fetch the triggering issue and check its labels. If the issue does NOT
-     have the "ready-for-dev" label, do nothing and exit immediately. The
-     "ready-for-dev" label is the authorization gate — only repo admins can
-     add it, and it signals that the issue has been reviewed and approved
-     for autonomous development.
-
-  2. If the event was an issue_comment, verify the comment author is "bmbouter".
-     If the comment is from anyone else, do nothing and exit immediately.
-
-  If either check fails, exit with no output and no side effects.
+  Note: The "ready-for-dev" label check is enforced at the trigger level —
+  this task only fires for issues/PRs that already have the label.
 
   ## Environment
 
@@ -37,8 +30,6 @@ prompt: |
   Fetch all open issues and find the one that triggered this event:
     curl -s -H "Authorization: token $GITHUB_TOKEN" \
       "$GITHUB_API_URL/repos/bmbouter/alcove/issues?state=open&sort=updated&direction=desc&per_page=10"
-
-  Check the issue's labels array — if "ready-for-dev" is not present, exit now.
 
   Read the issue title, body, and ALL comments. Understand what is being asked.
 
@@ -148,4 +139,6 @@ trigger:
       - created
     repos:
       - bmbouter/alcove
+    labels:
+      - ready-for-dev
     delivery_mode: polling

--- a/.alcove/tasks/issue-triage.yml
+++ b/.alcove/tasks/issue-triage.yml
@@ -7,14 +7,12 @@ prompt: |
 
   Use curl with $GITHUB_API_URL and $GITHUB_TOKEN for all GitHub API calls:
 
-  Step 1: Fetch the most recently updated open issue and check for the
-  "ready-for-dev" label:
+  Note: The "ready-for-dev" label check is enforced at the trigger level —
+  this task only fires for issues that already have the label.
+
+  Step 1: Fetch the most recently updated open issue:
     curl -s -H "Authorization: token $GITHUB_TOKEN" \
       "$GITHUB_API_URL/repos/bmbouter/alcove/issues?state=open&sort=updated&direction=desc&per_page=1"
-
-  Check the issue's labels array. If the issue does NOT have the "ready-for-dev"
-  label, exit immediately without commenting. Only triage issues that have been
-  explicitly approved with this label.
 
   Step 2: Read the issue title and body. Assess:
     1. Severity (critical, high, medium, low)
@@ -46,4 +44,6 @@ trigger:
     events: [issues]
     actions: [opened]
     repos: [bmbouter/alcove]
+    labels:
+      - ready-for-dev
     delivery_mode: polling

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1714,7 +1714,22 @@ Task definitions with event triggers (e.g., GitHub `issues.opened`) support two 
 - **`polling`** (default) — Alcove polls the GitHub Events API every 60 seconds. No webhook setup required. Suitable for local development and environments without a public URL.
 - **`webhook`** — GitHub pushes events to `POST /api/v1/webhooks/github`. Requires a publicly accessible Bridge URL and a configured webhook secret.
 
-See [Configuration Reference](configuration.md#event-delivery-mode) for YAML syntax and details.
+### Event Trigger Label Filtering
+
+The trigger configuration supports an optional `labels` field (string array). When specified, the event is only dispatched if at least one of the listed labels is present on the issue or pull request. This acts as a safety gate to prevent unauthorized issues from triggering automated tasks.
+
+```yaml
+trigger:
+  github:
+    events: [issues]
+    actions: [opened, labeled]
+    repos: [org/myproject]
+    labels: [ready-for-dev]
+```
+
+If `labels` is omitted or empty, all matching events are dispatched.
+
+See [Configuration Reference](configuration.md#label-based-trigger-filtering) for full details.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,6 +442,7 @@ schedule: "0 2 * * *"
 | `profiles`  | string[] | no       | Security profile names to apply |
 | `tools`     | string[] | no       | MCP tool names to enable |
 | `schedule`  | string   | no       | Cron expression for automatic execution |
+| `labels`    | string[] | no       | GitHub issue/PR labels for event filtering (see below) |
 
 ### Event Delivery Mode
 
@@ -462,6 +463,29 @@ trigger:
 ```
 
 Polling uses GitHub's conditional request support (ETags) to minimize API usage. On first poll, existing events are skipped to avoid a flood of retroactive task dispatches.
+
+### Label-Based Trigger Filtering
+
+The `labels` field provides a safety gate for event triggers. When specified,
+an event is only dispatched if at least one of the listed labels is present on
+the issue or pull request. This prevents unauthorized or unexpected issues from
+triggering automated development tasks.
+
+```yaml
+name: auto-fix
+prompt: |
+  Investigate and fix the issue described above.
+repo: https://github.com/org/myproject.git
+trigger:
+  github:
+    events: [issues]
+    actions: [opened, labeled]
+    repos: [org/myproject]
+    labels: [ready-for-dev]
+```
+
+If `labels` is omitted or empty, all matching events are dispatched regardless
+of labels on the issue or PR.
 
 Task definitions appear in the dashboard where users can run them directly or
 view the source YAML. Starter templates are also available via

--- a/docs/design/implementation-status.md
+++ b/docs/design/implementation-status.md
@@ -286,6 +286,11 @@ alcove/
     avoid retroactive dispatches. Works in any environment including local
     development with no webhook configuration required.
 
+25. **Label-Based Trigger Filtering** — Event triggers support an optional
+    `labels` field that restricts dispatch to issues or PRs carrying at least
+    one of the listed GitHub labels. This provides a safety gate that prevents
+    unauthorized issues from triggering automated development tasks.
+
 ## What's NOT Working Yet
 
 ### 1. NATS Dead Code

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -1709,6 +1709,30 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Extract labels from issue or pull_request.
+	var labels []string
+	if issue, ok := payload["issue"].(map[string]any); ok {
+		if labelArr, ok := issue["labels"].([]any); ok {
+			for _, lo := range labelArr {
+				if lm, ok := lo.(map[string]any); ok {
+					if name, ok := lm["name"].(string); ok {
+						labels = append(labels, name)
+					}
+				}
+			}
+		}
+	} else if pr, ok := payload["pull_request"].(map[string]any); ok {
+		if labelArr, ok := pr["labels"].([]any); ok {
+			for _, lo := range labelArr {
+				if lm, ok := lo.(map[string]any); ok {
+					if name, ok := lm["name"].(string); ok {
+						labels = append(labels, name)
+					}
+				}
+			}
+		}
+	}
+
 	// Extract additional info for dispatched tasks.
 	sha := ""
 	prNumber := ""
@@ -1795,7 +1819,7 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		if trigger.GitHub == nil || !trigger.GitHub.Matches(eventType, action, repo, branch) {
+		if trigger.GitHub == nil || !trigger.GitHub.Matches(eventType, action, repo, branch, labels) {
 			continue
 		}
 

--- a/internal/bridge/poller.go
+++ b/internal/bridge/poller.go
@@ -285,11 +285,35 @@ func (p *GitHubPoller) pollRepo(ctx context.Context, repo, owner string, schedul
 			}
 		}
 
+		// Extract labels from issue or pull_request.
+		var labels []string
+		if issue, ok := payload["issue"].(map[string]interface{}); ok {
+			if labelArr, ok := issue["labels"].([]interface{}); ok {
+				for _, lo := range labelArr {
+					if lm, ok := lo.(map[string]interface{}); ok {
+						if name, ok := lm["name"].(string); ok {
+							labels = append(labels, name)
+						}
+					}
+				}
+			}
+		} else if pr, ok := payload["pull_request"].(map[string]interface{}); ok {
+			if labelArr, ok := pr["labels"].([]interface{}); ok {
+				for _, lo := range labelArr {
+					if lm, ok := lo.(map[string]interface{}); ok {
+						if name, ok := lm["name"].(string); ok {
+							labels = append(labels, name)
+						}
+					}
+				}
+			}
+		}
+
 		eventRepo := event.Repo.Name
 
 		// Match against each schedule.
 		for _, sched := range schedules {
-			if !sched.Trigger.Matches(eventType, action, eventRepo, branch) {
+			if !sched.Trigger.Matches(eventType, action, eventRepo, branch, labels) {
 				continue
 			}
 

--- a/internal/bridge/webhook.go
+++ b/internal/bridge/webhook.go
@@ -30,11 +30,12 @@ type GitHubTrigger struct {
 	Actions      []string `json:"actions,omitempty" yaml:"actions"`                   // opened, synchronize, created, published
 	Repos        []string `json:"repos,omitempty" yaml:"repos"`                       // org/repo filters (empty = all)
 	Branches     []string `json:"branches,omitempty" yaml:"branches"`                 // branch filters (empty = all)
+	Labels       []string `json:"labels,omitempty" yaml:"labels"`                     // label filters (empty = all)
 	DeliveryMode string   `json:"delivery_mode,omitempty" yaml:"delivery_mode"`       // "polling" or "webhook", default "polling"
 }
 
 // Matches checks if an incoming webhook event matches this trigger config.
-func (t *GitHubTrigger) Matches(eventType, action, repo, branch string) bool {
+func (t *GitHubTrigger) Matches(eventType, action, repo, branch string, labels []string) bool {
 	if t == nil {
 		return false
 	}
@@ -57,6 +58,26 @@ func (t *GitHubTrigger) Matches(eventType, action, repo, branch string) bool {
 	// If t.Branches is non-empty, branch must be in t.Branches.
 	if len(t.Branches) > 0 && !stringInSlice(branch, t.Branches) {
 		return false
+	}
+
+	// Labels filter (AND with other filters). If trigger specifies labels,
+	// at least one must be present on the issue/PR.
+	if len(t.Labels) > 0 {
+		matched := false
+		for _, required := range t.Labels {
+			for _, have := range labels {
+				if strings.EqualFold(required, have) {
+					matched = true
+					break
+				}
+			}
+			if matched {
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
 	}
 
 	return true

--- a/internal/bridge/webhook_test.go
+++ b/internal/bridge/webhook_test.go
@@ -24,6 +24,7 @@ func TestGitHubTriggerMatches(t *testing.T) {
 		action    string
 		repo      string
 		branch    string
+		labels    []string
 		want      bool
 	}{
 		{
@@ -136,14 +137,64 @@ func TestGitHubTriggerMatches(t *testing.T) {
 			eventType: "push",
 			want:      true,
 		},
+		// Label filter tests
+		{
+			name:      "trigger with labels + event with matching label",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}, Labels: []string{"ready-for-dev"}},
+			eventType: "issues",
+			labels:    []string{"bug", "ready-for-dev"},
+			want:      true,
+		},
+		{
+			name:      "trigger with labels + event with no labels",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}, Labels: []string{"ready-for-dev"}},
+			eventType: "issues",
+			labels:    nil,
+			want:      false,
+		},
+		{
+			name:      "trigger with labels + event with different labels",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}, Labels: []string{"ready-for-dev"}},
+			eventType: "issues",
+			labels:    []string{"bug", "enhancement"},
+			want:      false,
+		},
+		{
+			name:      "trigger with no labels + event with any labels",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}},
+			eventType: "issues",
+			labels:    []string{"bug", "enhancement"},
+			want:      true,
+		},
+		{
+			name:      "case insensitive label matching",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}, Labels: []string{"Ready-For-Dev"}},
+			eventType: "issues",
+			labels:    []string{"ready-for-dev"},
+			want:      true,
+		},
+		{
+			name:      "trigger with multiple labels + event matches one",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}, Labels: []string{"ready-for-dev", "approved"}},
+			eventType: "issues",
+			labels:    []string{"approved"},
+			want:      true,
+		},
+		{
+			name:      "trigger with labels + empty labels slice",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}, Labels: []string{"ready-for-dev"}},
+			eventType: "issues",
+			labels:    []string{},
+			want:      false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.trigger.Matches(tt.eventType, tt.action, tt.repo, tt.branch)
+			got := tt.trigger.Matches(tt.eventType, tt.action, tt.repo, tt.branch, tt.labels)
 			if got != tt.want {
-				t.Errorf("Matches(%q, %q, %q, %q) = %v, want %v",
-					tt.eventType, tt.action, tt.repo, tt.branch, got, tt.want)
+				t.Errorf("Matches(%q, %q, %q, %q, %v) = %v, want %v",
+					tt.eventType, tt.action, tt.repo, tt.branch, tt.labels, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Event triggers can now require specific labels. If `labels: [ready-for-dev]` is set, the task only dispatches when the issue/PR has that label. Enforced at the trigger level, not in the prompt.

## Test plan
- [ ] CI passes (7 new test cases for label matching)
- [ ] Deploy to staging, open issue WITHOUT label → no task fires
- [ ] Add ready-for-dev label → task fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)