### PR TITLE
Add Claude Pro/Max OAuth support as LLM provider

### DIFF
--- a/docs/design/implementation-status.md
+++ b/docs/design/implementation-status.md
@@ -44,7 +44,7 @@ alcove/
 │   │   ├── dispatcher.go       ✅ Task dispatch: creates session, resolves security profiles, publishes to NATS, starts Skiff+Gate with LLM/SCM credentials and tool configs
 │   │   ├── config.go           ✅ Config loading from env vars, auth backend selection, debug mode
 │   │   ├── runtime.go          ✅ Runtime factory (podman/kubernetes selection)
-│   │   ├── credentials.go      ✅ Credential CRUD, AES-256-GCM encryption, OAuth2 token acquisition, token refresh, AcquireSCMToken, AcquireSystemToken, owner scoping, system credentials
+│   │   ├── credentials.go      ✅ Credential CRUD, AES-256-GCM encryption, OAuth2 token acquisition, token refresh, AcquireSCMToken, AcquireSystemToken, owner scoping, system credentials, claude-oauth support
 │   │   ├── credentials_test.go ✅ Credential store tests
 │   │   ├── scheduler.go        ✅ Cron scheduler: parsing, next-run computation, schedule CRUD, background tick loop, per-schedule debug flag
 │   │   ├── profiles.go         ✅ Security profiles: multi-rule per-repo operation scoping, profile CRUD with owner scoping
@@ -63,7 +63,7 @@ alcove/
 │   │       ├── 008_credential_api_host.sql  ✅ Custom API host for credentials (GitLab private servers)
 │   │       └── 009_system_settings.sql  ✅ System settings key-value store
 │   ├── gate/
-│   │   ├── proxy.go            ✅ HTTP proxy, CONNECT tunneling, LLM API injection (api_key + bearer), audit logging, 401 token refresh
+│   │   ├── proxy.go            ✅ HTTP proxy, CONNECT tunneling, LLM API injection (api_key + bearer + oauth_token), audit logging, 401 token refresh
 │   │   ├── proxy_test.go       ✅ Proxy tests
 │   │   └── scope.go            ✅ Scope enforcement, GitHub/GitLab URL parsing, git credential helper
 │   ├── hail/
