### PR TITLE
Add CI Gate: Bridge-driven CI retry, Go in Skiff, prompt hardening

### DIFF
--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -20,6 +20,9 @@ prompt: |
 
   Write JSON payloads to files before POSTing to avoid shell escaping issues.
 
+  Go 1.25 is installed in the Skiff container. You can and MUST use `go build`,
+  `go vet`, and `go test` to validate your changes before pushing.
+
   ## Step 1: Understand the request
 
   Extract the issue number from the event context at the end of this prompt.
@@ -117,6 +120,18 @@ prompt: |
   Consider ALL affected areas: Go code, API, dashboard UI, documentation,
   functional tests, YAML task/profile definitions.
 
+  ### Risk assessment for changes you cannot validate locally
+
+  If your planned changes include:
+  - CI/CD workflow modifications (.github/workflows/)
+  - Containerfile/Dockerfile changes
+  - Cross-platform build targets
+  - Changes that require running containers
+
+  Flag these as HIGH RISK in your plan. Be extra conservative with these
+  changes — prefer minimal, incremental modifications. If possible, make
+  the core logic changes in one commit and CI/workflow changes separately.
+
   ## Step 3: Implement changes with a team of agents
 
   Form a team of specialist agents working in parallel to implement changes
@@ -139,6 +154,20 @@ prompt: |
   - Tests: bash scripts in scripts/ using curl against running Bridge
   - Docs: markdown in docs/
 
+  ### Pre-push validation (MANDATORY)
+
+  Before committing and pushing, you MUST run local validation:
+    go build ./...      # Must compile cleanly
+    go vet ./...        # Must pass static analysis
+    go test ./...       # Run unit tests (some may need infra — that's OK)
+
+  If `go build` or `go vet` fail, fix the issues before pushing. These are
+  non-negotiable — never push code that doesn't compile.
+
+  If `go test` has failures, examine them:
+  - Tests that fail due to missing PostgreSQL/NATS → expected, skip mentally
+  - Tests that fail due to your code changes → fix before pushing
+
   ## Step 4: Open a Pull Request
 
   Commit, push, and open a PR:
@@ -156,21 +185,63 @@ prompt: |
       -d @/tmp/pr-body.json \
       "$GITHUB_API_URL/repos/bmbouter/alcove/pulls"
 
-  ## Step 5: Monitor CI and request review
+  ## Step 4.5: Register PR for CI monitoring
 
-  Poll the PR's check status every 30 seconds (up to 10 minutes):
+  After creating the PR, write the PR details to a well-known file so
+  Bridge can monitor CI status:
+
+    PR_RESPONSE=$(curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d @/tmp/pr-body.json \
+      "$GITHUB_API_URL/repos/bmbouter/alcove/pulls")
+    PR_NUM=$(echo "$PR_RESPONSE" | jq -r '.number')
+    echo "{\"repo\": \"bmbouter/alcove\", \"number\": $PR_NUM}" > /tmp/alcove-pr.json
+
+  ## Step 5: Monitor CI — your task is NOT DONE until CI is green
+
+  Your implementation is NOT complete when you open a PR. It is complete
+  when CI passes. Pushing code is a checkpoint, not a deliverable.
+
+  Poll the PR's check status every 30 seconds (up to 15 minutes):
     curl -s -H "Authorization: token $GITHUB_TOKEN" \
-      "$GITHUB_API_URL/repos/bmbouter/alcove/commits/BRANCH/status"
+      "$GITHUB_API_URL/repos/bmbouter/alcove/commits/$BRANCH/check-runs"
 
-  If checks fail:
-  1. Fetch the failed check details
-  2. Read the failure logs
-  3. Fix the issue, commit, and push to the same branch
-  4. Resume monitoring
+  ### When CI fails (you MUST follow this loop, up to 3 iterations):
 
