### PR TITLE
Add PR review workflow with reviewer agent

### DIFF
--- a/.alcove/security-profiles/alcove-reviewer.yml
+++ b/.alcove/security-profiles/alcove-reviewer.yml
@@ -1,0 +1,21 @@
+name: alcove-reviewer
+display_name: Alcove PR Reviewer
+description: Code review access to bmbouter/alcove — read code, PRs, issues, post reviews, merge, manage labels
+tools:
+  github:
+    rules:
+      - repos: ["bmbouter/alcove"]
+        operations:
+          - clone
+          - read_prs
+          - read_issues
+          - read_contents
+          - read_actions
+          - read_commits
+          - read_branches
+          - read_git
+          - create_comment
+          - update_issue
+          - update_pr
+          - merge_pr
+          - delete_branch

--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -42,6 +42,45 @@ prompt: |
     ISSUE_NUMBER=$(cat /tmp/issue_number.txt)
   fi
 
+  # Check if triggered by a PR with changes-requested label (revision mode)
+  PR_NUMBER=""
+  if echo "$0" | grep -q '\[event:'; then
+    PR_NUMBER=$(echo "$0" | sed -n 's/.*\[event: \(.*\)\].*/\1/p' | grep -o '"GITHUB_PR_NUMBER":"[^"]*"' | cut -d'"' -f4)
+  elif echo "$0" | grep -q '\[webhook:'; then
+    PR_NUMBER=$(echo "$0" | sed -n 's/.*\[webhook: \(.*\)\].*/\1/p' | grep -o '"GITHUB_PR_NUMBER":"[^"]*"' | cut -d'"' -f4)
+  fi
+
+  if [ -n "$PR_NUMBER" ] && [ -z "$ISSUE_NUMBER" ]; then
+    echo "Triggered by PR #$PR_NUMBER with changes-requested — entering revision mode"
+
+    # Fetch PR details
+    curl -s -H "Authorization: token $GITHUB_TOKEN" \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/$PR_NUMBER" > /tmp/pr.json
+
+    BRANCH=$(jq -r '.head.ref' /tmp/pr.json)
+    BODY=$(jq -r '.body' /tmp/pr.json)
+    ISSUE_NUMBER=$(echo "$BODY" | grep -oP '(?:Fixes|Closes|Resolves) #\K\d+' | head -1)
+
+    # Checkout existing branch instead of creating new one
+    git fetch origin "$BRANCH"
+    git checkout "$BRANCH"
+
+    # Read review comments to understand what needs fixing
+    curl -s -H "Authorization: token $GITHUB_TOKEN" \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/$PR_NUMBER/reviews" > /tmp/reviews.json
+
+    echo "Review feedback to address:"
+    jq -r '.[] | select(.state == "CHANGES_REQUESTED") | .body' /tmp/reviews.json
+
+    # Remove changes-requested label
+    curl -s -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/issues/$PR_NUMBER/labels/changes-requested" 2>/dev/null
+
+    # Skip to Step 3 — implement the requested changes on the existing branch
+    # After fixing, commit and push to the same branch (Step 4 push section)
+    # The CI workflow will re-add awaiting-review when checks pass
+  fi
+
   echo "Working on issue #$ISSUE_NUMBER"
 
   # Fetch the specific issue
@@ -110,13 +149,7 @@ prompt: |
       -d @/tmp/pr-body.json \
       "$GITHUB_API_URL/repos/bmbouter/alcove/pulls"
 
-  Enable auto-merge on the PR:
-    curl -s -X PUT -H "Authorization: token $GITHUB_TOKEN" \
-      "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/PR_NUMBER/merge" \
-      -H "Content-Type: application/json" \
-      -d '{"merge_method":"squash","auto_merge":true}'
-
-  ## Step 5: Monitor CI
+  ## Step 5: Monitor CI and request review
 
   Poll the PR's check status every 30 seconds (up to 10 minutes):
     curl -s -H "Authorization: token $GITHUB_TOKEN" \
