### PR TITLE
Revise automated release agent: daily cron + immediate-release label trigger

### DIFF
--- a/.alcove/tasks/release.yml
+++ b/.alcove/tasks/release.yml
@@ -9,7 +9,7 @@ prompt: |
 
   This task can be triggered in two ways:
   1. **Scheduled**: Runs daily to check for unreleased commits and create releases
-  2. **Manual**: Triggered by issues/comments with the "ready-for-release" label
+  2. **Manual**: Triggered by issues labeled with "immediate-release"
 
   ## Environment
 
@@ -22,11 +22,16 @@ prompt: |
 
   ## Step 1: Check for unreleased commits
 
+  First, determine the trigger type:
+  - **Cron trigger**: Check for unreleased commits, exit early if none exist
+  - **Label trigger**: Proceed with release (human explicitly requested it)
+
   Check if there are commits since the last release:
     LAST_TAG=$(git describe --tags --abbrev=0)
     UNRELEASED_COMMITS=$(git log $LAST_TAG..HEAD --oneline)
 
-  If there are no unreleased commits, exit early with a success message.
+  For cron triggers: If there are no unreleased commits, exit early with a success message.
+  For label triggers: Proceed regardless (the human requesting release overrides this check).
 
   ## Step 2: Determine version bump
 
@@ -169,19 +174,16 @@ profiles:
   - alcove-releaser
 
 trigger:
-  schedule: "0 12 * * *"  # Daily at noon UTC - configurable by admin
+  schedule:
+    cron: "0 6 * * *"
+    enabled: true
   github:
     events:
       - issues
-      - issue_comment
     actions:
-      - opened
-      - reopened
-      - created
       - labeled
     repos:
       - bmbouter/alcove
     labels:
-      - ready-for-release
-    users: [bmbouter]
+      - immediate-release
     delivery_mode: polling


### PR DESCRIPTION
Fixes #46

## Summary

This PR revises the Automated Release Agent task definition to:

- Run daily at 6 AM UTC (changed from noon)
- Trigger immediately when an issue is labeled `immediate-release` (instead of `ready-for-release`)
- Remove the `bmbouter` user gate — any admin can trigger by adding the label
- Handle both trigger scenarios appropriately in the prompt

## Changes Made

### Updated `.alcove/tasks/release.yml`

- **Schedule**: Changed from `"0 12 * * *"` to `cron: "0 6 * * *"` with proper structure
- **Label trigger**: Changed from `ready-for-release` to `immediate-release`
- **User gate**: Removed `users: [bmbouter]` restriction
- **Events**: Simplified to only `issues` + `labeled` actions
- **Prompt**: Updated to handle both cron and label trigger scenarios differently

### Trigger Logic

- **Cron trigger**: Checks for unreleased commits, exits early if none exist
- **Label trigger**: Proceeds regardless (human explicitly requested release)

## Next Steps

After this PR merges, the repository owner should create the `immediate-release` label:

```bash
gh label create "immediate-release" --description "Triggers an immediate release if unreleased commits exist" --color "D93F0B" --repo bmbouter/alcove
```

## Test Plan

- [ ] Verify the task syncs correctly with the new trigger configuration
- [ ] Test daily cron scheduling (6 AM UTC)
- [ ] Test immediate trigger by adding `immediate-release` label to an issue
- [ ] Confirm no user gate restrictions apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)