### PR TITLE
Add enable/disable toggle for task repos

### DIFF
--- a/internal/bridge/settings.go
+++ b/internal/bridge/settings.go
@@ -47,11 +47,18 @@ func NewSettingsStore(db *pgxpool.Pool) *SettingsStore {
 	return &SettingsStore{db: db}
 }
 
-// SkillRepo represents a git repository containing Claude Code skills/agents.
+// SkillRepo represents a git repository containing Claude Code skills/agents
+// or task definitions.
 type SkillRepo struct {
-	URL  string `json:"url"`
-	Ref  string `json:"ref,omitempty"`  // branch/tag/commit, default: main
-	Name string `json:"name,omitempty"` // display name
+	URL     string `json:"url"`
+	Ref     string `json:"ref,omitempty"`     // branch/tag/commit, default: main
+	Name    string `json:"name,omitempty"`    // display name
+	Enabled *bool  `json:"enabled,omitempty"` // nil or true = enabled, false = disabled
+}
+
+// IsEnabled returns whether the repo is enabled (defaults to true if not set).
+func (r SkillRepo) IsEnabled() bool {
+	return r.Enabled == nil || *r.Enabled
 }
 
 // GetSystemSkillRepos returns the system-wide skill repos.

--- a/internal/bridge/tasksync.go
+++ b/internal/bridge/tasksync.go
@@ -165,6 +165,15 @@ func (s *TaskRepoSyncer) SyncAll(ctx context.Context) error {
 	var errs []string
 	for _, urs := range userRepoSets {
 		for _, repo := range urs.repos {
+			if !repo.IsEnabled() {
+				// Repo is disabled — disable all its schedules but don't remove them.
+				sourceKeyPrefix := urs.username + "::" + repo.URL + "::"
+				_, _ = s.db.Exec(ctx,
+					`UPDATE schedules SET enabled = false WHERE source_key LIKE $1 || '%' AND source = 'yaml'`,
+					sourceKeyPrefix)
+				log.Printf("task-repo-syncer: repo %s disabled for user %s, schedules paused", repo.URL, urs.username)
+				continue
+			}
 			if err := s.syncRepo(ctx, repo, urs.username); err != nil {
 				errs = append(errs, fmt.Sprintf("%s (user %s): %v", repo.URL, urs.username, err))
 			}

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2035,3 +2035,32 @@ select.input {
     background: rgba(231, 76, 60, 0.25);
     border-color: rgba(231, 76, 60, 0.5);
 }
+
+/* === Task Repo Enable/Disable === */
+.repo-item-toggle {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 6px;
+    cursor: pointer;
+}
+
+.repo-item-toggle input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+}
+
+.repo-item-disabled {
+    opacity: 0.5;
+}
+
+.repo-item-badge-disabled {
+    display: inline-block;
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 4px;
+    background: rgba(231, 76, 60, 0.15);
+    color: var(--status-error);
+    border: 1px solid rgba(231, 76, 60, 0.3);
+    margin-left: 4px;
+}

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -421,14 +421,32 @@
         var html = '';
         for (var i = 0; i < taskReposList.length; i++) {
             var r = taskReposList[i];
+            var isEnabled = r.enabled === undefined || r.enabled === null || r.enabled === true;
             var displayUrl = (r.url || '').replace(/^https?:\/\//, '').replace(/\.git$/, '');
-            html += '<div class="repo-item">';
+            html += '<div class="repo-item' + (isEnabled ? '' : ' repo-item-disabled') + '">';
+            html += '<label class="repo-item-toggle"><input type="checkbox" class="repo-item-enabled" data-index="' + i + '"' + (isEnabled ? ' checked' : '') + '> </label>';
             html += '<span class="repo-item-url">' + escapeHtml(displayUrl) + '</span>';
             if (r.ref && r.ref !== 'main') html += ' <span class="repo-item-ref">' + escapeHtml(r.ref) + '</span>';
+            if (!isEnabled) html += ' <span class="repo-item-badge-disabled">disabled</span>';
             html += ' <button class="btn btn-small btn-outline repo-item-remove" data-index="' + i + '" style="color:var(--status-error);border-color:var(--status-error);padding:2px 8px;font-size:11px;">Remove</button>';
             html += '</div>';
         }
         listEl.innerHTML = html;
+
+        listEl.querySelectorAll('.repo-item-enabled').forEach(function(cb) {
+            cb.addEventListener('change', async function() {
+                var idx = parseInt(cb.getAttribute('data-index'), 10);
+                taskReposList[idx].enabled = cb.checked;
+                await saveTaskRepos();
+                var statusEl = $('#task-repo-add-status-inline');
+                if (statusEl) {
+                    statusEl.removeAttribute('hidden');
+                    statusEl.style.color = 'var(--text-muted)';
+                    statusEl.textContent = (cb.checked ? 'Enabled' : 'Disabled') + ' ' + (taskReposList[idx].name || taskReposList[idx].url) + '. Changes take effect on next sync.';
+                }
+                setTimeout(function() { loadUnifiedSchedules(); }, 2000);
+            });
+        });
 
         listEl.querySelectorAll('.repo-item-remove').forEach(function(btn) {
             btn.addEventListener('click', async function() {


### PR DESCRIPTION
## Summary
Adds an enable/disable toggle per task repo so that when two Alcove instances share the same repo's tasks, only one actively processes events.

## Changes
- **`SkillRepo` struct**: New `Enabled *bool` field (nil/true = enabled, false = disabled)
- **Syncer**: Disabled repos skip sync, their schedules are paused (`enabled = false`)
- **Re-enable**: Re-syncing a repo re-enables its schedules
- **Frontend**: Checkbox toggle in Repos page with disabled visual state

## Tested locally via API
1. Default repos show enabled
2. Disabling a repo pauses all 4 schedules
3. Poller stops finding polling schedules
4. Re-enabling restores all schedules
5. Poller resumes

## Test plan
- [ ] CI passes
- [ ] API test: disable/enable toggle works
- [ ] UI: checkbox renders and toggles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)