### PR TITLE
Fix: extract label from payload for labeled events

### DIFF
--- a/internal/bridge/poller.go
+++ b/internal/bridge/poller.go
@@ -322,6 +322,24 @@ func (p *GitHubPoller) pollRepo(ctx context.Context, repo, owner string, schedul
 				}
 			}
 		}
+		// For "labeled" actions, the added label may not be in the
+		// issue/PR labels array yet. Check payload["label"] directly.
+		if action == "labeled" {
+			if labelObj, ok := payload["label"].(map[string]interface{}); ok {
+				if name, ok := labelObj["name"].(string); ok {
+					found := false
+					for _, l := range labels {
+						if strings.EqualFold(l, name) {
+							found = true
+							break
+						}
+					}
+					if !found {
+						labels = append(labels, name)
+					}
+				}
+			}
+		}
 
 		// Extract user from comment or issue.
 		var users []string


### PR DESCRIPTION
## Summary
- GitHub Events API `labeled` action includes the added label in `payload.label`, not in `pull_request.labels` (which can be empty)
- Poller now checks `payload.label` directly for `labeled` actions
- Fixes PR reviewer agent not triggering on `awaiting-review` label

## Test plan
- [ ] CI passes
- [ ] After deploy, `awaiting-review` label triggers reviewer agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)