@@ -127,6 +160,10 @@ prompt: |
   2. Read the failure logs
   3. Fix the issue, commit, and push to the same branch
   4. Resume monitoring
+
+  Once all checks pass, the CI workflow will automatically add the
+  "awaiting-review" label. Your work is done — the PR Reviewer agent
+  will take it from here.
 
   ## Step 6: Handle blockers
 
@@ -163,6 +200,7 @@ trigger:
     events:
       - issues
       - issue_comment
+      - pull_request
     actions:
       - opened
       - reopened
@@ -172,5 +210,6 @@ trigger:
       - bmbouter/alcove
     labels:
       - ready-for-dev
+      - changes-requested
     users: [bmbouter]
     delivery_mode: polling

--- a/.alcove/tasks/pr-reviewer.yml
+++ b/.alcove/tasks/pr-reviewer.yml
@@ -1,0 +1,228 @@
+name: PR Reviewer
+description: |
+  Reviews pull requests after CI passes. Approves and merges good PRs,
+  or requests changes with detailed feedback for the dev agent to address.
+
+prompt: |
+  You are a code reviewer for the Alcove project (bmbouter/alcove).
+  A pull request has been labeled "awaiting-review" indicating all CI checks
+  have passed and the PR is ready for review.
+
+  ## Environment
+
+  You have a cloned copy of the repository. Use curl with $GITHUB_API_URL
+  and $GITHUB_TOKEN for all GitHub API calls (do NOT use the gh CLI):
+
+    curl -s -H "Authorization: token $GITHUB_TOKEN" "$GITHUB_API_URL/repos/bmbouter/alcove/..."
+
+  Write JSON payloads to files before POSTing to avoid shell escaping issues.
+
+  ## Step 1: Identify the PR
+
+  Extract the PR number from the event context at the end of this prompt.
+  The event context is appended as JSON after "[event: {...}]" or "[webhook: {...}]".
+
+  PR_NUMBER=""
+  if echo "$0" | grep -q '\[event:'; then
+    PR_NUMBER=$(echo "$0" | sed -n 's/.*\[event: \(.*\)\].*/\1/p' | grep -o '"GITHUB_PR_NUMBER":"[^"]*"' | cut -d'"' -f4)
+  elif echo "$0" | grep -q '\[webhook:'; then
+    PR_NUMBER=$(echo "$0" | sed -n 's/.*\[webhook: \(.*\)\].*/\1/p' | grep -o '"GITHUB_PR_NUMBER":"[^"]*"' | cut -d'"' -f4)
+  fi
+
+  if [ -z "$PR_NUMBER" ]; then
+    echo "Error: No PR number found in event context."
+    exit 1
+  fi
+
+  echo "Reviewing PR #$PR_NUMBER"
+
+  ## Step 2: Fetch PR details and verify CI
+
+  curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/$PR_NUMBER" > /tmp/pr.json
+
+  HEAD_SHA=$(jq -r '.head.sha' /tmp/pr.json)
+  BRANCH=$(jq -r '.head.ref' /tmp/pr.json)
+  TITLE=$(jq -r '.title' /tmp/pr.json)
+  BODY=$(jq -r '.body' /tmp/pr.json)
+  STATE=$(jq -r '.state' /tmp/pr.json)
+  MERGED=$(jq -r '.merged' /tmp/pr.json)
+
+  # Skip if PR is already merged or closed
+  if [ "$STATE" != "open" ] || [ "$MERGED" = "true" ]; then
+    echo "PR #$PR_NUMBER is already $STATE (merged=$MERGED). Skipping."
+    exit 0
+  fi
+
+  # Verify CI passed
+  curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    "$GITHUB_API_URL/repos/bmbouter/alcove/commits/$HEAD_SHA/check-runs" > /tmp/checks.json
+
+  FAILED=$(jq '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null)] | length' /tmp/checks.json)
+  PENDING=$(jq '[.check_runs[] | select(.conclusion == null)] | length' /tmp/checks.json)
+
+  if [ "$FAILED" -gt 0 ] || [ "$PENDING" -gt 0 ]; then
+    echo "CI has not fully passed (failed=$FAILED, pending=$PENDING). Removing label and skipping."
+    curl -s -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/issues/$PR_NUMBER/labels/awaiting-review" 2>/dev/null
+    exit 0
+  fi
+
+  ## Step 3: Check revision count
+
+  curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/$PR_NUMBER/reviews" > /tmp/reviews.json
+
+  REVISION_COUNT=$(jq '[.[] | select(.state == "CHANGES_REQUESTED")] | length' /tmp/reviews.json)
+
+  if [ "$REVISION_COUNT" -ge 3 ]; then
+    echo "PR has had 3+ revision cycles. Escalating to human review."
+
+    cat > /tmp/label.json << 'EOF'
+    {"labels":["needs-human-review"]}
+    EOF
+    curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d @/tmp/label.json \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/issues/$PR_NUMBER/labels"
+
+    curl -s -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/issues/$PR_NUMBER/labels/awaiting-review" 2>/dev/null
+
+    cat > /tmp/comment.json << 'EOF'
+    {"body":"This PR has gone through 3 revision cycles without resolution. Escalating to human review.\n\ncc @bmbouter"}
+    EOF
+    curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d @/tmp/comment.json \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/issues/$PR_NUMBER/comments"
+
+    exit 0
+  fi
+
+  ## Step 4: Review the changes
+
+  # Get the full diff
+  curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.v3.diff" \
+    "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/$PR_NUMBER" > /tmp/pr.diff
+
+  # Get list of changed files
+  curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/$PR_NUMBER/files" > /tmp/files.json
+
+  # Get commit history
+  curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/$PR_NUMBER/commits" > /tmp/commits.json
+
+  Read the diff thoroughly. For each changed file, understand the purpose
+  and check for issues. Also read the surrounding code in the repo to
+  understand context.
+
+  ## Step 5: Check linked issue
+
+  Extract the issue number from the PR body:
+    ISSUE_NUMBER=$(echo "$BODY" | grep -oP '(?:Fixes|Closes|Resolves) #\K\d+' | head -1)
+
+  If found, fetch the issue and comments to verify the PR implements
+  what was requested:
+    curl -s -H "Authorization: token $GITHUB_TOKEN" \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/issues/$ISSUE_NUMBER"
+    curl -s -H "Authorization: token $GITHUB_TOKEN" \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/issues/$ISSUE_NUMBER/comments"
+
+  ## Step 6: Review checklist
+
+  Evaluate the PR against these criteria:
+  - **Correctness**: Does the code implement what the issue/PR describes?
+  - **Testing**: Are there tests? Do they cover the main cases?
+  - **Security**: No credentials exposed, no injection flaws, no auth bypasses?
+  - **Code quality**: Follows Go conventions, uses existing patterns?
+  - **Documentation**: Updated docs if behavior changed?
+  - **Database**: Migrations are additive and safe?
+  - **Breaking changes**: API backward compatible?
+
+  ## Step 7: Decision
+
+  ### If APPROVE:
+
+  1. Post an approval review with a brief summary of what you reviewed:
+     Write review JSON to /tmp/review.json with event "APPROVE" and a body
+     summarizing what was checked and why it's good.
+
+     curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+       -H "Content-Type: application/json" \
+       -d @/tmp/review.json \
+       "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/$PR_NUMBER/reviews"
+
+  2. Swap labels (remove awaiting-review, add reviewer-approved):
+     curl -s -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
+       "$GITHUB_API_URL/repos/bmbouter/alcove/issues/$PR_NUMBER/labels/awaiting-review" 2>/dev/null
+
+     Write label JSON to /tmp/label.json: {"labels":["reviewer-approved"]}
+     curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+       -H "Content-Type: application/json" \
+       -d @/tmp/label.json \
+       "$GITHUB_API_URL/repos/bmbouter/alcove/issues/$PR_NUMBER/labels"
+
+  3. Merge the PR (squash merge):
+     Write merge JSON to /tmp/merge.json with merge_method "squash"
+     curl -s -X PUT -H "Authorization: token $GITHUB_TOKEN" \
+       -H "Content-Type: application/json" \
+       -d @/tmp/merge.json \
+       "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/$PR_NUMBER/merge"
+
+  4. Delete the feature branch:
+     curl -s -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
+       "$GITHUB_API_URL/repos/bmbouter/alcove/git/refs/heads/$BRANCH"
+
+  ### If REQUEST_CHANGES:
+
+  1. Post a detailed review with specific issues and suggestions:
+     Write review JSON to /tmp/review.json with event "REQUEST_CHANGES"
+     Include specific file references, explain WHY each issue matters,
+     and suggest concrete fixes.
+
+     curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+       -H "Content-Type: application/json" \
+       -d @/tmp/review.json \
+       "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/$PR_NUMBER/reviews"
+
+  2. Swap labels (remove awaiting-review, add changes-requested):
+     curl -s -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
+       "$GITHUB_API_URL/repos/bmbouter/alcove/issues/$PR_NUMBER/labels/awaiting-review" 2>/dev/null
+
+     Write label JSON to /tmp/label.json: {"labels":["changes-requested"]}
+     curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+       -H "Content-Type: application/json" \
+       -d @/tmp/label.json \
+       "$GITHUB_API_URL/repos/bmbouter/alcove/issues/$PR_NUMBER/labels"
+
+  ## Important rules
+
+  - ALWAYS use curl with $GITHUB_API_URL and $GITHUB_TOKEN, never gh CLI
+  - Write JSON to files before POSTing (avoids shell escaping bugs)
+  - Be thorough — read the full diff, not just file names
+  - Be constructive — explain WHY something is an issue and suggest fixes
+  - Do NOT approve PRs with obvious bugs or missing tests
+  - Do NOT approve PRs that don't match what the linked issue requested
+  - Changelog-only PRs from release branches can be auto-approved
+  - If uncertain about a design choice, request changes and ask
+
+repo: https://github.com/bmbouter/alcove.git
+timeout: 1800
+
+profiles:
+  - alcove-reviewer
+
+trigger:
+  github:
+    events:
+      - pull_request
+    actions:
+      - labeled
+    repos:
+      - bmbouter/alcove
+    labels:
+      - awaiting-review
+    delivery_mode: polling