@@ -429,6 +429,7 @@ See the full roadmap in [architecture-decisions.md](architecture-decisions.md#ro
 | `ALCOVE_DEBUG` | (unset) | Set to any value to enable debug mode (keep containers after exit) |
 | `ALCOVE_WEB_DIR` | `web` | Path to dashboard static files |
 | `ANTHROPIC_API_KEY` | (optional) | Anthropic API key (auto-migrated to credential store) |
+| `BRIDGE_LLM_OAUTH_TOKEN` | (optional) | Claude Pro/Max setup-token for system LLM |
 | `VERTEX_API_KEY` | (optional) | Vertex AI API key (auto-migrated to credential store) |
 | `VERTEX_PROJECT` | (optional) | GCP project ID for Vertex AI provider |
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-20250514` | Default model for Anthropic provider |

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -1019,6 +1019,22 @@ func (a *API) handleCredentials(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusBadRequest, "name, provider, auth_type, and credential are required")
 			return
 		}
+		// Enforce one LLM credential per user.
+		scmProviders := map[string]bool{"github": true, "gitlab": true, "jira": true}
+		if !scmProviders[req.Provider] {
+			existing, _ := a.credStore.ListCredentials(r.Context(), user)
+			for _, c := range existing {
+				if !scmProviders[c.Provider] {
+					respondJSON(w, http.StatusConflict, map[string]any{
+						"error":               "you already have an LLM credential configured",
+						"existing_credential":  c.Name,
+						"existing_provider":    c.Provider,
+						"existing_id":          c.ID,
+					})
+					return
+				}
+			}
+		}
 		cred := Credential{
 			Name:      req.Name,
 			Provider:  req.Provider,

--- a/internal/bridge/api_test.go
+++ b/internal/bridge/api_test.go
@@ -1,0 +1,25 @@
+package bridge
+
+import "testing"
+
+func TestIsScmProvider(t *testing.T) {
+	scmProviders := map[string]bool{"github": true, "gitlab": true, "jira": true}
+
+	tests := []struct {
+		provider string
+		isSCM    bool
+	}{
+		{"github", true},
+		{"gitlab", true},
+		{"jira", true},
+		{"anthropic", false},
+		{"google-vertex", false},
+		{"claude-oauth", false},
+	}
+
+	for _, tt := range tests {
+		if scmProviders[tt.provider] != tt.isSCM {
+			t.Errorf("provider %q: got isSCM=%v, want %v", tt.provider, scmProviders[tt.provider], tt.isSCM)
+		}
+	}
+}

--- a/internal/bridge/config.go
+++ b/internal/bridge/config.go
@@ -52,6 +52,7 @@ type SystemLLMConfig struct {
 	Provider           string `yaml:"provider"`
 	Model              string `yaml:"model"`
 	APIKey             string `yaml:"api_key"`
+	OAuthToken         string `yaml:"oauth_token"`
 	ServiceAccountJSON string `yaml:"service_account_json"`
 	ProjectID          string `yaml:"project_id"`
 	Region             string `yaml:"region"`
@@ -125,6 +126,9 @@ For Kubernetes:
 	}
 	if v := os.Getenv("BRIDGE_LLM_MODEL"); v != "" {
 		cfg.SystemLLM.Model = v
+	}
+	if v := os.Getenv("BRIDGE_LLM_OAUTH_TOKEN"); v != "" {
+		cfg.SystemLLM.OAuthToken = v
 	}
 	if v := os.Getenv("BRIDGE_LLM_SERVICE_ACCOUNT_JSON"); v != "" {
 		cfg.SystemLLM.ServiceAccountJSON = v

--- a/internal/bridge/credentials.go
+++ b/internal/bridge/credentials.go
@@ -35,7 +35,7 @@ import (
 type Credential struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
-	Provider  string    `json:"provider"`   // "anthropic" or "google-vertex"
+	Provider  string    `json:"provider"`   // "anthropic", "google-vertex", or "claude-oauth"
 	AuthType  string    `json:"auth_type"`  // "api_key", "service_account", or "adc"
 	ProjectID string    `json:"project_id"` // GCP project ID (Vertex only)
 	Region    string    `json:"region"`     // GCP region (Vertex only)
@@ -243,10 +243,10 @@ func (cs *CredentialStore) AcquireToken(ctx context.Context, providerName string
 	}
 
 	switch authType {
-	case "api_key":
+	case "api_key", "oauth_token":
 		return &TokenResult{
 			Token:     string(raw),
-			TokenType: "api_key",
+			TokenType: authType,
 			ExpiresIn: 0,
 			Provider:  provider,
 		}, nil
@@ -301,10 +301,10 @@ func (cs *CredentialStore) AcquireSystemToken(ctx context.Context, providerName 
 	}
 
 	switch authType {
-	case "api_key":
+	case "api_key", "oauth_token":
 		return &TokenResult{
 			Token:     string(raw),
-			TokenType: "api_key",
+			TokenType: authType,
 			ExpiresIn: 0,
 			Provider:  provider,
 		}, nil

--- a/internal/bridge/credentials_test.go
+++ b/internal/bridge/credentials_test.go
@@ -46,6 +46,25 @@ func TestEncryptDecryptWrongKey(t *testing.T) {
 	}
 }
 
+func TestEncryptDecryptOAuthTokenRoundtrip(t *testing.T) {
+	key := make([]byte, 32)
+	plaintext := []byte("sk-ant-oat01-oauth-token-value")
+	encrypted, err := encrypt(key, plaintext)
+	if err != nil {
+		t.Fatalf("encrypt failed: %v", err)
+	}
+	if string(encrypted) == string(plaintext) {
+		t.Fatal("encrypted should differ")
+	}
+	decrypted, err := decrypt(key, encrypted)
+	if err != nil {
+		t.Fatalf("decrypt failed: %v", err)
+	}
+	if string(decrypted) != string(plaintext) {
+		t.Fatalf("got %q, want %q", decrypted, plaintext)
+	}
+}
+
 func TestDeriveKey(t *testing.T) {
 	key := deriveKey("my-master-password")
 	if len(key) != 32 {

--- a/internal/bridge/llm.go
+++ b/internal/bridge/llm.go
@@ -90,10 +90,8 @@ func (l *BridgeLLM) Complete(ctx context.Context, systemPrompt, userPrompt strin
 	}
 
 	switch l.provider {
-	case "anthropic":
+	case "anthropic", "claude-oauth":
 		return l.completeAnthropic(ctx, systemPrompt, userPrompt, maxTokens)
-	case "claude-oauth":
-		return l.completeClaudeOAuth(ctx, systemPrompt, userPrompt, maxTokens)
 	case "google-vertex":
 		return l.completeVertex(ctx, systemPrompt, userPrompt, maxTokens)
 	default:
@@ -121,63 +119,9 @@ func (l *BridgeLLM) completeAnthropic(ctx context.Context, systemPrompt, userPro
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-api-key", l.apiKey)
 	req.Header.Set("anthropic-version", "2023-06-01")
-
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("LLM request failed: %w", err)
+	if l.provider == "claude-oauth" {
+		req.Header.Set("anthropic-beta", "oauth-2025-04-20,claude-code-20250219")
 	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("reading LLM response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("LLM returned %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	var result struct {
-		Content []struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
-		} `json:"content"`
-	}
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return "", fmt.Errorf("parsing LLM response: %w", err)
-	}
-
-	for _, c := range result.Content {
-		if c.Type == "text" {
-			log.Printf("system LLM call: model=%s prompt_len=%d response_len=%d", l.model, len(userPrompt), len(c.Text))
-			return c.Text, nil
-		}
-	}
-	return "", fmt.Errorf("no text content in LLM response")
-}
-
-func (l *BridgeLLM) completeClaudeOAuth(ctx context.Context, systemPrompt, userPrompt string, maxTokens int) (string, error) {
-	body := map[string]any{
-		"model":      l.model,
-		"max_tokens": maxTokens,
-		"system":     systemPrompt,
-		"messages":   []map[string]string{{"role": "user", "content": userPrompt}},
-	}
-
-	data, err := json.Marshal(body)
-	if err != nil {
-		return "", fmt.Errorf("marshaling request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.anthropic.com/v1/messages", bytes.NewReader(data))
-	if err != nil {
-		return "", fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", l.apiKey)
-	req.Header.Set("anthropic-version", "2023-06-01")
-	req.Header.Set("anthropic-beta", "oauth-2025-04-20,claude-code-20250219")
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)

--- a/internal/bridge/llm.go
+++ b/internal/bridge/llm.go
@@ -31,7 +31,7 @@ import (
 // BridgeLLM provides LLM capabilities for Bridge system features.
 // It calls the LLM API directly (not through Gate).
 type BridgeLLM struct {
-	provider           string // "anthropic" or "google-vertex"
+	provider           string // "anthropic", "google-vertex", or "claude-oauth"
 	model              string
 	apiKey             string
 	region             string
@@ -50,9 +50,16 @@ func NewBridgeLLM(cfg *Config, credStore *CredentialStore) *BridgeLLM {
 	}
 
 	provider := eff.Provider
+
 	apiKey := cfg.SystemLLM.APIKey
+	if provider == "claude-oauth" {
+		apiKey = cfg.SystemLLM.OAuthToken
+	}
 
 	if provider == "anthropic" && apiKey == "" {
+		return nil
+	}
+	if provider == "claude-oauth" && apiKey == "" {
 		return nil
 	}
 	if provider == "google-vertex" && eff.ProjectID == "" {
@@ -85,6 +92,8 @@ func (l *BridgeLLM) Complete(ctx context.Context, systemPrompt, userPrompt strin
 	switch l.provider {
 	case "anthropic":
 		return l.completeAnthropic(ctx, systemPrompt, userPrompt, maxTokens)
+	case "claude-oauth":
+		return l.completeClaudeOAuth(ctx, systemPrompt, userPrompt, maxTokens)
 	case "google-vertex":
 		return l.completeVertex(ctx, systemPrompt, userPrompt, maxTokens)
 	default:
@@ -142,6 +151,63 @@ func (l *BridgeLLM) completeAnthropic(ctx context.Context, systemPrompt, userPro
 	for _, c := range result.Content {
 		if c.Type == "text" {
 			log.Printf("system LLM call: model=%s prompt_len=%d response_len=%d", l.model, len(userPrompt), len(c.Text))
+			return c.Text, nil
+		}
+	}
+	return "", fmt.Errorf("no text content in LLM response")
+}
+
+func (l *BridgeLLM) completeClaudeOAuth(ctx context.Context, systemPrompt, userPrompt string, maxTokens int) (string, error) {
+	body := map[string]any{
+		"model":      l.model,
+		"max_tokens": maxTokens,
+		"system":     systemPrompt,
+		"messages":   []map[string]string{{"role": "user", "content": userPrompt}},
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.anthropic.com/v1/messages", bytes.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", l.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("anthropic-beta", "oauth-2025-04-20,claude-code-20250219")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("LLM request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading LLM response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("LLM returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("parsing LLM response: %w", err)
+	}
+
+	for _, c := range result.Content {
+		if c.Type == "text" {
+			log.Printf("system LLM call (claude-oauth): model=%s prompt_len=%d response_len=%d", l.model, len(userPrompt), len(c.Text))
 			return c.Text, nil
 		}
 	}

--- a/internal/gate/proxy.go
+++ b/internal/gate/proxy.go
@@ -312,6 +312,10 @@ func (p *Proxy) handleLLMRequest(w http.ResponseWriter, r *http.Request) {
 
 			// Inject credential based on token type
 			switch p.config.LLMTokenType {
+			case "oauth_token":
+				req.Header.Set("x-api-key", p.config.LLMToken)
+				req.Header.Set("anthropic-version", "2023-06-01")
+				req.Header.Set("anthropic-beta", "oauth-2025-04-20,claude-code-20250219")
 			case "bearer":
 				req.Header.Set("Authorization", "Bearer "+p.config.LLMToken)
 			case "api_key":
@@ -363,6 +367,10 @@ func (p *Proxy) handleLLMForward(w http.ResponseWriter, r *http.Request) {
 
 			// Inject credential based on token type
 			switch p.config.LLMTokenType {
+			case "oauth_token":
+				req.Header.Set("x-api-key", p.config.LLMToken)
+				req.Header.Set("anthropic-version", "2023-06-01")
+				req.Header.Set("anthropic-beta", "oauth-2025-04-20,claude-code-20250219")
 			case "bearer":
 				req.Header.Set("Authorization", "Bearer "+p.config.LLMToken)
 			case "api_key":

--- a/internal/gate/proxy.go
+++ b/internal/gate/proxy.go
@@ -67,7 +67,7 @@ type Config struct {
 	SessionToken       string                  // opaque token that Skiff presents
 	LLMToken           string                  // bearer token or API key (was LLMAPIKey)
 	LLMProvider        string                  // "anthropic" or "google-vertex"
-	LLMTokenType       string                  // "api_key" or "bearer"
+	LLMTokenType       string                  // "api_key", "bearer", or "oauth_token"
 	TokenRefreshURL    string                  // Bridge endpoint for token refresh
 	TokenRefreshSecret string                  // session-scoped secret for refresh auth
 	VertexRegion       string // Vertex AI region (e.g., "us-east5")

--- a/internal/gate/proxy_test.go
+++ b/internal/gate/proxy_test.go
@@ -1211,3 +1211,59 @@ func TestJiraCredentialIsolation(t *testing.T) {
 		t.Errorf("expected 403 for jira (not in scope when only github allowed), got %d", code)
 	}
 }
+
+// --------------------------------------------------------------------
+// LLM OAuth token injection tests
+// --------------------------------------------------------------------
+
+func TestLLMOAuthToken_InjectsCorrectHeaders(t *testing.T) {
+	// Create a proxy with oauth_token type and send a request to /v1/messages.
+	// Verify that Gate accepts the request (no "unknown LLM provider" error).
+	cfg := Config{
+		SessionID:    "test-session",
+		Scope:        internal.Scope{Services: map[string]internal.ServiceScope{}},
+		Credentials:  map[string]string{},
+		ToolConfigs:  map[string]ToolConfig{},
+		SessionToken: "session-tok",
+		LLMToken:     "sk-ant-oat01-test",
+		LLMProvider:  "anthropic",
+		LLMTokenType: "oauth_token",
+	}
+	p := NewProxy(cfg)
+	ts := httptest.NewServer(p.Handler())
+	t.Cleanup(func() { ts.Close(); p.Stop() })
+
+	// Send a request to /v1/messages. The upstream (api.anthropic.com) will
+	// likely fail or refuse, but we verify Gate itself does not return a 500
+	// "unknown LLM provider" error — the request should be proxied.
+	code, body := doRequest(t, "POST", ts.URL+"/v1/messages", `{"model":"claude-sonnet-4-20250514","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}`)
+	if code == http.StatusInternalServerError && strings.Contains(body, "unknown LLM provider") {
+		t.Errorf("oauth_token type should be accepted, but got 'unknown LLM provider' error")
+	}
+}
+
+func TestLLMOAuthToken_NotUnknownProvider(t *testing.T) {
+	// Verify that oauth_token with LLMProvider "anthropic" does not trigger
+	// the "unknown LLM provider" error path.
+	cfg := Config{
+		SessionID:    "test-session",
+		Scope:        internal.Scope{Services: map[string]internal.ServiceScope{}},
+		Credentials:  map[string]string{},
+		ToolConfigs:  map[string]ToolConfig{},
+		SessionToken: "session-tok",
+		LLMToken:     "sk-ant-oat01-test",
+		LLMProvider:  "anthropic",
+		LLMTokenType: "oauth_token",
+	}
+	p := NewProxy(cfg)
+	ts := httptest.NewServer(p.Handler())
+	t.Cleanup(func() { ts.Close(); p.Stop() })
+
+	code, body := doRequest(t, "POST", ts.URL+"/v1/messages", `{"model":"claude-sonnet-4-20250514","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}`)
+	// The request should NOT get the "unknown LLM provider" error (500).
+	// It may fail for other reasons (upstream unreachable, auth failure, etc.)
+	// but the provider routing should work correctly.
+	if code == http.StatusInternalServerError && strings.Contains(body, "unknown LLM provider") {
+		t.Errorf("oauth_token with anthropic provider should not trigger 'unknown LLM provider'; got %d: %s", code, body)
+	}
+}

--- a/scripts/test-credentials.sh
+++ b/scripts/test-credentials.sh
@@ -55,27 +55,28 @@ RESULT=$(curl -s -X POST "$BRIDGE_URL/api/v1/credentials" \
 CRED1_ID=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
 if [ "$CRED1_ID" != "ERROR" ]; then pass "Created Anthropic credential"; else fail "Failed to create Anthropic credential: $RESULT"; fi
 
-# Test 2: Create Vertex SA credential
-log "Test 2: Create Vertex SA credential"
+# Test 2: One-LLM enforcement — second LLM credential blocked
+log "Test 2: One-LLM-per-user enforcement"
+RESULT=$(curl -s -w "\n%{http_code}" -X POST "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $USER1_TOKEN" -H "Content-Type: application/json" \
+  -d '{"name":"my-vertex-sa","provider":"google-vertex","auth_type":"service_account","credential":"{\"type\":\"service_account\",\"project_id\":\"test\"}","project_id":"test-project","region":"us-east5"}')
+HTTP_CODE=$(echo "$RESULT" | tail -1)
+if [ "$HTTP_CODE" = "409" ]; then pass "Second LLM credential blocked with 409"; else fail "Expected 409, got $HTTP_CODE"; fi
+
+# Test 3: Replace LLM credential (delete old, create new)
+log "Test 3: Replace LLM credential"
+curl -s -X DELETE "$BRIDGE_URL/api/v1/credentials/$CRED1_ID" -H "Authorization: Bearer $USER1_TOKEN" > /dev/null
 RESULT=$(curl -s -X POST "$BRIDGE_URL/api/v1/credentials" \
   -H "Authorization: Bearer $USER1_TOKEN" -H "Content-Type: application/json" \
   -d '{"name":"my-vertex-sa","provider":"google-vertex","auth_type":"service_account","credential":"{\"type\":\"service_account\",\"project_id\":\"test\"}","project_id":"test-project","region":"us-east5"}')
 CRED2_ID=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
-if [ "$CRED2_ID" != "ERROR" ]; then pass "Created Vertex SA credential"; else fail "Failed: $RESULT"; fi
+if [ "$CRED2_ID" != "ERROR" ]; then pass "Replaced with Vertex SA credential"; else fail "Failed: $RESULT"; fi
 
-# Test 3: Create Vertex ADC credential
-log "Test 3: Create Vertex ADC credential"
-RESULT=$(curl -s -X POST "$BRIDGE_URL/api/v1/credentials" \
-  -H "Authorization: Bearer $USER1_TOKEN" -H "Content-Type: application/json" \
-  -d '{"name":"my-vertex-adc","provider":"google-vertex","auth_type":"adc","credential":"{\"type\":\"authorized_user\",\"client_id\":\"test\"}","project_id":"test-project-2","region":"us-central1"}')
-CRED3_ID=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
-if [ "$CRED3_ID" != "ERROR" ]; then pass "Created Vertex ADC credential"; else fail "Failed: $RESULT"; fi
-
-# Test 4: List credentials (should see all 3)
+# Test 4: List credentials (should see 1 LLM credential)
 log "Test 4: List own credentials"
 COUNT=$(curl -s "$BRIDGE_URL/api/v1/credentials" -H "Authorization: Bearer $USER1_TOKEN" | \
   python3 -c "import json,sys; print(json.load(sys.stdin).get('count',0))")
-if [ "$COUNT" = "3" ]; then pass "User1 sees 3 credentials"; else fail "User1 sees $COUNT (expected 3)"; fi
+if [ "$COUNT" = "1" ]; then pass "User1 sees 1 credential"; else fail "User1 sees $COUNT (expected 1)"; fi
 
 # Test 5: Credential secrets NOT returned
 log "Test 5: Secrets not in response"
@@ -94,7 +95,7 @@ if [ "$USER2_GET" = "404" ]; then pass "User2 gets 404 on User1's credential"; e
 
 # Test 7: Delete credential
 log "Test 7: Delete credential"
-DEL_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$BRIDGE_URL/api/v1/credentials/$CRED1_ID" -H "Authorization: Bearer $USER1_TOKEN")
+DEL_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$BRIDGE_URL/api/v1/credentials/$CRED2_ID" -H "Authorization: Bearer $USER1_TOKEN")
 if [ "$DEL_CODE" = "200" ]; then pass "Deleted credential"; else fail "Delete returned $DEL_CODE"; fi
 
 # Test 8: User2 cannot delete User1's credential
@@ -102,9 +103,7 @@ log "Test 8: Cross-user delete blocked"
 DEL_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$BRIDGE_URL/api/v1/credentials/$CRED2_ID" -H "Authorization: Bearer $USER2_TOKEN")
 if [ "$DEL_CODE" = "404" ]; then pass "Cross-user delete blocked"; else fail "Cross-user delete returned $DEL_CODE"; fi
 
-# Cleanup
-curl -s -X DELETE "$BRIDGE_URL/api/v1/credentials/$CRED2_ID" -H "Authorization: Bearer $USER1_TOKEN" > /dev/null 2>&1
-curl -s -X DELETE "$BRIDGE_URL/api/v1/credentials/$CRED3_ID" -H "Authorization: Bearer $USER1_TOKEN" > /dev/null 2>&1
+# Cleanup (CRED2_ID already deleted in test 7)
 
 # =====================================================================
 # Test: System credentials hidden from users
@@ -255,7 +254,9 @@ else
 fi
 
 # Admin creates a credential — it should only be visible to admin
+# Delete existing system LLM credential first (one-LLM-per-user enforcement)
 log "Test 18: Admin's own credential visible only to admin"
+curl -s -X DELETE "$BRIDGE_URL/api/v1/credentials/$SYSTEM_CRED_ID" -H "Authorization: Bearer $ADMIN_TOKEN" > /dev/null 2>&1
 ADMIN_OWN_RESULT=$(curl -s -X POST "$BRIDGE_URL/api/v1/credentials" \
   -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
   -d '{"name":"admin-own-key","provider":"anthropic","auth_type":"api_key","credential":"sk-ant-admin-own-789"}')

--- a/web/index.html
+++ b/web/index.html
@@ -884,6 +884,7 @@
                         <option value="">Select a provider</option>
                         <option value="anthropic">Anthropic</option>
                         <option value="google-vertex">Google Vertex AI</option>
+                        <option value="claude-oauth">Claude Pro/Max</option>
                         <option value="github">GitHub</option>
                         <option value="gitlab">GitLab</option>
                         <option value="jira">Jira</option>
@@ -895,6 +896,17 @@
                     <label>API Key <span class="required">*</span></label>
                     <input type="password" data-role="cred-api-key" class="input" placeholder="sk-ant-...">
                     <small class="form-help">Your Anthropic API key. It will be stored securely and never shown again.</small>
+                </div>
+            </div>
+            <div data-role="cred-claude-oauth-fields" hidden>
+                <div class="form-group">
+                    <label>Setup Token <span class="required">*</span></label>
+                    <input type="password" data-role="cred-oauth-token" class="input mono" placeholder="sk-ant-oat01-...">
+                    <small class="form-help">
+                        Run <code>claude setup-token</code> in your terminal to generate this token.
+                        It uses your Claude Pro or Max subscription — no separate API billing needed.
+                        The token is valid for ~1 year.
+                    </small>
                 </div>
             </div>
             <div data-role="cred-vertex-fields" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1335,7 +1335,7 @@
             });
             select.innerHTML = '<option value="">Select a provider</option>';
             llmCreds.forEach((c) => {
-                const label = c.name + ' (' + (c.provider === 'google-vertex' ? 'Vertex AI' : 'Anthropic') + ')';
+                const label = c.name + ' (' + (c.provider === 'google-vertex' ? 'Vertex AI' : c.provider === 'claude-oauth' ? 'Claude Pro/Max' : 'Anthropic') + ')';
                 select.innerHTML += '<option value="' + escapeHtml(c.name) + '">' + escapeHtml(label) + '</option>';
             });
             if (llmCreds.length === 1) select.selectedIndex = 1;
