### PR TITLE
Fix TBR Registry identity logging and CI Gate retry prompt

### DIFF
--- a/internal/auth/rh_identity.go
+++ b/internal/auth/rh_identity.go
@@ -75,6 +75,9 @@ func ParseRHIdentity(headerValue string) (*RHIdentity, error) {
 
 	// Log raw header and decoded identity type for debugging
 	log.Printf("rh-identity: parsed header type=%s auth_type=%s", id.Identity.Type, id.Identity.AuthType)
+	if id.Identity.Type == "Registry" {
+		log.Printf("rh-identity: registry identity raw payload: %s", string(decoded))
+	}
 
 	// Validate SAML Associate identity
 	if id.Identity.Associate != nil {

--- a/internal/bridge/cigate.go
+++ b/internal/bridge/cigate.go
@@ -406,11 +406,15 @@ Use curl with $GITHUB_API_URL and $GITHUB_TOKEN for GitHub API calls.
 Write JSON payloads to files before POSTing.
 
 ## Instructions
-1. Checkout the existing branch: git fetch origin %s && git checkout %s
+1. The repo is already cloned. Fetch and checkout the PR branch:
+   git fetch origin %s && git checkout %s
 2. Read the CI failure analysis below and fix the issues
-3. Run any available local validation before pushing (go build, go test, go vet, etc.)
-4. Commit and push to the same branch
+3. Run local validation before pushing: go build ./... && go vet ./...
+4. Commit and push to the same branch:
+   git add -A && git commit -m "Fix CI failures" && git push origin %s
 5. Do NOT create a new PR — push to the existing branch
+6. Write the PR artifact file so Bridge can continue monitoring:
+   echo '{"repo": "%s", "number": %d}' > /tmp/alcove-pr.json
 
 ## CI Failure Analysis
 %s
@@ -419,7 +423,7 @@ Write JSON payloads to files before POSTing.
 - Fix ONLY the CI failures — do not refactor or add features
 - Run local validation before pushing
 - If you cannot fix a failure, leave a comment on PR #%d explaining what you tried
-`, repo, prNumber, branch, title, attempt, maxAttempts, branch, branch, analysis, prNumber)
+`, repo, prNumber, branch, title, attempt, maxAttempts, branch, branch, branch, repo, prNumber, analysis, prNumber)
 		}
 		log.Printf("cigate: LLM analysis failed, using template: %v", err)
 	}
@@ -438,14 +442,18 @@ Use curl with $GITHUB_API_URL and $GITHUB_TOKEN for GitHub API calls.
 Write JSON payloads to files before POSTing.
 
 ## Instructions
-1. Checkout the existing branch: git fetch origin %s && git checkout %s
+1. The repo is already cloned. Fetch and checkout the PR branch:
+   git fetch origin %s && git checkout %s
 2. Fetch the CI check runs to understand what failed:
    curl -s -H "Authorization: token $GITHUB_TOKEN" "$GITHUB_API_URL/repos/%s/commits/%s/check-runs"
 3. For each failed check, fetch the log and analyze the error
 4. Fix the issues in the code
-5. Run any available local validation (go build, go test, go vet, etc.)
-6. Commit and push to the same branch
+5. Run local validation before pushing: go build ./... && go vet ./...
+6. Commit and push to the same branch:
+   git add -A && git commit -m "Fix CI failures" && git push origin %s
 7. Do NOT create a new PR — push to the existing branch
+8. Write the PR artifact file so Bridge can continue monitoring:
+   echo '{"repo": "%s", "number": %d}' > /tmp/alcove-pr.json
 
 ## CI Failure Summary
 %s
@@ -454,7 +462,7 @@ Write JSON payloads to files before POSTing.
 - Fix ONLY the CI failures — do not refactor or add features
 - Run local validation before pushing
 - If you cannot fix a failure, leave a comment on PR #%d explaining what you tried
-`, repo, prNumber, branch, title, attempt, maxAttempts, branch, branch, repo, branch, failureLogs, prNumber)
+`, repo, prNumber, branch, title, attempt, maxAttempts, branch, branch, repo, branch, branch, repo, prNumber, failureLogs, prNumber)
 }
 
 // githubGet performs an authenticated GET request to the GitHub API.


### PR DESCRIPTION
## Summary
- **TBR auth debugging**: Add logging for `type=Registry` identities from Turnpike so we can see the full payload and implement proper support. Currently these fail with "identity missing both associate and user fields".
- **CI Gate retry fix**: Add `/tmp/alcove-pr.json` write instruction to retry prompts so Bridge can chain subsequent retries. Previous retries completed in 66s without pushing because the prompt didn't give explicit enough instructions.

## Test plan
- [x] `make build` && `make test` pass
- [ ] CI passes
- [ ] Deploy, hit staging API with TBR creds, check logs for Registry payload
- [ ] Re-trigger issue #107 to test CI Gate retry chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)