--- a/.alcove/tasks/release.yml
+++ b/.alcove/tasks/release.yml
@@ -81,18 +81,22 @@ prompt: |
 
   5. Create PR via API:
      Write PR body to /tmp/pr-body.json:
-     {"title":"Add vX.Y.Z changelog","head":"release-vX.Y.Z","base":"main","body":"Changelog for vX.Y.Z release.\n\nThis is an automated release PR. CI will run and auto-merge when all checks pass."}
+     {"title":"Add vX.Y.Z changelog","head":"release-vX.Y.Z","base":"main","body":"Changelog for vX.Y.Z release.\n\nThis is an automated release PR."}
 
      curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
        -H "Content-Type: application/json" \
        -d @/tmp/pr-body.json \
        "$GITHUB_API_URL/repos/bmbouter/alcove/pulls"
 
-  6. Extract PR number from response and enable auto-merge:
-     curl -s -X PUT -H "Authorization: token $GITHUB_TOKEN" \
-       "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/PR_NUMBER/merge" \
+  6. Extract PR number from response.
+
+  7. Add reviewer-approved label to skip review (release PRs are automated):
+     Write label JSON to /tmp/release-label.json: {"labels":["reviewer-approved"]}
+
+     curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
        -H "Content-Type: application/json" \