-  Once all checks pass, the CI workflow will automatically add the
-  "awaiting-review" label. Your work is done — the PR Reviewer agent
-  will take it from here.
+  1. Fetch the failed check details:
+     curl -s -H "Authorization: token $GITHUB_TOKEN" \
+       "$GITHUB_API_URL/repos/bmbouter/alcove/commits/$BRANCH/check-runs" \
+       | jq '.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped")'
+
+  2. For each failed check, fetch the job log:
+     JOB_ID=$(... extract from check run ...)
+     curl -s -H "Authorization: token $GITHUB_TOKEN" \
+       "$GITHUB_API_URL/repos/bmbouter/alcove/actions/jobs/$JOB_ID/logs"
+
+  3. Classify the failure and fix:
+     - COMPILATION ERROR: Read the error message, fix the code, run `go build`
+       locally to verify, then push.
+     - TEST FAILURE: Read the test output, understand what's being tested,
+       fix the code or test, run the specific test locally, then push.
+     - LINT ERROR: Read the lint output, fix the issue, run `go vet` locally,
+       then push.
+     - INFRASTRUCTURE/FLAKY: If a test fails due to missing infrastructure
+       (PostgreSQL not available, NATS connection refused), this is expected
+       in CI for integration tests — focus on whether the unit tests passed.
+
+  4. After fixing, run local validation again (go build, go vet), commit,
+     and push to the same branch.
+
+  5. Resume polling for the new CI run.
+
+  ### Stopping criteria
+  - CI passes → your work is done, the CI workflow adds "awaiting-review"
+  - 3 fix attempts exhausted → post a comment on the issue explaining what
+    failed and what you tried. Do NOT silently give up.
+
+  CRITICAL: Stopping after a single CI failure is unacceptable. CI failures
+  are expected and normal — they are information, not blockers. Your value
+  is in iterating through them.
 
   ## Step 6: Handle blockers
 
@@ -201,6 +272,10 @@ timeout: 7200
 
 profiles:
   - alcove-developer
+
+ci_gate:
+  max_retries: 3
+  timeout: 900
 
 trigger:
   github:

--- a/build/Containerfile.skiff-base
+++ b/build/Containerfile.skiff-base
@@ -38,6 +38,12 @@ RUN dnf install -y \
         gzip \
     && dnf clean all
 
+# Install Go for local build/test validation
+RUN curl -sL https://go.dev/dl/go1.25.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ENV PATH="/usr/local/go/bin:${PATH}" \
+    GOPATH="/home/skiff/go" \
+    GOBIN="/home/skiff/go/bin"
+
 # Install Node.js (LTS) for Claude Code CLI
 RUN dnf module enable -y nodejs:20 && \
     dnf install -y nodejs npm && \
@@ -85,6 +91,7 @@ RUN git config --system credential.helper '/usr/local/bin/alcove-credential-help
 # Create a non-root user for running tasks
 RUN useradd -m -u 1001 -s /bin/bash skiff && \
     chmod 777 /home/skiff
