### PR TITLE
Fix: clear poll ETags on startup to prevent stale 304 loops

### DIFF
--- a/internal/bridge/scheduler.go
+++ b/internal/bridge/scheduler.go
@@ -266,6 +266,13 @@ func (s *Scheduler) Start(ctx context.Context) {
 		ticker := time.NewTicker(60 * time.Second)
 		defer ticker.Stop()
 
+		// Clear stale GitHub poll ETags on startup. After a deployment or
+		// restart, the stored ETag may cause permanent 304 responses from
+		// GitHub's CDN. Clearing forces a fresh full poll on the first tick.
+		// The first-poll skip logic (no lastEventID) prevents duplicate dispatches.
+		_, _ = s.db.Exec(ctx, `UPDATE github_poll_state SET etag = ''`)
+		log.Printf("scheduler: cleared GitHub poll ETags on startup")
+
 		// Run immediately on start, then every tick.
 		s.tick(ctx)
 


### PR DESCRIPTION
## Summary
Clears stored GitHub Events API ETags when Bridge starts. Prevents the poller from getting permanently stuck in 304 Not Modified loops after deployments.

## Root Cause
After any deployment/restart, the `github_poll_state` table retains the old ETag. GitHub's CDN returns 304 indefinitely, and the poller never sees new events. This broke the entire SDLC pipeline on staging.

## Fix
One line in `scheduler.go`: `UPDATE github_poll_state SET etag = ''` on startup. The first poll runs without an ETag (gets a 200 with all events). The existing first-poll skip logic prevents duplicate dispatches.

## Test plan
- [ ] CI passes
- [ ] Locally verified: set stale ETag → restart → ETag cleared → events fetched

🤖 Generated with [Claude Code](https://claude.com/claude-code)