### PR TITLE
Fix: add labeled action to autonomous-dev and issue-triage triggers

### DIFF
--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -141,6 +141,7 @@ trigger:
       - opened
       - reopened
       - created
+      - labeled
     repos:
       - bmbouter/alcove
     labels:

--- a/.alcove/tasks/issue-triage.yml
+++ b/.alcove/tasks/issue-triage.yml
@@ -42,7 +42,7 @@ profiles:
 trigger:
   github:
     events: [issues]
-    actions: [opened]
+    actions: [opened, labeled]
     repos: [bmbouter/alcove]
     labels:
       - ready-for-dev


### PR DESCRIPTION
Adding ready-for-dev label generates a 'labeled' action. Without it in the trigger, tasks never fire on label addition.