+ENV PATH="/home/skiff/go/bin:/usr/local/go/bin:${PATH}"
 USER 1001
 WORKDIR /home/skiff
 

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -168,6 +168,11 @@ func main() {
 	// Create dispatcher and API.
 	dispatcher := bridge.NewDispatcher(nc, dbpool, rt, cfg, credStore, toolStore, profileStore, settingsStore)
 
+	// Create CI Gate monitor for automated CI retry.
+	ciGateMonitor := bridge.NewCIGateMonitor(dbpool, dispatcher, credStore, bridgeLLM)
+	dispatcher.SetCIGateMonitor(ciGateMonitor)
+	log.Println("CI gate monitor initialized")
+
 	// Start listening for status updates from Skiff pods.
 	if err := dispatcher.ListenForStatusUpdates(context.Background()); err != nil {
 		log.Fatalf("subscribing to status updates: %v", err)

--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -378,6 +378,11 @@ func runClaude(
 		outcome = "error"
 	}
 
+	// Check for PR artifact from task.
+	if prArtifact := readPRArtifact(); prArtifact != nil {
+		artifacts = append(artifacts, *prArtifact)
+	}
+
 	return exitCode, outcome, artifacts
 }
 
@@ -387,6 +392,35 @@ func flushBatch(lc *ledger.Client, sessionID string, batch *[]json.RawMessage) {
 		log.Printf("warning: failed to flush transcript batch to Ledger: %v", err)
 	}
 	*batch = nil
+}
+
+// readPRArtifact checks for a PR artifact file written by the task.
+// Tasks write {"repo": "owner/repo", "number": 123} to /tmp/alcove-pr.json
+// to report the PR they created for CI Gate monitoring.
+func readPRArtifact() *internal.Artifact {
+	data, err := os.ReadFile("/tmp/alcove-pr.json")
+	if err != nil {
+		return nil // No PR artifact file — normal for most tasks.
+	}
+
+	var pr struct {
+		Repo   string `json:"repo"`
+		Number int    `json:"number"`
+	}
+	if err := json.Unmarshal(data, &pr); err != nil {
+		log.Printf("warning: invalid /tmp/alcove-pr.json: %v", err)
+		return nil
+	}
+	if pr.Repo == "" || pr.Number == 0 {
+		return nil
+	}
+
+	log.Printf("PR artifact detected: %s#%d", pr.Repo, pr.Number)
+	return &internal.Artifact{
+		Type: "pull_request",
+		URL:  pr.Repo,
+		Ref:  strconv.Itoa(pr.Number),
+	}
 }
 
 // setupEnv configures the environment for Claude Code execution.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,19 @@
 All notable changes to Alcove are documented here. This project uses
 [Semantic Versioning](https://semver.org/).
 
+## v0.10.0
+
+### Features
+- Add CI Gate: Bridge-driven CI retry loop for autonomous developer tasks.
+  When a task definition includes `ci_gate`, Bridge monitors CI status on PRs
+  created by the task and automatically dispatches fresh retry agents on failure,
+  using the system LLM to analyze failure logs and compose targeted fix prompts.
+- Add Go 1.25 toolchain to Skiff base image. Autonomous agents can now run
+  `go build`, `go vet`, and `go test` locally before pushing, catching
+  compilation and test errors without waiting for CI.
+- Rewrite autonomous developer prompt with mandatory pre-push validation,
+  structured CI retry discipline, and risk assessment for untestable changes.
+
 ## v0.9.1
 
 ### Bug Fixes

--- a/internal/bridge/cigate.go
+++ b/internal/bridge/cigate.go
@@ -1,0 +1,529 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bmbouter/alcove/internal"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// CIGateMonitor watches PRs created by tasks with ci_gate config and
+// retries on CI failure using the system LLM to analyze logs.
+type CIGateMonitor struct {
+	db         *pgxpool.Pool
+	dispatcher *Dispatcher
+	credStore  *CredentialStore
+	llm        *BridgeLLM
+	client     *http.Client
+	mu         sync.Mutex
+	watching   map[string]bool // session IDs being monitored
+}
+
+// NewCIGateMonitor creates a CIGateMonitor.
+func NewCIGateMonitor(db *pgxpool.Pool, dispatcher *Dispatcher, credStore *CredentialStore, llm *BridgeLLM) *CIGateMonitor {
+	return &CIGateMonitor{
+		db:         db,
+		dispatcher: dispatcher,
+		credStore:  credStore,
+		llm:        llm,
+		client:     &http.Client{Timeout: 30 * time.Second},
+		watching:   make(map[string]bool),
+	}
+}
+
+// parsePRArtifact extracts the repo slug and PR number from a PR artifact URL.
+// Expected format: https://github.com/owner/repo/pull/42
+func parsePRArtifact(a internal.Artifact) (repo string, prNumber int, ok bool) {
+	if a.Type != "pr" {
+		return "", 0, false
+	}
+	u := a.URL
+	// Strip scheme.
+	u = strings.TrimPrefix(u, "https://")
+	u = strings.TrimPrefix(u, "http://")
+	// Expected: github.com/owner/repo/pull/42
+	parts := strings.Split(u, "/")
+	if len(parts) < 5 || parts[3] != "pull" {
+		return "", 0, false
+	}
+	repo = parts[1] + "/" + parts[2]
+	n, err := strconv.Atoi(parts[4])
+	if err != nil {
+		return "", 0, false
+	}
+	return repo, n, true
+}
+
+// OnTaskCompleted is called when a task finishes. It checks for PR artifacts
+// and ci_gate config, and starts CI monitoring if applicable.
+func (m *CIGateMonitor) OnTaskCompleted(ctx context.Context, sessionID string, artifacts []internal.Artifact) {
+	// Find PR artifact.
+	var prRepo string
+	var prNumber int
+	for _, a := range artifacts {
+		r, n, ok := parsePRArtifact(a)
+		if ok {
+			prRepo = r
+			prNumber = n
+			break
+		}
+	}
+	if prNumber == 0 || prRepo == "" {
+		return
+	}
+
+	// Look up task definition to check for ci_gate config.
+	var sourceKey string
+	var owner string
+	err := m.db.QueryRow(ctx,
+		`SELECT COALESCE(s.source_key, ''), s.submitter FROM sessions sess
+         JOIN schedules s ON s.source_key != ''
+         WHERE sess.id = $1
+         LIMIT 1`, sessionID).Scan(&sourceKey, &owner)
+	if err != nil || sourceKey == "" {
+		// Try getting owner from session directly.
+		_ = m.db.QueryRow(ctx, `SELECT submitter FROM sessions WHERE id = $1`, sessionID).Scan(&owner)
+	}
+
+	// Look up ci_gate config from task definition.
+	var parsedJSON []byte
+	if sourceKey != "" {
+		_ = m.db.QueryRow(ctx,
+			`SELECT parsed FROM task_definitions WHERE source_key = $1`, sourceKey,
+		).Scan(&parsedJSON)
+	}
+
+	// Also try matching by prompt similarity if source_key lookup fails.
+	if parsedJSON == nil {
+		_ = m.db.QueryRow(ctx,
+			`SELECT td.parsed FROM sessions sess
+             JOIN schedules sch ON sch.source_key != ''
+             JOIN task_definitions td ON td.source_key = sch.source_key
+             WHERE sess.id = $1 LIMIT 1`, sessionID,
+		).Scan(&parsedJSON)
+	}
+
+	if parsedJSON == nil {
+		return
+	}
+
+	var td TaskDefinition
+	if json.Unmarshal(parsedJSON, &td) != nil || td.CIGate == nil {
+		return
+	}
+
+	maxRetries := td.CIGate.MaxRetries
+	if maxRetries <= 0 {
+		maxRetries = 3
+	}
+	timeout := td.CIGate.Timeout
+	if timeout <= 0 {
+		timeout = 900
+	}
+
+	// Check if this is already a retry (has parent ci_gate_state).
+	var existingRetryCount int
+	var originalSessionID string
+	err = m.db.QueryRow(ctx,
+		`SELECT retry_count, original_session_id FROM ci_gate_state WHERE session_id = $1`, sessionID,
+	).Scan(&existingRetryCount, &originalSessionID)
+
+	retryCount := 0
+	if err == nil {
+		retryCount = existingRetryCount
+	} else {
+		originalSessionID = sessionID
+	}
+
+	// Insert ci_gate_state for this PR.
+	_, err = m.db.Exec(ctx,
+		`INSERT INTO ci_gate_state (session_id, pr_repo, pr_number, retry_count, max_retries, status, original_session_id, task_def_source_key, owner)
+         VALUES ($1, $2, $3, $4, $5, 'monitoring', $6, $7, $8)
+         ON CONFLICT (session_id) DO UPDATE SET status = 'monitoring', updated_at = NOW()`,
+		sessionID, prRepo, prNumber, retryCount, maxRetries, originalSessionID, sourceKey, owner)
+	if err != nil {
+		log.Printf("cigate: error inserting state for session %s: %v", sessionID, err)
+		return
+	}
+
+	// Start monitoring in background.
+	m.mu.Lock()
+	if m.watching[sessionID] {
+		m.mu.Unlock()
+		return
+	}
+	m.watching[sessionID] = true
+	m.mu.Unlock()
+
+	go m.monitorPR(context.Background(), sessionID, prRepo, prNumber, timeout, owner)
+}
+
+// ciCheckRun represents a GitHub check run from the API response.
+type ciCheckRun struct {
+	ID         int64  `json:"id"`
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+// monitorPR polls CI status on a PR until it passes, fails, or times out.
+func (m *CIGateMonitor) monitorPR(ctx context.Context, sessionID, repo string, prNumber, timeoutSecs int, owner string) {
+	defer func() {
+		m.mu.Lock()
+		delete(m.watching, sessionID)
+		m.mu.Unlock()
+	}()
+
+	log.Printf("cigate: monitoring CI for PR %s#%d (session %s)", repo, prNumber, sessionID)
+
+	token, _, err := m.credStore.AcquireSCMTokenForOwner(ctx, "github", owner)
+	if err != nil {
+		log.Printf("cigate: no GitHub credential for %s: %v", owner, err)
+		m.updateStatus(ctx, sessionID, "error")
+		return
+	}
+
+	deadline := time.Now().Add(time.Duration(timeoutSecs) * time.Second)
+	pollInterval := 30 * time.Second
+
+	for time.Now().Before(deadline) {
+		// Get PR head SHA.
+		prData, err := m.githubGet(ctx, token, fmt.Sprintf("https://api.github.com/repos/%s/pulls/%d", repo, prNumber))
+		if err != nil {
+			log.Printf("cigate: error fetching PR %s#%d: %v", repo, prNumber, err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		var pr struct {
+			Head struct{ SHA string `json:"sha"` } `json:"head"`
+			State  string `json:"state"`
+			Merged bool   `json:"merged"`
+		}
+		json.Unmarshal(prData, &pr)
+
+		if pr.State != "open" || pr.Merged {
+			log.Printf("cigate: PR %s#%d is %s (merged=%v), stopping monitor", repo, prNumber, pr.State, pr.Merged)
+			m.updateStatus(ctx, sessionID, "passed")
+			return
+		}
+
+		// Check CI status.
+		checksData, err := m.githubGet(ctx, token, fmt.Sprintf("https://api.github.com/repos/%s/commits/%s/check-runs", repo, pr.Head.SHA))
+		if err != nil {
+			log.Printf("cigate: error fetching checks for %s#%d: %v", repo, prNumber, err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		var checks struct {
+			CheckRuns []ciCheckRun `json:"check_runs"`
+		}
+		json.Unmarshal(checksData, &checks)
+
+		if len(checks.CheckRuns) == 0 {
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		allComplete := true
+		anyFailed := false
+		var failedChecks []string
+		for _, cr := range checks.CheckRuns {
+			if cr.Status != "completed" {
+				allComplete = false
+				break
+			}
+			if cr.Conclusion != "success" && cr.Conclusion != "skipped" {
+				anyFailed = true
+				failedChecks = append(failedChecks, fmt.Sprintf("%s (conclusion: %s, id: %d)", cr.Name, cr.Conclusion, cr.ID))
+			}
+		}
+
+		if !allComplete {
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		if !anyFailed {
+			log.Printf("cigate: CI passed for PR %s#%d", repo, prNumber)
+			m.updateStatus(ctx, sessionID, "passed")
+			return
+		}
+
+		// CI failed — trigger retry.
+		log.Printf("cigate: CI failed for PR %s#%d: %v", repo, prNumber, failedChecks)
+		m.handleCIFailure(ctx, sessionID, repo, prNumber, token, checks.CheckRuns, owner)
+		return
+	}
+
+	log.Printf("cigate: CI monitoring timed out for PR %s#%d", repo, prNumber)
+	m.updateStatus(ctx, sessionID, "timeout")
+}
+
+// handleCIFailure fetches failure logs, uses system LLM to analyze them,
+// and dispatches a retry task.
+func (m *CIGateMonitor) handleCIFailure(ctx context.Context, sessionID, repo string, prNumber int, token string, checkRuns []ciCheckRun, owner string) {
+	// Load ci_gate_state.
+	var retryCount, maxRetries int
+	var originalSessionID, sourceKey string
+	err := m.db.QueryRow(ctx,
+		`SELECT retry_count, max_retries, original_session_id, COALESCE(task_def_source_key, '') FROM ci_gate_state WHERE session_id = $1`,
+		sessionID,
+	).Scan(&retryCount, &maxRetries, &originalSessionID, &sourceKey)
+	if err != nil {
+		log.Printf("cigate: error loading state for %s: %v", sessionID, err)
+		return
+	}
+
+	if retryCount >= maxRetries {
+		log.Printf("cigate: max retries (%d) exhausted for PR %s#%d", maxRetries, repo, prNumber)
+		m.updateStatus(ctx, sessionID, "exhausted")
+		m.postExhaustedComment(ctx, repo, prNumber, token, retryCount)
+		m.addLabel(ctx, repo, prNumber, token, "needs-human-review")
+		return
+	}
+
+	// Fetch failure logs for failed checks.
+	var failureSummary strings.Builder
+	for _, cr := range checkRuns {
+		if cr.Conclusion != "success" && cr.Conclusion != "skipped" && cr.Status == "completed" {
+			// Fetch job log.
+			logData, err := m.githubGet(ctx, token, fmt.Sprintf("https://api.github.com/repos/%s/actions/jobs/%d/logs", repo, cr.ID))
+			if err != nil {
+				failureSummary.WriteString(fmt.Sprintf("\n### %s (conclusion: %s)\nCould not fetch logs: %v\n", cr.Name, cr.Conclusion, err))
+				continue
+			}
+			// Truncate logs to last 3000 chars to keep within LLM context.
+			logStr := string(logData)
+			if len(logStr) > 3000 {
+				logStr = logStr[len(logStr)-3000:]
+			}
+			failureSummary.WriteString(fmt.Sprintf("\n### %s (conclusion: %s)\n```\n%s\n```\n", cr.Name, cr.Conclusion, logStr))
+		}
+	}
+
+	// Get the PR branch name.
+	prData, _ := m.githubGet(ctx, token, fmt.Sprintf("https://api.github.com/repos/%s/pulls/%d", repo, prNumber))
+	var prInfo struct {
+		Head struct {
+			Ref string `json:"ref"`
+		} `json:"head"`
+		Title string `json:"title"`
+		Body  string `json:"body"`
+	}
+	json.Unmarshal(prData, &prInfo)
+
+	// Compose retry prompt using system LLM if available, otherwise use template.
+	retryPrompt := m.composeRetryPrompt(ctx, repo, prNumber, prInfo.Head.Ref, prInfo.Title, failureSummary.String(), retryCount+1, maxRetries)
+
+	// Look up original task definition for profiles, repo, provider, timeout.
+	var taskReq TaskRequest
+	if sourceKey != "" {
+		var parsedJSON []byte
+		_ = m.db.QueryRow(ctx,
+			`SELECT parsed FROM task_definitions WHERE source_key = $1`, sourceKey,
+		).Scan(&parsedJSON)
+		if parsedJSON != nil {
+			var td TaskDefinition
+			if json.Unmarshal(parsedJSON, &td) == nil {
+				taskReq = td.ToTaskRequest()
+			}
+		}
+	}
+
+	// Override prompt with retry-specific one.
+	taskReq.Prompt = retryPrompt
+
+	// Dispatch retry task.
+	newSession, err := m.dispatcher.DispatchTask(ctx, taskReq, owner)
+	if err != nil {
+		log.Printf("cigate: error dispatching retry for PR %s#%d: %v", repo, prNumber, err)
+		m.updateStatus(ctx, sessionID, "error")
+		return
+	}
+
+	log.Printf("cigate: dispatched retry %d/%d for PR %s#%d (new session %s)", retryCount+1, maxRetries, repo, prNumber, newSession.ID)
+
+	// Update current session status.
+	m.updateStatus(ctx, sessionID, "retrying")
+
+	// Create ci_gate_state for the new retry session.
+	_, _ = m.db.Exec(ctx,
+		`INSERT INTO ci_gate_state (session_id, pr_repo, pr_number, retry_count, max_retries, status, original_session_id, task_def_source_key, owner)
+         VALUES ($1, $2, $3, $4, $5, 'pending', $6, $7, $8)`,
+		newSession.ID, repo, prNumber, retryCount+1, maxRetries, originalSessionID, sourceKey, owner)
+}
+
+// composeRetryPrompt uses the system LLM to create a targeted retry prompt,
+// or falls back to a template if no LLM is available.
+func (m *CIGateMonitor) composeRetryPrompt(ctx context.Context, repo string, prNumber int, branch, title, failureLogs string, attempt, maxAttempts int) string {
+	if m.llm != nil && m.llm.Available() {
+		systemPrompt := `You are a CI failure analysis assistant. Given CI failure logs from a GitHub pull request, compose a concise, actionable prompt for an AI coding agent that will fix the failures. The agent has the repo cloned and can read/edit files and push to the branch. Focus on:
+1. What specifically failed (compilation errors, test failures, lint issues)
+2. The likely root cause
+3. Specific files/lines to investigate
+4. A clear action plan
+
+Output ONLY the prompt text, no explanations or markdown fencing.`
+
+		userPrompt := fmt.Sprintf(`PR: %s#%d
+Branch: %s
+Title: %s
+Attempt: %d of %d
+
+CI Failure Logs:
+%s`, repo, prNumber, branch, title, attempt, maxAttempts, failureLogs)
+
+		analysis, err := m.llm.Complete(ctx, systemPrompt, userPrompt, 2000)
+		if err == nil && analysis != "" {
+			return fmt.Sprintf(`You are fixing CI failures on an existing pull request.
+
+## Context
+- Repository: %s
+- PR: #%d (branch: %s)
+- Title: %s
+- This is CI fix attempt %d of %d
+
+## Environment
+Use curl with $GITHUB_API_URL and $GITHUB_TOKEN for GitHub API calls.
+Write JSON payloads to files before POSTing.
+
+## Instructions
+1. Checkout the existing branch: git fetch origin %s && git checkout %s
+2. Read the CI failure analysis below and fix the issues
+3. Run any available local validation before pushing (go build, go test, go vet, etc.)
+4. Commit and push to the same branch
+5. Do NOT create a new PR — push to the existing branch
+
+## CI Failure Analysis
+%s
+
+## Important
+- Fix ONLY the CI failures — do not refactor or add features
+- Run local validation before pushing
+- If you cannot fix a failure, leave a comment on PR #%d explaining what you tried
+`, repo, prNumber, branch, title, attempt, maxAttempts, branch, branch, analysis, prNumber)
+		}
+		log.Printf("cigate: LLM analysis failed, using template: %v", err)
+	}
+
+	// Fallback template.
+	return fmt.Sprintf(`You are fixing CI failures on an existing pull request.
+
+## Context
+- Repository: %s
+- PR: #%d (branch: %s)
+- Title: %s
+- This is CI fix attempt %d of %d
+
+## Environment
+Use curl with $GITHUB_API_URL and $GITHUB_TOKEN for GitHub API calls.
+Write JSON payloads to files before POSTing.
+
+## Instructions
+1. Checkout the existing branch: git fetch origin %s && git checkout %s
+2. Fetch the CI check runs to understand what failed:
+   curl -s -H "Authorization: token $GITHUB_TOKEN" "$GITHUB_API_URL/repos/%s/commits/%s/check-runs"
+3. For each failed check, fetch the log and analyze the error
+4. Fix the issues in the code
+5. Run any available local validation (go build, go test, go vet, etc.)
+6. Commit and push to the same branch
+7. Do NOT create a new PR — push to the existing branch
+
+## CI Failure Summary
+%s
+
+## Important
+- Fix ONLY the CI failures — do not refactor or add features
+- Run local validation before pushing
+- If you cannot fix a failure, leave a comment on PR #%d explaining what you tried
+`, repo, prNumber, branch, title, attempt, maxAttempts, branch, branch, repo, branch, failureLogs, prNumber)
+}
+
+// githubGet performs an authenticated GET request to the GitHub API.
+func (m *CIGateMonitor) githubGet(ctx context.Context, token, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "alcove-cigate")
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return body, fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, truncateStr(string(body), 200))
+	}
+	return body, nil
+}
+
+func (m *CIGateMonitor) updateStatus(ctx context.Context, sessionID, status string) {
+	_, _ = m.db.Exec(ctx,
+		`UPDATE ci_gate_state SET status = $1, updated_at = NOW() WHERE session_id = $2`,
+		status, sessionID)
+}
+
+func (m *CIGateMonitor) postExhaustedComment(ctx context.Context, repo string, prNumber int, token string, retryCount int) {
+	comment := fmt.Sprintf(`{"body":"**CI Gate: Retries Exhausted**\n\nThis PR has failed CI %d times with automated fix attempts. The CI failures could not be resolved automatically.\n\nPlease review the CI logs and fix manually."}`, retryCount)
+
+	req, _ := http.NewRequestWithContext(ctx, "POST",
+		fmt.Sprintf("https://api.github.com/repos/%s/issues/%d/comments", repo, prNumber),
+		strings.NewReader(comment))
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "alcove-cigate")
+	m.client.Do(req)
+}
+
+func (m *CIGateMonitor) addLabel(ctx context.Context, repo string, prNumber int, token, label string) {
+	body := fmt.Sprintf(`{"labels":["%s"]}`, label)
+	req, _ := http.NewRequestWithContext(ctx, "POST",
+		fmt.Sprintf("https://api.github.com/repos/%s/issues/%d/labels", repo, prNumber),
+		strings.NewReader(body))
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "alcove-cigate")
+	m.client.Do(req)
+}
+
+// truncateStr shortens a string for log messages.
+func truncateStr(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/bridge/cigate.go
+++ b/internal/bridge/cigate.go
@@ -54,27 +54,20 @@ func NewCIGateMonitor(db *pgxpool.Pool, dispatcher *Dispatcher, credStore *Crede
 	}
 }
 
-// parsePRArtifact extracts the repo slug and PR number from a PR artifact URL.
-// Expected format: https://github.com/owner/repo/pull/42
+// parsePRArtifact extracts the repo slug and PR number from a PR artifact.
+// Skiff-init writes: Type="pull_request", URL="owner/repo", Ref="42"
 func parsePRArtifact(a internal.Artifact) (repo string, prNumber int, ok bool) {
-	if a.Type != "pr" {
+	if a.Type != "pull_request" && a.Type != "pr" {
 		return "", 0, false
 	}
-	u := a.URL
-	// Strip scheme.
-	u = strings.TrimPrefix(u, "https://")
-	u = strings.TrimPrefix(u, "http://")
-	// Expected: github.com/owner/repo/pull/42
-	parts := strings.Split(u, "/")
-	if len(parts) < 5 || parts[3] != "pull" {
+	if a.URL == "" || a.Ref == "" {
 		return "", 0, false
 	}
-	repo = parts[1] + "/" + parts[2]
-	n, err := strconv.Atoi(parts[4])
-	if err != nil {
+	n, err := strconv.Atoi(a.Ref)
+	if err != nil || n == 0 {
 		return "", 0, false
 	}
-	return repo, n, true
+	return a.URL, n, true
 }
 
 // OnTaskCompleted is called when a task finishes. It checks for PR artifacts

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -43,6 +43,7 @@ type Dispatcher struct {
 	settingsStore *SettingsStore
 	mu            sync.Mutex
 	handles       map[string]runtime.TaskHandle // sessionID -> handle
+	ciGate        *CIGateMonitor
 }
 
 // NewDispatcher creates a Dispatcher with the given dependencies.
@@ -58,6 +59,12 @@ func NewDispatcher(nc *nats.Conn, db *pgxpool.Pool, rt runtime.Runtime, cfg *Con
 		settingsStore: settingsStore,
 		handles:       make(map[string]runtime.TaskHandle),
 	}
+}
+
+// SetCIGateMonitor attaches a CIGateMonitor to the dispatcher so that
+// completed tasks with PR artifacts can be automatically monitored for CI.
+func (d *Dispatcher) SetCIGateMonitor(m *CIGateMonitor) {
+	d.ciGate = m
 }
 
 // TaskRequest is the JSON body for POST /api/v1/tasks.
@@ -621,6 +628,11 @@ func (d *Dispatcher) ListenForStatusUpdates(ctx context.Context) error {
 			d.mu.Lock()
 			delete(d.handles, update.SessionID)
 			d.mu.Unlock()
+
+			// Notify CI Gate monitor if task completed with artifacts.
+			if d.ciGate != nil && update.Status == "completed" {
+				go d.ciGate.OnTaskCompleted(ctx, update.SessionID, update.Artifacts)
+			}
 		}
 	})
 

--- a/internal/bridge/migrations/018_ci_gate.sql
+++ b/internal/bridge/migrations/018_ci_gate.sql
@@ -1,0 +1,14 @@
+-- CI Gate state tracking for Bridge-driven CI retry loop.
+CREATE TABLE IF NOT EXISTS ci_gate_state (
+    session_id TEXT PRIMARY KEY,
+    pr_repo TEXT NOT NULL,
+    pr_number INT NOT NULL,
+    retry_count INT NOT NULL DEFAULT 0,
+    max_retries INT NOT NULL DEFAULT 3,
+    status TEXT NOT NULL DEFAULT 'monitoring',
+    original_session_id TEXT NOT NULL,
+    task_def_source_key TEXT,
+    owner TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/internal/bridge/taskdef.go
+++ b/internal/bridge/taskdef.go
@@ -25,6 +25,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// CIGate configures Bridge-driven CI monitoring for PRs created by a task.
+type CIGate struct {
+	MaxRetries int `json:"max_retries" yaml:"max_retries"`
+	Timeout    int `json:"timeout" yaml:"timeout"` // seconds to wait for CI, default 900
+}
+
 // TaskDefinition represents a task defined in a YAML file within a task repo.
 type TaskDefinition struct {
 	ID          string                `json:"id"`
@@ -41,6 +47,7 @@ type TaskDefinition struct {
 	Tools       map[string]ToolConfig `json:"tools,omitempty" yaml:"tools"`
 	Schedule    *TaskDefSchedule      `json:"schedule,omitempty" yaml:"schedule"`
 	Trigger     *EventTrigger         `json:"trigger,omitempty" yaml:"trigger"`
+	CIGate      *CIGate               `json:"ci_gate,omitempty" yaml:"ci_gate"`
 
 	// Metadata (not from YAML).
 	Owner      string     `json:"owner,omitempty"`


### PR DESCRIPTION
## Summary
- **CI Gate monitor**: Bridge watches CI status on PRs created by tasks with `ci_gate` config. On CI failure, uses system LLM to analyze logs and dispatches a fresh retry agent. Configurable via `ci_gate.max_retries` and `ci_gate.timeout` in task YAML.
- **Go 1.25 in Skiff image**: Agents can now run `go build`, `go vet`, `go test` locally before pushing
- **Autonomous developer prompt rewrite**: Mandatory pre-push validation, structured CI retry loop with 3-iteration budget, failure classification, risk assessment for untestable changes
- **PR artifact reporting**: skiff-init reads `/tmp/alcove-pr.json` on task completion, reports PR number back to Bridge for CI Gate monitoring
- **Database migration 018**: `ci_gate_state` table for tracking PR monitoring state and retry counts

## Architecture
```
Task creates PR → writes /tmp/alcove-pr.json
    ↓
skiff-init reads file → sends PR artifact via NATS
    ↓
Bridge OnTaskCompleted → checks ci_gate config
    ↓
CIGateMonitor polls check-runs (every 30s, up to timeout)
    ↓
CI passes → done
CI fails → system LLM analyzes logs → dispatches fresh retry task
    ↓
Repeat until passes or max_retries exhausted
    ↓
Exhausted → adds needs-human-review label, posts comment
```

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [ ] CI passes on this PR
- [ ] Deploy to staging and verify CI Gate triggers on failing PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)