### PR TITLE
Add user-based trigger filtering to prevent self-triggering

### DIFF
--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -145,4 +145,5 @@ trigger:
       - bmbouter/alcove
     labels:
       - ready-for-dev
+    users: [bmbouter]
     delivery_mode: polling

--- a/.alcove/tasks/issue-triage.yml
+++ b/.alcove/tasks/issue-triage.yml
@@ -46,4 +46,5 @@ trigger:
     repos: [bmbouter/alcove]
     labels:
       - ready-for-dev
+    users: [bmbouter]
     delivery_mode: polling

--- a/.alcove/tasks/planning.yml
+++ b/.alcove/tasks/planning.yml
@@ -114,4 +114,5 @@ trigger:
       - bmbouter/alcove
     labels:
       - needs-planning
+    users: [bmbouter]
     delivery_mode: polling

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1731,6 +1731,24 @@ If `labels` is omitted or empty, all matching events are dispatched.
 
 See [Configuration Reference](configuration.md#label-based-trigger-filtering) for full details.
 
+### Event Trigger User Filtering
+
+The trigger configuration supports an optional `users` field (string array). When specified, the event is only dispatched if the user who authored the comment or issue matches at least one of the listed GitHub usernames (case-insensitive). This prevents automated agents' own comments from re-triggering tasks and limits dispatch to trusted users.
+
+```yaml
+trigger:
+  github:
+    events: [issues, issue_comment]
+    actions: [opened, created]
+    repos: [org/myproject]
+    labels: [ready-for-dev]
+    users: [bmbouter]
+```
+
+If `users` is omitted or empty, all matching events are dispatched regardless of the event author.
+
+See [Configuration Reference](configuration.md#user-based-trigger-filtering) for full details.
+
 ---
 
 ## Task Templates

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -443,6 +443,7 @@ schedule: "0 2 * * *"
 | `tools`     | string[] | no       | MCP tool names to enable |
 | `schedule`  | string   | no       | Cron expression for automatic execution |
 | `labels`    | string[] | no       | GitHub issue/PR labels for event filtering (see below) |
+| `users`     | string[] | no       | GitHub usernames for event filtering (see below) |
 
 ### Event Delivery Mode
 
@@ -486,6 +487,31 @@ trigger:
 
 If `labels` is omitted or empty, all matching events are dispatched regardless
 of labels on the issue or PR.
+
+### User-Based Trigger Filtering
+
+The `users` field provides a safety gate for event triggers. When specified,
+an event is only dispatched if the user who authored the comment or issue
+matches at least one of the listed GitHub usernames (case-insensitive). This
+prevents automated agents' own comments from re-triggering tasks and limits
+task dispatch to trusted users.
+
+```yaml
+name: auto-fix
+prompt: |
+  Investigate and fix the issue described above.
+repo: https://github.com/org/myproject.git
+trigger:
+  github:
+    events: [issues, issue_comment]
+    actions: [opened, created]
+    repos: [org/myproject]
+    labels: [ready-for-dev]
+    users: [bmbouter]
+```
+
+If `users` is omitted or empty, all matching events are dispatched regardless
+of the event author.
 
 Task definitions appear in the dashboard where users can run them directly or
 view the source YAML. Starter templates are also available via

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -1733,6 +1733,22 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Extract user from comment or issue.
+	var users []string
+	if comment, ok := payload["comment"].(map[string]any); ok {
+		if user, ok := comment["user"].(map[string]any); ok {
+			if login, ok := user["login"].(string); ok {
+				users = append(users, login)
+			}
+		}
+	} else if issue, ok := payload["issue"].(map[string]any); ok {
+		if user, ok := issue["user"].(map[string]any); ok {
+			if login, ok := user["login"].(string); ok {
+				users = append(users, login)
+			}
+		}
+	}
+
 	// Extract additional info for dispatched tasks.
 	sha := ""
 	prNumber := ""
@@ -1819,7 +1835,7 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		if trigger.GitHub == nil || !trigger.GitHub.Matches(eventType, action, repo, branch, labels) {
+		if trigger.GitHub == nil || !trigger.GitHub.Matches(eventType, action, repo, branch, labels, users) {
 			continue
 		}
 

--- a/internal/bridge/poller.go
+++ b/internal/bridge/poller.go
@@ -309,11 +309,27 @@ func (p *GitHubPoller) pollRepo(ctx context.Context, repo, owner string, schedul
 			}
 		}
 
+		// Extract user from comment or issue.
+		var users []string
+		if comment, ok := payload["comment"].(map[string]interface{}); ok {
+			if user, ok := comment["user"].(map[string]interface{}); ok {
+				if login, ok := user["login"].(string); ok {
+					users = append(users, login)
+				}
+			}
+		} else if issue, ok := payload["issue"].(map[string]interface{}); ok {
+			if user, ok := issue["user"].(map[string]interface{}); ok {
+				if login, ok := user["login"].(string); ok {
+					users = append(users, login)
+				}
+			}
+		}
+
 		eventRepo := event.Repo.Name
 
 		// Match against each schedule.
 		for _, sched := range schedules {
-			if !sched.Trigger.Matches(eventType, action, eventRepo, branch, labels) {
+			if !sched.Trigger.Matches(eventType, action, eventRepo, branch, labels, users) {
 				continue
 			}
 

--- a/internal/bridge/webhook.go
+++ b/internal/bridge/webhook.go
@@ -31,11 +31,12 @@ type GitHubTrigger struct {
 	Repos        []string `json:"repos,omitempty" yaml:"repos"`                       // org/repo filters (empty = all)
 	Branches     []string `json:"branches,omitempty" yaml:"branches"`                 // branch filters (empty = all)
 	Labels       []string `json:"labels,omitempty" yaml:"labels"`                     // label filters (empty = all)
+	Users        []string `json:"users,omitempty" yaml:"users"`                       // user filters (empty = all)
 	DeliveryMode string   `json:"delivery_mode,omitempty" yaml:"delivery_mode"`       // "polling" or "webhook", default "polling"
 }
 
 // Matches checks if an incoming webhook event matches this trigger config.
-func (t *GitHubTrigger) Matches(eventType, action, repo, branch string, labels []string) bool {
+func (t *GitHubTrigger) Matches(eventType, action, repo, branch string, labels, users []string) bool {
 	if t == nil {
 		return false
 	}
@@ -66,6 +67,26 @@ func (t *GitHubTrigger) Matches(eventType, action, repo, branch string, labels [
 		matched := false
 		for _, required := range t.Labels {
 			for _, have := range labels {
+				if strings.EqualFold(required, have) {
+					matched = true
+					break
+				}
+			}
+			if matched {
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	// Users filter (AND with other filters). If trigger specifies users,
+	// at least one must match the event's user.
+	if len(t.Users) > 0 {
+		matched := false
+		for _, required := range t.Users {
+			for _, have := range users {
 				if strings.EqualFold(required, have) {
 					matched = true
 					break

--- a/internal/bridge/webhook_test.go
+++ b/internal/bridge/webhook_test.go
@@ -25,6 +25,7 @@ func TestGitHubTriggerMatches(t *testing.T) {
 		repo      string
 		branch    string
 		labels    []string
+		users     []string
 		want      bool
 	}{
 		{
@@ -187,14 +188,57 @@ func TestGitHubTriggerMatches(t *testing.T) {
 			labels:    []string{},
 			want:      false,
 		},
+		// User filter tests
+		{
+			name:      "trigger with users + matching user",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}, Users: []string{"bmbouter"}},
+			eventType: "issues",
+			users:     []string{"bmbouter"},
+			want:      true,
+		},
+		{
+			name:      "trigger with users + no users",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}, Users: []string{"bmbouter"}},
+			eventType: "issues",
+			users:     nil,
+			want:      false,
+		},
+		{
+			name:      "trigger with users + different user",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}, Users: []string{"bmbouter"}},
+			eventType: "issues",
+			users:     []string{"otheruser"},
+			want:      false,
+		},
+		{
+			name:      "trigger with no users filter + any event",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}},
+			eventType: "issues",
+			users:     []string{"anyuser"},
+			want:      true,
+		},
+		{
+			name:      "case insensitive user matching",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}, Users: []string{"BMBouter"}},
+			eventType: "issues",
+			users:     []string{"bmbouter"},
+			want:      true,
+		},
+		{
+			name:      "multiple trigger users, one matches",
+			trigger:   &GitHubTrigger{Events: []string{"issues"}, Users: []string{"alice", "bmbouter"}},
+			eventType: "issues",
+			users:     []string{"bmbouter"},
+			want:      true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.trigger.Matches(tt.eventType, tt.action, tt.repo, tt.branch, tt.labels)
+			got := tt.trigger.Matches(tt.eventType, tt.action, tt.repo, tt.branch, tt.labels, tt.users)
 			if got != tt.want {
-				t.Errorf("Matches(%q, %q, %q, %q, %v) = %v, want %v",
-					tt.eventType, tt.action, tt.repo, tt.branch, tt.labels, got, tt.want)
+				t.Errorf("Matches(%q, %q, %q, %q, %v, %v) = %v, want %v",
+					tt.eventType, tt.action, tt.repo, tt.branch, tt.labels, tt.users, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Tasks can now filter events by the actor's username. Prevents the planner from re-triggering when its own comment is posted.

- `users: [bmbouter]` in trigger config = only fire for events from bmbouter
- All three task definitions updated
- 6 new test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)