### PR TITLE
Add Registry identity support for TBR auth via Turnpike

### DIFF
--- a/internal/auth/rh_identity.go
+++ b/internal/auth/rh_identity.go
@@ -40,6 +40,10 @@ type RHIdentity struct {
 		User *struct {
 			Username string `json:"username"`
 		} `json:"user,omitempty"`
+		Registry *struct {
+			OrgID    string `json:"org_id"`
+			Username string `json:"username"`
+		} `json:"registry,omitempty"`
 		OrgID string `json:"org_id,omitempty"`
 	} `json:"identity"`
 }
@@ -73,11 +77,8 @@ func ParseRHIdentity(headerValue string) (*RHIdentity, error) {
 		return nil, fmt.Errorf("unmarshaling identity: %w", err)
 	}
 
-	// Log raw header and decoded identity type for debugging
+	// Log decoded identity type for debugging
 	log.Printf("rh-identity: parsed header type=%s auth_type=%s", id.Identity.Type, id.Identity.AuthType)
-	if id.Identity.Type == "Registry" {
-		log.Printf("rh-identity: registry identity raw payload: %s", string(decoded))
-	}
 
 	// Validate SAML Associate identity
 	if id.Identity.Associate != nil {
@@ -100,15 +101,32 @@ func ParseRHIdentity(headerValue string) (*RHIdentity, error) {
 		return &id, nil
 	}
 
-	return nil, fmt.Errorf("identity missing both associate and user fields")
+	// Validate Registry identity (TBR via Turnpike registry auth).
+	// Turnpike sends: {"identity": {"type": "Registry", "auth_type": "registry-auth", "registry": {"org_id": "...", "username": "..."}}}
+	if id.Identity.Registry != nil {
+		if id.Identity.Registry.OrgID == "" || id.Identity.Registry.Username == "" {
+			return nil, fmt.Errorf("missing org_id or username in Registry identity")
+		}
+		log.Printf("rh-identity: valid Registry identity org_id=%s username=%s", id.Identity.Registry.OrgID, id.Identity.Registry.Username)
+		return &id, nil
+	}
+
+	return nil, fmt.Errorf("identity missing associate, user, and registry fields")
 }
 
-// ExtractTBRIdentity extracts TBR identity information from RHIdentity if present
+// ExtractTBRIdentity extracts TBR identity information from RHIdentity if present.
+// Supports both User-type TBR identities and Registry-type identities from Turnpike.
 func ExtractTBRIdentity(id *RHIdentity) *TBRIdentity {
 	if id.Identity.User != nil && id.Identity.OrgID != "" && id.Identity.User.Username != "" {
 		return &TBRIdentity{
 			OrgID:    id.Identity.OrgID,
 			Username: id.Identity.User.Username,
+		}
+	}
+	if id.Identity.Registry != nil && id.Identity.Registry.OrgID != "" && id.Identity.Registry.Username != "" {
+		return &TBRIdentity{
+			OrgID:    id.Identity.Registry.OrgID,
+			Username: id.Identity.Registry.Username,
 		}
 	}
 	return nil

--- a/internal/auth/rh_identity_test.go
+++ b/internal/auth/rh_identity_test.go
@@ -359,6 +359,66 @@ func TestIsTBRIdentity(t *testing.T) {
 	}
 }
 
+// --- Registry Identity Tests ---
+
+func makeRegistryIdentityHeader(orgID, username string) string {
+	identity := map[string]interface{}{
+		"identity": map[string]interface{}{
+			"type":      "Registry",
+			"auth_type": "registry-auth",
+			"registry": map[string]interface{}{
+				"org_id":   orgID,
+				"username": username,
+			},
+		},
+	}
+	data, _ := json.Marshal(identity)
+	return base64.StdEncoding.EncodeToString(data)
+}
+
+func TestParseRHIdentity_ValidRegistry(t *testing.T) {
+	header := makeRegistryIdentityHeader("13409664", "alcove-dev")
+	id, err := ParseRHIdentity(header)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if id.Identity.Type != "Registry" {
+		t.Errorf("expected type Registry, got %q", id.Identity.Type)
+	}
+	if id.Identity.Registry == nil {
+		t.Fatal("expected non-nil Registry field")
+	}
+	if id.Identity.Registry.OrgID != "13409664" {
+		t.Errorf("expected org_id 13409664, got %q", id.Identity.Registry.OrgID)
+	}
+	if id.Identity.Registry.Username != "alcove-dev" {
+		t.Errorf("expected username alcove-dev, got %q", id.Identity.Registry.Username)
+	}
+}
+
+func TestExtractTBRIdentity_FromRegistry(t *testing.T) {
+	header := makeRegistryIdentityHeader("13409664", "alcove-dev")
+	id, _ := ParseRHIdentity(header)
+	tbr := ExtractTBRIdentity(id)
+	if tbr == nil {
+		t.Fatal("expected non-nil TBRIdentity from Registry identity")
+	}
+	if tbr.OrgID != "13409664" {
+		t.Errorf("expected org_id 13409664, got %q", tbr.OrgID)
+	}
+	if tbr.Username != "alcove-dev" {
+		t.Errorf("expected username alcove-dev, got %q", tbr.Username)
+	}
+}
+
+func TestIsTBRIdentity_Registry(t *testing.T) {
+	header := makeRegistryIdentityHeader("13409664", "alcove-dev")
+	id, _ := ParseRHIdentity(header)
+	if !IsTBRIdentity(id) {
+		t.Error("expected true for Registry identity")
+	}
+}
+
 // --- RHIdentityStore interface compliance ---
 
 func TestRHIdentityStore_Authenticate_ReturnsError(t *testing.T) {


### PR DESCRIPTION
## Summary
- Turnpike sends TBR identities as `type=Registry, auth_type=registry-auth` with `identity.registry.org_id` and `identity.registry.username` — not `identity.user` as assumed
- Add `Registry` field to `RHIdentity` struct, handle in `ParseRHIdentity()`, treat as TBR identity in `ExtractTBRIdentity()`
- 3 new tests for Registry identity parsing, TBR extraction, and `IsTBRIdentity` check
- Remove debug raw payload logging (no longer needed)

## Evidence
From staging logs after hitting the API with TBR Basic Auth:
```
rh-identity: registry identity raw payload: {"identity": {"type": "Registry", "auth_type": "registry-auth", "registry": {"org_id": "13409664", "username": "alcove-dev"}}}
```

## Test plan
- [x] `make build` && `make test` pass (3 new Registry tests)
- [ ] CI passes
- [ ] Deploy and verify TBR API access works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)