### PR TITLE
Add v0.9.1 changelog: dedup-only poller fix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,14 @@
 All notable changes to Alcove are documented here. This project uses
 [Semantic Versioning](https://semver.org/).
 
+## v0.9.1
+
+### Bug Fixes
+- Fix GitHub Events API poller reliability by removing all ID-based event
+  filtering. GitHub event IDs are not chronologically ordered, causing the
+  poller to skip valid events. The poller now processes all fetched events
+  and relies solely on the webhook_deliveries table for deduplication.
+
 ## v0.9.0
 
 ### Features


### PR DESCRIPTION
## Summary
- Add changelog entry for v0.9.1 documenting the poller dedup-only fix

## Test plan
- [x] Changelog follows existing format

🤖 Generated with [Claude Code](https://claude.com/claude-code)