### PR TITLE
Fix double dispatch: remove opened action, add persistent dedup

### DIFF
--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -284,7 +284,6 @@ trigger:
       - issue_comment
       - pull_request
     actions:
-      - opened
       - reopened
       - created
       - labeled

--- a/.alcove/tasks/planning.yml
+++ b/.alcove/tasks/planning.yml
@@ -167,7 +167,6 @@ trigger:
       - issues
       - issue_comment
     actions:
-      - opened
       - reopened
       - created
       - labeled

--- a/internal/bridge/migrations/019_dispatched_dedup.sql
+++ b/internal/bridge/migrations/019_dispatched_dedup.sql
@@ -1,0 +1,13 @@
+-- Persistent deduplication for polled events.
+-- Prevents the same issue/PR + schedule from being dispatched twice
+-- when multiple GitHub events (e.g. opened + labeled) arrive across
+-- different poll cycles.
+CREATE TABLE IF NOT EXISTS dispatched_dedup (
+    repo TEXT NOT NULL,
+    item_number TEXT NOT NULL,
+    schedule_id TEXT NOT NULL,
+    dispatched_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (repo, item_number, schedule_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dispatched_dedup_at ON dispatched_dedup(dispatched_at);

--- a/internal/bridge/poller.go
+++ b/internal/bridge/poller.go
@@ -266,6 +266,9 @@ func (p *GitHubPoller) pollRepo(ctx context.Context, repo, owner string, schedul
 
 	dispatched := 0
 
+	// Clean up old dedup entries (older than 1 hour).
+	_, _ = p.db.Exec(ctx, `DELETE FROM dispatched_dedup WHERE dispatched_at < NOW() - INTERVAL '1 hour'`)
+
 	// Track dispatched (issue_number, schedule_id) pairs to prevent duplicates in this poll cycle.
 	dispatchedTasks := make(map[string]bool)
 
@@ -400,6 +403,25 @@ func (p *GitHubPoller) pollRepo(ctx context.Context, repo, owner string, schedul
 			}
 			if dedupeKey != "" && dispatchedTasks[dedupeKey] {
 				continue // Already dispatched this task for this issue/PR in this poll cycle.
+			}
+
+			// Persistent dedup: prevent dispatching the same schedule for the
+			// same issue/PR across poll cycles. GitHub emits multiple events
+			// for a single action (e.g., "opened" + "labeled"), and they may
+			// arrive in different poll cycles.
+			itemNumber := issueNumber
+			if itemNumber == "" {
+				itemNumber = prNumber
+			}
+			if itemNumber != "" {
+				dedupResult, _ := p.db.Exec(ctx,
+					`INSERT INTO dispatched_dedup (repo, item_number, schedule_id)
+					VALUES ($1, $2, $3)
+					ON CONFLICT DO NOTHING`,
+					eventRepo, itemNumber, sched.ID)
+				if dedupResult.RowsAffected() == 0 {
+					continue // Already dispatched for this issue/PR + schedule recently.
+				}
 			}
 
 			// Deduplicate via webhook_deliveries.


### PR DESCRIPTION
## Summary
- **Root cause**: GitHub emits both `opened` and `labeled` events when an issue is created with a label. These arrive in separate poll cycles, bypassing the in-memory dedup map which is recreated fresh each cycle.
- **Fix 1 (trigger config)**: Remove `opened` from trigger actions in `planning.yml` and `autonomous-dev.yml`. These label-triggered tasks only need the `labeled` action — `opened` without a label shouldn't trigger anything.
- **Fix 2 (persistent dedup)**: Add `dispatched_dedup` table (migration 019) keyed on `(repo, item_number, schedule_id)` with 1-hour TTL. Checked before dispatch, prevents the same issue+schedule from firing twice across poll cycles.

## Evidence from staging logs
```
14:59:06 dispatched Implementation Planner for issues opened  (event 8290061701)
15:01:06 dispatched Implementation Planner for issues labeled (event 8290061871)
```
Same issue, two events, two poll cycles → duplicate dispatch.

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [ ] CI passes
- [ ] Deploy to staging and verify no duplicate dispatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)