-       -d '{"merge_method":"squash"}'
+       -d @/tmp/release-label.json \
+       "$GITHUB_API_URL/repos/bmbouter/alcove/issues/$PR_NUMBER/labels"
 
   ## Step 5: Wait for CI and merge
 
@@ -102,7 +106,13 @@ prompt: |
 
   Look for state: "success" and all check contexts passing.
   
-  Once CI passes, the PR will auto-merge. Confirm it merged:
+  Once CI passes, merge the PR via squash merge:
+     curl -s -X PUT -H "Authorization: token $GITHUB_TOKEN" \
+       "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/PR_NUMBER/merge" \
+       -H "Content-Type: application/json" \
+       -d '{"merge_method":"squash"}'
+
+  Confirm it merged:
     curl -s -H "Authorization: token $GITHUB_TOKEN" \
       "$GITHUB_API_URL/repos/bmbouter/alcove/pulls/PR_NUMBER"
 

--- a/.claude/skills/deploy-staging/SKILL.md
+++ b/.claude/skills/deploy-staging/SKILL.md
@@ -1,53 +1,102 @@
 ---
 name: deploy-staging
-description: Deploy a new Alcove version to the OpenShift staging environment via app-interface MR
+description: Check for new releases, security audit changes, and deploy to OpenShift staging
 user-invocable: true