@@ -1476,7 +1476,7 @@
 
             function renderLlmRow(c) {
                 const name = c.name || '-';
-                const provider = c.provider === 'vertex' ? 'Vertex AI' : (c.provider === 'anthropic' ? 'Anthropic' : escapeHtml(c.provider || '-'));
+                const provider = c.provider === 'google-vertex' ? 'Vertex AI' : (c.provider === 'claude-oauth' ? 'Claude Pro/Max' : (c.provider === 'anthropic' ? 'Anthropic' : escapeHtml(c.provider || '-')));
                 var authBadge = '';
                 if (c.auth_type === 'api_key') {
                     authBadge = '<span class="badge">API Key</span>';
@@ -1484,6 +1484,8 @@
                     authBadge = '<span class="badge badge-running">Service Account</span>';
                 } else if (c.auth_type === 'adc') {
                     authBadge = '<span class="badge badge-completed">ADC</span>';
+                } else if (c.auth_type === 'oauth_token') {
+                    authBadge = '<span class="badge badge-completed">OAuth</span>';
                 } else {
                     authBadge = '<span class="badge">' + escapeHtml(c.auth_type || '-') + '</span>';
                 }
@@ -1603,6 +1605,7 @@
         // Wire up provider toggle
         var providerSelect = q('cred-provider');
         var anthropicFields = q('cred-anthropic-fields');
+        var claudeOauthFields = q('cred-claude-oauth-fields');
         var vertexFields = q('cred-vertex-fields');
         var scmFields = q('cred-scm-fields');
         var gitlabHostGroup = q('cred-gitlab-host-group');
@@ -1615,6 +1618,7 @@
 
             // Hide all
             if (anthropicFields) anthropicFields.hidden = true;
+            if (claudeOauthFields) claudeOauthFields.hidden = true;
             if (vertexFields) vertexFields.hidden = true;
             if (scmFields) scmFields.hidden = true;
             if (jiraHostGroup) jiraHostGroup.hidden = true;
@@ -1622,6 +1626,8 @@
 
             if (val === 'anthropic') {
                 if (anthropicFields) anthropicFields.hidden = false;
+            } else if (val === 'claude-oauth') {
+                if (claudeOauthFields) claudeOauthFields.hidden = false;
             } else if (val === 'google-vertex') {
                 if (vertexFields) vertexFields.hidden = false;
             } else if (val === 'github' || val === 'gitlab' || val === 'jira') {
@@ -1733,6 +1739,11 @@
                 payload.credential = jsonVal;
                 payload.project_id = projectId;
                 payload.region = region;
+            } else if (provider === 'claude-oauth') {
+                var oauthToken = (q('cred-oauth-token') || {}).value?.trim();
+                if (!oauthToken) { if (errorEl) { errorEl.textContent = 'Setup token is required. Run "claude setup-token" in your terminal.'; show(errorEl); } return; }
+                payload.auth_type = 'oauth_token';
+                payload.credential = oauthToken;
             } else if (provider === 'github' || provider === 'gitlab') {
                 var pat = (q('cred-pat') || {}).value?.trim();
                 if (!pat) {
@@ -1797,6 +1808,22 @@
             submitLabel: 'Add Credential',
             onSubmit: async function(payload) {
                 var resp = await api('POST', '/api/v1/credentials', payload);
+
+                if (resp.status === 409) {
+                    var conflict = await resp.json();
+                    var replace = confirm(
+                        'You already have an LLM credential: "' + conflict.existing_credential +
+                        '" (' + (conflict.existing_provider === 'google-vertex' ? 'Google Vertex AI' :
+                                 conflict.existing_provider === 'claude-oauth' ? 'Claude Pro/Max' : 'Anthropic') +
+                        ').\n\nReplace it with this new credential?'
+                    );
+                    if (!replace) {
+                        return;
+                    }
+                    await api('DELETE', '/api/v1/credentials/' + conflict.existing_id);
+                    resp = await api('POST', '/api/v1/credentials', payload);
+                }
+
                 if (!resp.ok) {
                     var data = await resp.json().catch(function () { return {}; });
                     throw new Error(data.error || data.message || 'Failed to add credential.');
@@ -3267,7 +3294,7 @@
             const creds = data.credentials || [];
             select.innerHTML = '<option value="">Select a provider</option>';
             creds.forEach(function (c) {
-                const label = c.name + ' (' + (c.provider === 'google-vertex' ? 'Vertex AI' : 'Anthropic') + ')';
+                const label = c.name + ' (' + (c.provider === 'google-vertex' ? 'Vertex AI' : c.provider === 'claude-oauth' ? 'Claude Pro/Max' : 'Anthropic') + ')';
                 select.innerHTML += '<option value="' + escapeHtml(c.name) + '">' + escapeHtml(label) + '</option>';
             });
             if (creds.length === 1) select.selectedIndex = 1;


### PR DESCRIPTION
## Summary

- Add Claude Pro/Max as a new LLM provider option for both user tasks and Bridge system LLM
- Users run `claude setup-token` locally and paste the token into the dashboard
- Gate injects the OAuth token via `x-api-key` header with required beta headers — Skiff never sees real credentials
- Enforce one LLM credential per user (API returns 409 Conflict, UI prompts to confirm replacement)

## Changes

- **Gate** (`internal/gate/proxy.go`): Add `oauth_token` case to token injection — sets `x-api-key` + `anthropic-beta: oauth-2025-04-20,claude-code-20250219`
- **Credential store** (`internal/bridge/credentials.go`): Handle `oauth_token` auth type in `AcquireToken`/`AcquireSystemToken`
- **System LLM** (`internal/bridge/llm.go`, `config.go`): Add `claude-oauth` provider with conditional beta headers
- **API** (`internal/bridge/api.go`): Enforce one LLM credential per user with 409 Conflict response
- **Dashboard** (`web/index.html`, `web/js/app.js`): Add Claude Pro/Max form with `claude setup-token` instructions, replacement flow
- **Docs**: Update implementation-status.md

## Test plan

- [x] All unit tests pass (`make test`)
- [ ] Add Claude Pro/Max credential via dashboard UI
- [ ] Verify one-LLM enforcement (409 on duplicate)
- [ ] Run a task with Claude Pro/Max credential
- [ ] Verify setup-token instructions appear in credential form

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)