### PR TITLE
Fix: add create_review to alcove-reviewer profile

### DIFF
--- a/.alcove/security-profiles/alcove-reviewer.yml
+++ b/.alcove/security-profiles/alcove-reviewer.yml
@@ -15,6 +15,7 @@ tools:
           - read_branches
           - read_git
           - create_comment
+          - create_review
           - update_issue
           - update_pr
           - merge_pr


### PR DESCRIPTION
Adds missing create_review operation so the reviewer agent can post PR reviews.