-argument-hint: "[version] (e.g., 0.3.15 — omit to use latest release)"
+argument-hint: "[version] (optional — omit to auto-detect from latest release vs deployed)"
 ---
 
-Deploy Alcove to the OpenShift staging environment (pulp-stage on crcs02ue1).
+Automatically detect if a new Alcove release is available, audit the changes for safety, and deploy to staging if approved.
 
 ## Steps
 
-### 1. Determine version
-If $ARGUMENTS is provided, use it. Otherwise, find the latest release:
+### 1. Determine versions
+
+**Latest release:**
 ```bash
 gh release view --repo bmbouter/alcove --json tagName -q '.tagName'
 ```
 
-### 2. Check for config changes
-Read `docs/changelog.md` for the target version. Look for new template parameters, auth changes, new secrets. If config changes are needed and the context doesn't tell you what values to use, ASK THE USER.
+**Currently deployed on staging:**
+```bash
+oc get deployment alcove-bridge -o jsonpath='{.spec.template.spec.containers[0].image}'
+```
+Extract the tag from the image URL (e.g., `ghcr.io/bmbouter/alcove-bridge:0.4.15` → `0.4.15`).
 
-### 3. Create the app-interface branch
+If $ARGUMENTS is provided, use that version instead of auto-detecting.
+
+**Compare:** If the deployed version matches the latest release, report "staging is up to date" and exit. If oc login is expired, ask the user for a fresh token.
+
+### 2. Audit changes for safety
+
+Read the changelog and commit diff between the deployed version and the target version:
+```bash
+git log v{deployed}..v{target} --oneline
+```
+
+Read `docs/changelog.md` for the target version's entry.
+
+**Spawn a team of agents in parallel to audit the changes:**
+
+- **Architecture agent**: Review for breaking API changes, database migration risks, backward compatibility issues. Check if new migrations exist and whether they are additive (safe) or destructive.
+
+- **Security agent**: Check for new credential handling, auth changes, scope changes, network policy modifications. Flag any changes to Gate proxy, credential encryption, or token handling. Verify no secrets are exposed in new code.
+
+- **Staging compatibility agent**: Check for new environment variables, template parameters, or config changes needed in `deploy/openshift/template.yaml` or `data/services/pulp/deploy-alcove.yml`. Flag anything that requires manual app-interface config changes beyond image tag bumps.
+
+- **Rollback risk agent**: Assess whether the deployment can be safely rolled back by reverting the image tag. Flag any one-way migrations or state changes that would prevent rollback.
+
+Each agent should report: SAFE, CAUTION (proceed with noted risks), or BLOCK (do not deploy without resolution).
+
+### 3. Decision
+
+- If all agents report SAFE: proceed to deploy automatically
+- If any agent reports CAUTION: present the findings to the user and ask whether to proceed
+- If any agent reports BLOCK: stop and report the blocking issue to the user. Do not proceed without explicit approval.
+
+If config changes are needed beyond image tags and the context doesn't tell you what values to use, ASK THE USER.
+
+### 4. Deploy via app-interface MR
+
 ```bash
 cd ~/devel/pulp/app-interface
 git checkout master && git pull origin master
 git checkout -b alcove-vXYZ master
 ```
 
