### PR TITLE
Fix Gate URLs on Kubernetes: use localhost for sidecar

### DIFF
--- a/internal/runtime/kubernetes.go
+++ b/internal/runtime/kubernetes.go
@@ -147,8 +147,26 @@ func (k *KubernetesRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHan
 	if _, ok := skiffEnv["NO_PROXY"]; !ok {
 		skiffEnv["NO_PROXY"] = "localhost,127.0.0.1,alcove-hail,alcove-bridge,alcove-ledger,.svc,.svc.cluster.local"
 	}
-	// Override ANTHROPIC_BASE_URL to use localhost since Gate is a sidecar.
+	// Override Gate-referenced URLs to use localhost since Gate is a sidecar
+	// sharing the pod network namespace (not a separate container with its own hostname).
 	skiffEnv["ANTHROPIC_BASE_URL"] = "http://localhost:8443"
+	for _, key := range []string{
+		"GITHUB_API_URL", "GITLAB_API_URL", "JIRA_API_URL",
+	} {
+		if val, ok := skiffEnv[key]; ok {
+			// Replace gate-{taskid}:8443 with localhost:8443
+			if strings.Contains(val, ":8443/") {
+				parts := strings.SplitN(val, ":8443/", 2)
+				skiffEnv[key] = "http://localhost:8443/" + parts[1]
+			}
+		}
+	}
+	if _, ok := skiffEnv["GH_HOST"]; ok {
+		skiffEnv["GH_HOST"] = "localhost:8443"
+	}
+	if _, ok := skiffEnv["GLAB_HOST"]; ok {
+		skiffEnv["GLAB_HOST"] = "http://localhost:8443/gitlab"
+	}
 
 	// Resolve service hostnames to IPs to bypass DNS issues in task pods.
 	// OVN-Kubernetes may block UDP DNS from pods with restrictive egress policies.


### PR DESCRIPTION
## Summary
On Kubernetes, Gate is a sidecar (shares pod network). SCM URLs (GITHUB_API_URL, etc.) pointed to `gate-{taskid}:8443` which doesn't resolve. Only ANTHROPIC_BASE_URL was correctly overridden to localhost.

**Root cause from transcript**: `Could not resolve host: gate-3cb14036-b1dd-4dd5-82b5-7b21259c66eb` (curl exit code 6)

**Fix**: Override all Gate-referenced URLs to `localhost:8443` on Kubernetes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)