### PR TITLE
Redesign task list: metadata at dispatch, type pills, status viz, empty state

### DIFF
--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -188,6 +188,8 @@ func (a *API) handleTasks(w http.ResponseWriter, r *http.Request) {
 		submitter = "anonymous"
 	}
 
+	req.TriggerType = "manual"
+
 	session, err := a.dispatcher.DispatchTask(r.Context(), req, submitter)
 	if err != nil {
 		log.Printf("error: dispatch failed: %v", err)
@@ -754,9 +756,12 @@ func (a *API) listSessions(ctx context.Context, status, repo, since, until, subm
 		return nil, 0, err
 	}
 
-	// Main query with pagination - include LEFT JOIN to potentially get task names
+	// Main query with pagination - include LEFT JOIN as fallback for old sessions
 	query := `SELECT s.id, s.task_id, s.submitter, s.prompt, s.scope, s.provider, s.outcome, s.started_at, s.finished_at, s.exit_code, s.artifacts, s.parent_id,
-		COALESCE(td.name, '') as task_name
+		COALESCE(s.task_name, td.name, '') as task_name,
+		COALESCE(s.trigger_type, '') as trigger_type,
+		COALESCE(s.trigger_ref, '') as trigger_ref,
+		COALESCE(s.repo, '') as repo
 		FROM sessions s
 		LEFT JOIN schedules sc ON s.prompt LIKE '%[' || sc.source_key || ']%' AND sc.source_key IS NOT NULL AND sc.source_key != ''
 		LEFT JOIN task_definitions td ON sc.source_key = td.source_key` +
@@ -779,11 +784,11 @@ func (a *API) listSessions(ctx context.Context, status, repo, since, until, subm
 		var finishedAt *time.Time
 		var exitCode *int
 		var parentID *string
-		var taskName string
+		var taskName, triggerType, triggerRef, repo string
 
 		if err := rows.Scan(&s.ID, &s.TaskID, &s.Submitter, &s.Prompt,
 			&scopeJSON, &s.Provider, &s.Status, &s.StartedAt, &finishedAt,
-			&exitCode, &artifactsJSON, &parentID, &taskName); err != nil {
+			&exitCode, &artifactsJSON, &parentID, &taskName, &triggerType, &triggerRef, &repo); err != nil {
 			return nil, 0, err
 		}
 
@@ -805,6 +810,7 @@ func (a *API) listSessions(ctx context.Context, status, repo, since, until, subm
 		if parentID != nil {
 			s.ParentID = *parentID
 		}
+		s.Repo = repo
 
 		// Set task name with fallback
 		if taskName != "" {
@@ -813,8 +819,19 @@ func (a *API) listSessions(ctx context.Context, status, repo, since, until, subm
 			s.TaskName = "Manual Task"
 		}
 
-		// Parse trigger context from prompt
-		s.TriggerContext = parseEventContext(s.Prompt)
+		// Set trigger type and ref from stored metadata
+		s.TriggerType = triggerType
+		s.TriggerRef = triggerRef
+
+		// Parse trigger context from prompt as fallback for old sessions
+		if triggerType != "" {
+			s.TriggerContext = triggerType
+			if triggerRef != "" {
+				s.TriggerContext = triggerType + ": " + triggerRef
+			}
+		} else {
+			s.TriggerContext = parseEventContext(s.Prompt)
+		}
 
 		sessions = append(sessions, s)
 	}
@@ -832,18 +849,21 @@ func (a *API) getSession(ctx context.Context, id string) (*internal.Session, err
 	var finishedAt *time.Time
 	var exitCode *int
 	var parentID *string
-	var taskName string
+	var taskName, triggerType, triggerRef, repo string
 
 	err := a.db.QueryRow(ctx,
 		`SELECT s.id, s.task_id, s.submitter, s.prompt, s.scope, s.provider, s.outcome, s.started_at, s.finished_at, s.exit_code, s.artifacts, s.parent_id,
-		COALESCE(td.name, '') as task_name
+		COALESCE(s.task_name, td.name, '') as task_name,
+		COALESCE(s.trigger_type, '') as trigger_type,
+		COALESCE(s.trigger_ref, '') as trigger_ref,
+		COALESCE(s.repo, '') as repo
 		FROM sessions s
 		LEFT JOIN schedules sc ON s.prompt LIKE '%[' || sc.source_key || ']%' AND sc.source_key IS NOT NULL AND sc.source_key != ''
 		LEFT JOIN task_definitions td ON sc.source_key = td.source_key
 		WHERE s.id = $1`, id,
 	).Scan(&s.ID, &s.TaskID, &s.Submitter, &s.Prompt,
 		&scopeJSON, &s.Provider, &s.Status, &s.StartedAt, &finishedAt,
-		&exitCode, &artifactsJSON, &parentID, &taskName)
+		&exitCode, &artifactsJSON, &parentID, &taskName, &triggerType, &triggerRef, &repo)
 	if err != nil {
 		return nil, err
 	}
@@ -866,6 +886,7 @@ func (a *API) getSession(ctx context.Context, id string) (*internal.Session, err
 	if parentID != nil {
 		s.ParentID = *parentID
 	}
+	s.Repo = repo
 
 	// Set task name with fallback
 	if taskName != "" {
@@ -874,8 +895,19 @@ func (a *API) getSession(ctx context.Context, id string) (*internal.Session, err
 		s.TaskName = "Manual Task"
 	}
 
-	// Parse trigger context from prompt
-	s.TriggerContext = parseEventContext(s.Prompt)
+	// Set trigger type and ref from stored metadata
+	s.TriggerType = triggerType
+	s.TriggerRef = triggerRef
+
+	// Parse trigger context from prompt as fallback for old sessions
+	if triggerType != "" {
+		s.TriggerContext = triggerType
+		if triggerRef != "" {
+			s.TriggerContext = triggerType + ": " + triggerRef
+		}
+	} else {
+		s.TriggerContext = parseEventContext(s.Prompt)
+	}
 
 	return &s, nil
 }
@@ -1659,6 +1691,8 @@ func (a *API) handleTaskDefinitionRun(w http.ResponseWriter, r *http.Request, id
 	}
 
 	req := def.ToTaskRequest()
+	req.TaskName = def.Name
+	req.TriggerType = "manual"
 	session, err := a.dispatcher.DispatchTask(r.Context(), req, submitter)
 	if err != nil {
 		log.Printf("error: dispatching task definition %s: %v", id, err)
@@ -1943,11 +1977,18 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 
 		// Build TaskRequest with webhook context as env vars.
 		taskReq := TaskRequest{
-			Prompt:   sched.Prompt,
-			Repo:     sched.Repo,
-			Provider: sched.Provider,
-			Timeout:  sched.Timeout,
-			Debug:    sched.Debug,
+			Prompt:      sched.Prompt,
+			Repo:        sched.Repo,
+			Provider:    sched.Provider,
+			Timeout:     sched.Timeout,
+			Debug:       sched.Debug,
+			TaskName:    sched.Name,
+			TriggerType: "webhook",
+		}
+		if issueNumber != "" {
+			taskReq.TriggerRef = fmt.Sprintf("%s#%s", repo, issueNumber)
+		} else if prNumber != "" {
+			taskReq.TriggerRef = fmt.Sprintf("%s#%s", repo, prNumber)
 		}
 
 		session, err := a.dispatcher.DispatchTask(ctx, taskReq, sched.Owner)

--- a/internal/bridge/cigate.go
+++ b/internal/bridge/cigate.go
@@ -366,6 +366,11 @@ func (m *CIGateMonitor) handleCIFailure(ctx context.Context, sessionID, repo str
 	ciContext := m.composeCIFailureContext(ctx, repo, prNumber, prInfo.Head.Ref, prInfo.Title, failureSummary.String(), retryCount+1, maxRetries)
 	taskReq.Prompt = ciContext + "\n\n" + modifyPromptForRetry(originalPrompt, prInfo.Head.Ref, repo, prNumber)
 
+	// Set task metadata for session storage.
+	taskReq.TaskName = "CI Retry"
+	taskReq.TriggerType = "event"
+	taskReq.TriggerRef = fmt.Sprintf("%s#%d", repo, prNumber)
+
 	// Dispatch retry task.
 	newSession, err := m.dispatcher.DispatchTask(ctx, taskReq, owner)
 	if err != nil {

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -79,6 +79,10 @@ type TaskRequest struct {
 	Model    string                `json:"model,omitempty"`
 	Budget   float64               `json:"budget_usd,omitempty"`
 	Debug    bool                  `json:"debug,omitempty"`
+	// Task metadata — set by dispatch code paths, stored in sessions table.
+	TaskName    string `json:"-"` // Schedule/task definition name
+	TriggerType string `json:"-"` // "event", "cron", "manual", "webhook"
+	TriggerRef  string `json:"-"` // e.g., "bmbouter/alcove#107" for GitHub events
 }
 
 // ToolConfig specifies per-tool configuration in a task request.
@@ -191,15 +195,18 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 
 	now := time.Now().UTC()
 	session := &internal.Session{
-		ID:        sessionID,
-		TaskID:    taskID,
-		Submitter: submitter,
-		Prompt:    req.Prompt,
-		Repo:      req.Repo,
-		Provider:  provider,
-		Scope:     scope,
-		Status:    "running",
-		StartedAt: now,
+		ID:          sessionID,
+		TaskID:      taskID,
+		Submitter:   submitter,
+		Prompt:      req.Prompt,
+		Repo:        req.Repo,
+		Provider:    provider,
+		Scope:       scope,
+		Status:      "running",
+		StartedAt:   now,
+		TaskName:    req.TaskName,
+		TriggerType: req.TriggerType,
+		TriggerRef:  req.TriggerRef,
 	}
 
 	// Generate a session token for the Skiff pod to authenticate to Ledger.
@@ -643,9 +650,10 @@ func (d *Dispatcher) ListenForStatusUpdates(ctx context.Context) error {
 func (d *Dispatcher) insertSession(ctx context.Context, s *internal.Session, sessionToken string) error {
 	scopeJSON, _ := json.Marshal(s.Scope)
 	_, err := d.db.Exec(ctx, `
-		INSERT INTO sessions (id, task_id, submitter, prompt, scope, provider, started_at, outcome, session_token)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-	`, s.ID, s.TaskID, s.Submitter, s.Prompt, scopeJSON, s.Provider, s.StartedAt, s.Status, sessionToken)
+		INSERT INTO sessions (id, task_id, submitter, prompt, scope, provider, started_at, outcome, session_token, task_name, trigger_type, trigger_ref, repo)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+	`, s.ID, s.TaskID, s.Submitter, s.Prompt, scopeJSON, s.Provider, s.StartedAt, s.Status, sessionToken,
+		nilIfEmpty(s.TaskName), nilIfEmpty(s.TriggerType), nilIfEmpty(s.TriggerRef), nilIfEmpty(s.Repo))
 	return err
 }
 

--- a/internal/bridge/migrations/020_session_metadata.sql
+++ b/internal/bridge/migrations/020_session_metadata.sql
@@ -1,0 +1,20 @@
+-- Copyright 2026 Brian Bouterse
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Store task metadata at dispatch time for efficient querying.
+-- Previously these were reconstructed via fragile JOINs and prompt parsing.
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS task_name TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS trigger_type TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS trigger_ref TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS repo TEXT;

--- a/internal/bridge/poller.go
+++ b/internal/bridge/poller.go
@@ -474,6 +474,15 @@ func (p *GitHubPoller) pollRepo(ctx context.Context, repo, owner string, schedul
 			// Enrich event context with full GitHub data.
 			enrichedContext := p.enrichEventContext(ctx, token, baseURL, eventType, action, meta)
 
+			// Set task metadata for session storage.
+			taskReq.TaskName = sched.Name
+			taskReq.TriggerType = "event"
+			if issueNumber != "" {
+				taskReq.TriggerRef = fmt.Sprintf("%s#%s", eventRepo, issueNumber)
+			} else if prNumber != "" {
+				taskReq.TriggerRef = fmt.Sprintf("%s#%s", eventRepo, prNumber)
+			}
+
 			// Prepend enriched context, keep raw metadata for backward compatibility.
 			metaJSON, _ := json.Marshal(meta)
 			taskReq.Prompt = taskReq.Prompt + "\n\n" + enrichedContext + "\n\n[event: " + string(metaJSON) + "]"

--- a/internal/bridge/scheduler.go
+++ b/internal/bridge/scheduler.go
@@ -351,11 +351,13 @@ func (s *Scheduler) tick(ctx context.Context) {
 		log.Printf("scheduler: dispatching schedule %s (%s)", sched.Name, sched.ID)
 
 		req := TaskRequest{
-			Prompt:   sched.Prompt,
-			Repo:     sched.Repo,
-			Provider: sched.Provider,
-			Timeout:  sched.Timeout,
-			Debug:    sched.Debug,
+			Prompt:      sched.Prompt,
+			Repo:        sched.Repo,
+			Provider:    sched.Provider,
+			Timeout:     sched.Timeout,
+			Debug:       sched.Debug,
+			TaskName:    sched.Name,
+			TriggerType: "cron",
 		}
 
 		if _, err := s.dispatcher.DispatchTask(ctx, req, sched.Owner); err != nil {

--- a/internal/types.go
+++ b/internal/types.go
@@ -59,7 +59,9 @@ type Session struct {
 	Artifacts      []Artifact `json:"artifacts,omitempty"`
 	ParentID       string     `json:"parent_id,omitempty"`
 	TaskName       string     `json:"task_name,omitempty"`
-	TriggerContext string     `json:"trigger_context,omitempty"`
+	TriggerContext string     `json:"trigger_context,omitempty"` // keep for backward compat
+	TriggerType    string     `json:"trigger_type,omitempty"`
+	TriggerRef     string     `json:"trigger_ref,omitempty"`
 }
 
 // Artifact represents an output produced by a task (PR, commit, etc.).

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2124,3 +2124,136 @@ select.input {
     border: 1px solid rgba(231, 76, 60, 0.3);
     margin-left: 4px;
 }
+
+/* Text utility */
+.text-muted { color: var(--text-muted); }
+
+/* === Task List Redesign === */
+
+/* Task type pills */
+.task-type-pill {
+    display: inline-block;
+    font-size: 10px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    margin-right: 8px;
+    vertical-align: middle;
+    text-transform: uppercase;
+}
+.task-type-dev { background: rgba(52,152,219,0.15); color: #3498db; }
+.task-type-review { background: rgba(155,89,182,0.15); color: #9b59b6; }
+.task-type-plan { background: rgba(46,204,113,0.15); color: #2ecc71; }
+.task-type-release { background: rgba(243,156,18,0.15); color: #f39c12; }
+.task-type-neutral { background: rgba(127,127,127,0.12); color: #888; }
+
+/* Status left border on rows */
+.session-row { border-left: 4px solid transparent; transition: background 0.15s; }
+.session-row:hover { background: rgba(255,255,255,0.06); }
+.session-row-running { border-left-color: #3498db; background: rgba(52,152,219,0.04); }
+.session-row-completed { border-left-color: #28a745; }
+.session-row-error { border-left-color: #dc3545; }
+.session-row-timeout { border-left-color: #6f42c1; }
+.session-row-cancelled { border-left-color: #ffc107; }
+
+/* Pulsing status dot */
+.status-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-right: 6px;
+    vertical-align: middle;
+}
+.status-dot-running {
+    background: #3498db;
+    animation: pulse-dot 1.5s ease-in-out infinite;
+}
+.status-dot-completed { background: #28a745; }
+.status-dot-error { background: #dc3545; }
+.status-dot-timeout { background: #6f42c1; }
+.status-dot-cancelled { background: #ffc107; }
+
+@keyframes pulse-dot {
+    0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(52,152,219,0.4); }
+    50% { opacity: 0.7; box-shadow: 0 0 0 6px rgba(52,152,219,0); }
+}
+
+/* Section headers */
+.section-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-muted);
+    padding: 12px 16px 6px;
+    border-left: none;
+}
+.section-label-running { color: #3498db; }
+
+/* Trigger links */
+.trigger-link {
+    color: #3498db;
+    text-decoration: none;
+    font-weight: 500;
+}
+.trigger-link:hover { text-decoration: underline; }
+
+/* Empty state (task list redesign) */
+.empty-state-redesign {
+    text-align: center;
+    padding: 60px 20px;
+    max-width: 600px;
+    margin: 0 auto;
+}
+.empty-state-redesign h2 {
+    font-size: 24px;
+    color: var(--text);
+    margin-bottom: 8px;
+}
+.empty-state-redesign p {
+    color: var(--text-muted);
+    margin-bottom: 32px;
+    font-size: 15px;
+}
+.empty-state-cards {
+    display: flex;
+    gap: 16px;
+    justify-content: center;
+}
+.empty-card {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 20px 16px;
+    width: 170px;
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+.empty-card:hover {
+    border-color: #3498db;
+    box-shadow: 0 2px 8px rgba(52,152,219,0.15);
+}
+.empty-card-icon {
+    font-size: 28px;
+    margin-bottom: 8px;
+    color: var(--text-muted);
+}
+.empty-card-title {
+    font-weight: 600;
+    font-size: 14px;
+    margin-bottom: 4px;
+    color: var(--text);
+}
+.empty-card-desc {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+/* Running duration live counter */
+.duration-live {
+    color: #3498db;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+}

--- a/web/index.html
+++ b/web/index.html
@@ -126,22 +126,20 @@
                     </div>
                 </div>
                 <div id="sessions-table-container" class="table-container">
-                    <table class="data-table">
+                    <table class="data-table" id="sessions-table">
                         <thead>
                             <tr>
-                                <th>ID</th>
+                                <th style="width:40px"></th>
+                                <th>Task</th>
                                 <th>Submitter</th>
-                                <th>Status</th>
                                 <th>When</th>
-                                <th>Task Name</th>
                                 <th>Duration</th>
-                                <th>Trigger Context</th>
+                                <th>Trigger</th>
                             </tr>
                         </thead>
                         <tbody id="sessions-tbody"></tbody>
                     </table>
-                    <div id="sessions-empty" class="empty-state" hidden>
-                        <p>No tasks found.</p>
+                    <div id="sessions-empty" hidden>
                     </div>
                     <div id="sessions-loading" class="loading-state" hidden>
                         <div class="spinner"></div>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1179,6 +1179,54 @@
     // ---------------------
     // Sessions list
     // ---------------------
+
+    function getTaskType(taskName) {
+        if (!taskName) return { label: 'TASK', color: 'neutral' };
+        var name = taskName.toLowerCase();
+        if (name.includes('review')) return { label: 'REVIEW', color: 'review' };
+        if (name.includes('plan')) return { label: 'PLAN', color: 'plan' };
+        if (name.includes('release')) return { label: 'RELEASE', color: 'release' };
+        if (name.includes('developer') || name.includes('dev')) return { label: 'DEV', color: 'dev' };
+        if (name.includes('retry') || name.includes('ci')) return { label: 'CI FIX', color: 'dev' };
+        var firstWord = taskName.split(/[\s-]/)[0].toUpperCase();
+        return { label: firstWord.substring(0, 8), color: 'neutral' };
+    }
+
+    function formatTriggerRef(triggerContext) {
+        if (!triggerContext || triggerContext === 'Manual') return '<span class="text-muted">Manual</span>';
+        if (triggerContext === 'Scheduled' || triggerContext === 'cron') return '<span class="text-muted">Scheduled</span>';
+
+        // Parse "owner/repo#number" format
+        var match = triggerContext.match(/^(.+?)#(\d+)$/);
+        if (match) {
+            var repo = match[1];
+            var number = match[2];
+            var url = 'https://github.com/' + repo + '/issues/' + number;
+            var shortRef = '#' + number;
+            return '<a href="' + escapeHtml(url) + '" class="trigger-link" target="_blank" rel="noopener" onclick="event.stopPropagation()">' + escapeHtml(shortRef) + '</a>';
+        }
+        return '<span class="text-muted">' + escapeHtml(triggerContext) + '</span>';
+    }
+
+    function formatSubmitter(submitter) {
+        if (!submitter) return '-';
+        // Strip @domain from email addresses
+        var atIdx = submitter.indexOf('@');
+        if (atIdx > 0) return submitter.substring(0, atIdx);
+        return submitter;
+    }
+
+    function startRunningTimers() {
+        if (window._runningTimer) clearInterval(window._runningTimer);
+        window._runningTimer = setInterval(function () {
+            document.querySelectorAll('[data-started-at]').forEach(function (el) {
+                var started = new Date(el.dataset.startedAt);
+                var elapsed = Math.floor((Date.now() - started) / 1000);
+                el.textContent = humanDuration(elapsed);
+            });
+        }, 1000);
+    }
+
     async function loadSessions(silent) {
         const tbody = $('#sessions-tbody');
         const loading = $('#sessions-loading');
@@ -1197,7 +1245,7 @@
 
             const sessions = Array.isArray(data) ? data : (data.sessions || data.items || []);
             if (sessions.length === 0) {
-                show(empty);
+                renderEmptyState();
                 return;
             }
 
@@ -1207,59 +1255,135 @@
         } catch (err) {
             hide(loading);
             if (err.message !== 'unauthorized') {
-                tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;color:var(--status-error);">Failed to load tasks. Check your connection and try again.</td></tr>';
+                tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;color:var(--status-error);padding:24px;">Failed to load tasks. Check your connection and try again.</td></tr>';
             }
         }
     }
 
-    function renderSessions(sessions) {
-        const tbody = $('#sessions-tbody');
-        const statusFilter = $('#filter-status').value;
-        const searchFilter = $('#filter-search').value.toLowerCase();
+    function renderEmptyState() {
+        var tbody = $('#sessions-tbody');
+        var empty = $('#sessions-empty');
+        var table = $('#sessions-table');
+        tbody.innerHTML = '';
+        if (table) table.hidden = true;
+        empty.innerHTML = '<div class="empty-state-redesign">' +
+            '<h2>No tasks yet</h2>' +
+            '<p>Tasks appear here when they run -- triggered by events, on a schedule, or submitted manually.</p>' +
+            '<div class="empty-state-cards">' +
+                '<a href="#task/new" class="empty-card">' +
+                    '<div class="empty-card-icon">&gt;_</div>' +
+                    '<div class="empty-card-title">Run a task</div>' +
+                    '<div class="empty-card-desc">Submit a prompt to an AI agent</div>' +
+                '</a>' +
+                '<a href="#repos" class="empty-card">' +
+                    '<div class="empty-card-icon">&#9201;</div>' +
+                    '<div class="empty-card-title">Set up automation</div>' +
+                    '<div class="empty-card-desc">Connect a task repo for event-driven agents</div>' +
+                '</a>' +
+                '<a href="#credentials" class="empty-card">' +
+                    '<div class="empty-card-icon">&#128273;</div>' +
+                    '<div class="empty-card-title">Add credentials</div>' +
+                    '<div class="empty-card-desc">Configure LLM and platform credentials</div>' +
+                '</a>' +
+            '</div>' +
+        '</div>';
+        show(empty);
+    }
 
-        const filtered = sessions.filter((s) => {
+    function renderSessionRow(s) {
+        var status = s.status || 'unknown';
+        var taskName = s.task_name || 'Manual Task';
+        var taskType = getTaskType(s.task_name);
+        var submitter = formatSubmitter(s.submitter);
+        var when = formatRelativeTime(s.started_at);
+        var triggerHtml = formatTriggerRef(s.trigger_context);
+        var isRunning = status === 'running';
+
+        // Duration: for running tasks, show live counter
+        var durationHtml;
+        if (isRunning && s.started_at) {
+            var elapsed = Math.floor((Date.now() - new Date(s.started_at).getTime()) / 1000);
+            durationHtml = '<span class="duration-live" data-started-at="' + escapeHtml(s.started_at) + '">' + humanDuration(elapsed) + '</span>';
+        } else {
+            durationHtml = escapeHtml(formatDuration(s.started_at, s.finished_at, s.duration));
+        }
+
+        return '<tr class="clickable session-row session-row-' + escapeHtml(status) + '" data-session-id="' + escapeHtml(s.id) + '" tabindex="0" role="link">' +
+            '<td><span class="status-dot status-dot-' + escapeHtml(status) + '" title="' + escapeHtml(status) + '"></span></td>' +
+            '<td><span class="task-type-pill task-type-' + escapeHtml(taskType.color) + '">' + escapeHtml(taskType.label) + '</span>' + escapeHtml(taskName) + '</td>' +
+            '<td>' + escapeHtml(submitter) + '</td>' +
+            '<td>' + escapeHtml(when) + '</td>' +
+            '<td class="mono">' + durationHtml + '</td>' +
+            '<td>' + triggerHtml + '</td>' +
+            '</tr>';
+    }
+
+    function renderSessions(sessions) {
+        var tbody = $('#sessions-tbody');
+        var table = $('#sessions-table');
+        var statusFilter = $('#filter-status').value;
+        var searchFilter = $('#filter-search').value.toLowerCase();
+
+        if (table) table.hidden = false;
+
+        var filtered = sessions.filter(function (s) {
             if (statusFilter && s.status !== statusFilter) return false;
             if (searchFilter) {
-                const text = (s.id + ' ' + (s.task_name || '') + ' ' + (s.trigger_context || '') + ' ' + (s.prompt || '')).toLowerCase();
+                var text = (s.id + ' ' + (s.task_name || '') + ' ' + (s.trigger_context || '') + ' ' + (s.prompt || '')).toLowerCase();
                 if (!text.includes(searchFilter)) return false;
             }
             return true;
         });
 
-        const empty = $('#sessions-empty');
+        var empty = $('#sessions-empty');
         if (filtered.length === 0) {
             tbody.innerHTML = '';
+            empty.innerHTML = '<p>No tasks match your filters.</p>';
             show(empty);
             return;
         }
         hide(empty);
 
-        tbody.innerHTML = filtered.map((s) => {
-            const idShort = (s.id || '').substring(0, 12);
-            const submitter = s.submitter || '-';
-            const status = s.status || 'unknown';
-            const taskName = s.task_name || 'Manual Task';
-            const duration = formatDuration(s.started_at, s.finished_at, s.duration);
-            const triggerContext = s.trigger_context || 'Manual';
-            const when = formatRelativeTime(s.started_at);
+        // Split into running and recent
+        var running = filtered.filter(function (s) { return s.status === 'running'; });
+        var recent = filtered.filter(function (s) { return s.status !== 'running'; });
 
-            return '<tr class="clickable" data-session-id="' + escapeHtml(s.id) + '" tabindex="0" role="link">' +
-                '<td class="mono" title="' + escapeHtml(s.id) + '">' + escapeHtml(idShort) + '</td>' +
-                '<td>' + escapeHtml(submitter) + '</td>' +
-                '<td><span class="badge badge-' + escapeHtml(status) + '">' + escapeHtml(status) + '</span></td>' +
-                '<td>' + escapeHtml(when) + '</td>' +
-                '<td>' + escapeHtml(taskName) + '</td>' +
-                '<td class="mono">' + escapeHtml(duration) + '</td>' +
-                '<td class="truncate">' + escapeHtml(triggerContext) + '</td>' +
-                '</tr>';
-        }).join('');
+        var html = '';
+
+        // Running section
+        if (running.length > 0) {
+            html += '<tr><td colspan="6" class="section-label section-label-running">RUNNING (' + running.length + ')</td></tr>';
+            running.forEach(function (s) {
+                html += renderSessionRow(s);
+            });
+        }
+
+        // Recent section
+        if (recent.length > 0) {
+            if (running.length > 0) {
+                html += '<tr><td colspan="6" class="section-label">RECENT</td></tr>';
+            }
+            recent.forEach(function (s) {
+                html += renderSessionRow(s);
+            });
+        }
+
+        tbody.innerHTML = html;
+
+        // Start live timers for running tasks
+        if (running.length > 0) {
+            startRunningTimers();
+        } else if (window._runningTimer) {
+            clearInterval(window._runningTimer);
+            window._runningTimer = null;
+        }
 
         // Click and keyboard handlers
-        tbody.querySelectorAll('tr.clickable').forEach((row) => {
-            row.addEventListener('click', () => {
+        tbody.querySelectorAll('tr.clickable').forEach(function (row) {
+            row.addEventListener('click', function () {
                 navigate('session/' + row.dataset.sessionId);
             });
-            row.addEventListener('keydown', (e) => {
+            row.addEventListener('keydown', function (e) {
                 if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault();
                     navigate('session/' + row.dataset.sessionId);
@@ -1316,6 +1440,10 @@
         if (durationInterval) {
             clearInterval(durationInterval);
             durationInterval = null;
+        }
+        if (window._runningTimer) {
+            clearInterval(window._runningTimer);
+            window._runningTimer = null;
         }
     }
 


### PR DESCRIPTION
## Summary

Full task list redesign with backend + frontend changes:

### Backend (migration 020 + dispatch paths)
- Add `task_name`, `trigger_type`, `trigger_ref`, `repo` columns to sessions table
- Store metadata at dispatch time (poller, scheduler, webhook, manual, CI Gate)
- Eliminates fragile LEFT JOIN chain and prompt parsing for task names
- Backward compatible: old sessions get NULL (fallback to existing logic)

### Frontend (task list view)
- **Two-section layout**: Running tasks pinned at top with count, Recent below
- **Task type pills**: DEV, REVIEW, PLAN, RELEASE, or first word of task name (supports arbitrary task types like research, content, etc.)
- **Status visualization**: Pulsing dots for running, colored left borders, background tint
- **Trigger links**: Clickable GitHub issue/PR links parsed from `trigger_ref`
- **Live duration**: Running tasks show live elapsed counter updating every second
- **Empty state**: Onboarding cards (Run a task, Set up automation, Add credentials) for fresh installs
- **ID column removed**: Reduces noise, available on detail page
- **Submitter shortened**: Strips @domain from emails

## Test plan
- [x] `make build` && `make test` pass
- [x] Local dev environment verified — empty state renders correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)