-### 4. Update deploy-alcove.yml
-Edit `data/services/pulp/deploy-alcove.yml` — update BRIDGE_IMAGE_TAG, GATE_IMAGE, SKIFF_IMAGE tags. Add any new parameters.
+Edit `data/services/pulp/deploy-alcove.yml` — update BRIDGE_IMAGE_TAG, GATE_IMAGE, SKIFF_IMAGE tags. Add any new parameters identified by the staging compatibility agent.
 
-### 5. Commit and push
 ```bash
 git add -A && git commit -m "Upgrade Alcove to vX.Y.Z — summary"
 git push fork BRANCH_NAME
 ```
 
-### 6. Open the MR via GitLab API
+### 5. Open the MR via GitLab API
+
 ```bash
 GITLAB_TOKEN=$(cat ~/.config/alcove-gitlab-token)
 curl -s -X POST "https://gitlab.cee.redhat.com/api/v4/projects/79823/merge_requests" \
   -H "PRIVATE-TOKEN: $GITLAB_TOKEN" -H "Content-Type: application/json" \
-  -d '{"source_branch":"BRANCH","target_branch":"master","target_project_id":13582,"title":"TITLE","description":"DESC"}'
+  -d '{"source_branch":"BRANCH","target_branch":"master","target_project_id":13582,"title":"TITLE","description":"DESC including audit findings"}'
 ```
 
-### 7. Post /lgtm
+### 6. Wait for pipeline, then post /lgtm
+
+Poll the pipeline status every 60 seconds. Once it passes:
 ```bash
 curl -s -X POST "https://gitlab.cee.redhat.com/api/v4/projects/13582/merge_requests/MR_IID/notes" \
   -H "PRIVATE-TOKEN: $GITLAB_TOKEN" -H "Content-Type: application/json" \
   -d '{"body": "/lgtm"}'
 ```
 
-### 8. Monitor deployment via oc
-Watch for the new image version to appear on the Bridge deployment. Report when live.
+### 7. Monitor deployment
+
+Watch for the new image version to appear:
+```bash
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+  sleep 30
+  IMG=$(oc get deployment alcove-bridge -o jsonpath='{.spec.template.spec.containers[0].image}')
+  if echo "$IMG" | grep -q "TARGET_VERSION"; then echo "Deployed!"; break; fi
+done
+```
+
+Report when live with the version number.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,29 +1,48 @@
 ---
 name: release
-description: Create a new Alcove release — changelog, tag, push, and verify CI builds containers
+description: Trigger the automated release pipeline for Alcove
 user-invocable: true
-argument-hint: "[version] (e.g., 0.4.0 — omit to auto-detect from semver)"
+argument-hint: "[version] (optional — omit to let the release agent decide)"
 ---
 
-Create a new Alcove release. All building happens in GitHub Actions, not locally.
+Trigger the Alcove automated release pipeline. Releases are handled by the Automated Release Agent task running on the staging environment — not locally.
+
+## How It Works
+
+The release agent (`.alcove/tasks/release.yml`) runs daily at 6 AM UTC and checks for unreleased commits. To trigger an immediate release:
 
 ## Steps
 
-1. **Determine version**: If $ARGUMENTS is provided, use it. Otherwise, examine commits since the last tag and determine the semver bump (features → minor, fixes → patch).
+### 1. Create or find an issue to tag
+If there's already an open issue, use it. Otherwise create one:
+```bash
+gh issue create --repo bmbouter/alcove --title "Release vX.Y.Z" --body "Triggering immediate release."
+```
 
-2. **Generate changelog**: Add a new `## vX.Y.Z` section to `docs/changelog.md` with categorized entries from the commit log.
+### 2. Add the immediate-release label
+```bash
+gh issue edit ISSUE_NUMBER --repo bmbouter/alcove --add-label "immediate-release"
+```
 
-3. **Create a PR**: Commit the changelog, push to a branch, open a PR against main via `gh pr create`. Wait for CI to pass (all three jobs: unit-tests, build, functional-tests).
+The release agent will:
+1. Check for unreleased commits on main
+2. Determine the semver bump (features → minor, fixes → patch)
+3. Generate changelog in `docs/changelog.md`
+4. Open a PR, wait for CI to pass, merge
+5. Tag and push the version
+6. Monitor the GitHub Actions release build (builds binaries + container images on ghcr.io)
 
-4. **Merge the PR**: Once CI passes, merge via `gh pr merge --squash`.
+### 3. Monitor progress
+Watch for the release agent task to appear in the Alcove staging dashboard. It will show up as a running task within ~60 seconds of the label being added.
 
-5. **Tag and push**: After merge, pull main, create an annotated tag, push it:
-   ```bash
-   git checkout main && git pull
-   git tag -a vX.Y.Z -m "Alcove vX.Y.Z — summary"
-   git push origin vX.Y.Z
-   ```
+### 4. Verify
+After the release agent completes:
+```bash
+gh release view --repo bmbouter/alcove
+```
 
-6. **Monitor release build**: The tag push triggers the Release workflow in GitHub Actions. Monitor with `gh run list` until it completes successfully.
-
-7. **Verify**: Check `gh release view vX.Y.Z` for assets and pull container images to confirm they exist on ghcr.io.
+## Notes
+- The release agent runs on staging, not locally
+- It uses the `alcove-developer` security profile for full repo access
+- Building and publishing containers happens in GitHub Actions (triggered by tag push)
+- Do NOT manually tag or push — the release agent handles everything

--- a/.github/workflows/label-on-ci-pass.yml
+++ b/.github/workflows/label-on-ci-pass.yml
@@ -1,0 +1,49 @@
+name: Label PRs for Review
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  label:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add awaiting-review label to PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Find PRs associated with the head SHA
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${context.payload.workflow_run.head_branch}`,
+              state: 'open'
+            });
+
+            for (const pr of prs.data) {
+              // Skip if reviewer-approved already present (e.g., release PRs)
+              const labels = pr.labels.map(l => l.name);
+              if (labels.includes('reviewer-approved')) {
+                console.log(`PR #${pr.number} already has reviewer-approved, skipping`);
+                continue;
+              }
+
+              // Skip if awaiting-review already present
+              if (labels.includes('awaiting-review')) {
+                console.log(`PR #${pr.number} already has awaiting-review, skipping`);
+                continue;
+              }
+
+              // Add awaiting-review label
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: ['awaiting-review']
+              });
+              console.log(`Added awaiting-review to PR #${pr.number}`);
+            }


### PR DESCRIPTION
## Summary
- New **PR Reviewer** task agent that reviews PRs after CI passes, can approve+merge or request changes with detailed feedback
- New **label-on-ci-pass** GitHub Action that adds `awaiting-review` label when CI succeeds on PRs
- Updated **autonomous-dev** to handle PR revision cycles (triggered by `changes-requested` label)
- Updated **release** task to bypass review (adds `reviewer-approved` label, direct squash merge)
- Updated deploy-staging and release skills to match current automated workflows
- Auto-merge disabled on the repo; all merging now goes through the reviewer agent

## Workflow
```
PR opened → CI runs → CI passes → GH Action adds awaiting-review
→ Reviewer agent triggered → APPROVE (merge) or REQUEST_CHANGES
→ If changes requested → dev agent revises → CI re-runs → reviewer re-triggered
→ 3-cycle limit → escalates to needs-human-review
```

## New labels
`awaiting-review`, `changes-requested`, `reviewer-approved`, `needs-human-review`

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, verify task definitions appear in staging dashboard
- [ ] Open a test issue with `ready-for-dev` label and watch the full workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)