### PR TITLE
Redesign repo enable/disable: toggle switch, paused state, cross-page UX

### DIFF
--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -925,6 +925,29 @@ func (a *API) handleSchedules(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusInternalServerError, "failed to list schedules")
 			return
 		}
+
+		// Annotate schedules with repo_disabled by joining through task definitions.
+		disabledRepos := a.buildDisabledReposMap(r.Context(), user)
+		if len(disabledRepos) > 0 {
+			// Build source_key -> source_repo map from task definitions.
+			defs, defErr := a.defStore.ListTaskDefinitions(r.Context(), user)
+			if defErr == nil {
+				sourceKeyToRepo := make(map[string]string)
+				for _, d := range defs {
+					if d.SourceKey != "" {
+						sourceKeyToRepo[d.SourceKey] = d.SourceRepo
+					}
+				}
+				for i := range schedules {
+					if sourceRepo, ok := sourceKeyToRepo[schedules[i].SourceKey]; ok {
+						if disabledRepos[sourceRepo] {
+							schedules[i].RepoDisabled = true
+						}
+					}
+				}
+			}
+		}
+
 		respondJSON(w, http.StatusOK, map[string]any{
 			"schedules": schedules,
 			"count":     len(schedules),
@@ -1612,6 +1635,16 @@ func (a *API) handleTaskDefinitions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Fetch user's task repos to check disabled status.
+	disabledRepos := a.buildDisabledReposMap(r.Context(), user)
+
+	// Annotate each task definition with repo_disabled.
+	for i := range defs {
+		if disabledRepos[defs[i].SourceRepo] {
+			defs[i].RepoDisabled = true
+		}
+	}
+
 	respondJSON(w, http.StatusOK, map[string]any{
 		"task_definitions": defs,
 		"count":            len(defs),
@@ -2172,6 +2205,21 @@ func (a *API) handleTBRAssociationByID(w http.ResponseWriter, r *http.Request) {
 	default:
 		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
 	}
+}
+
+// buildDisabledReposMap returns a set of repo URLs that are disabled for the given user.
+func (a *API) buildDisabledReposMap(ctx context.Context, username string) map[string]bool {
+	taskRepos, err := a.settingsStore.GetUserTaskRepos(ctx, username)
+	if err != nil {
+		return nil
+	}
+	disabledRepos := make(map[string]bool)
+	for _, repo := range taskRepos {
+		if !repo.IsEnabled() {
+			disabledRepos[repo.URL] = true
+		}
+	}
+	return disabledRepos
 }
 
 // --- Helpers ---

--- a/internal/bridge/scheduler.go
+++ b/internal/bridge/scheduler.go
@@ -47,8 +47,9 @@ type Schedule struct {
 	Debug       bool          `json:"debug,omitempty"`
 	Source      string        `json:"source,omitempty"`
 	SourceKey   string        `json:"source_key,omitempty"`
-	TriggerType string        `json:"trigger_type,omitempty"`
-	EventConfig *EventTrigger `json:"event_config,omitempty"`
+	TriggerType  string        `json:"trigger_type,omitempty"`
+	EventConfig  *EventTrigger `json:"event_config,omitempty"`
+	RepoDisabled bool          `json:"repo_disabled"`
 }
 
 // CronExpr represents a parsed 5-field cron expression.

--- a/internal/bridge/taskdef.go
+++ b/internal/bridge/taskdef.go
@@ -57,8 +57,9 @@ type TaskDefinition struct {
 	RawYAML    string     `json:"raw_yaml,omitempty"`
 	SyncError  string     `json:"sync_error,omitempty"`
 	LastSynced time.Time  `json:"last_synced"`
-	NextRun    *time.Time `json:"next_run,omitempty"`
-	LastRun    *time.Time `json:"last_run,omitempty"`
+	NextRun      *time.Time `json:"next_run,omitempty"`
+	LastRun      *time.Time `json:"last_run,omitempty"`
+	RepoDisabled bool       `json:"repo_disabled"`
 }
 
 // TaskDefSchedule defines an optional cron schedule for a task definition.

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -1731,6 +1731,7 @@ select.input {
 .repo-item {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 8px;
     padding: 6px 0;
     border-bottom: 1px solid var(--border);
@@ -2096,34 +2097,82 @@ select.input {
     border-color: rgba(231, 76, 60, 0.5);
 }
 
-/* === Task Repo Enable/Disable === */
-.repo-item-toggle {
-    display: inline-flex;
-    align-items: center;
-    margin-right: 6px;
-    cursor: pointer;
-}
-
-.repo-item-toggle input[type="checkbox"] {
-    width: 16px;
-    height: 16px;
-    cursor: pointer;
-}
-
-.repo-item-disabled {
-    opacity: 0.5;
-}
-
-.repo-item-badge-disabled {
+/* === Toggle Switch === */
+.toggle-switch {
+    position: relative;
     display: inline-block;
-    font-size: 10px;
-    padding: 1px 6px;
-    border-radius: 4px;
-    background: rgba(231, 76, 60, 0.15);
-    color: var(--status-error);
-    border: 1px solid rgba(231, 76, 60, 0.3);
-    margin-left: 4px;
+    width: 40px;
+    height: 22px;
+    vertical-align: middle;
+    margin-right: 8px;
 }
+.toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+.toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background-color: #ccc;
+    transition: 0.2s;
+    border-radius: 22px;
+}
+.toggle-slider:before {
+    position: absolute;
+    content: "";
+    height: 16px;
+    width: 16px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: 0.2s;
+    border-radius: 50%;
+}
+.toggle-switch input:checked + .toggle-slider {
+    background-color: #28a745;
+}
+.toggle-switch input:checked + .toggle-slider:before {
+    transform: translateX(18px);
+}
+
+/* Toggle labels */
+.toggle-label-active { color: #28a745; font-weight: 600; font-size: 13px; }
+.toggle-label-paused { color: #f39c12; font-weight: 600; font-size: 13px; }
+
+/* Repo paused state */
+.repo-paused { opacity: 0.6; border-left: 3px solid #f39c12; padding-left: 8px; }
+.repo-active { border-left: 3px solid #28a745; padding-left: 8px; }
+.repo-paused-message {
+    font-size: 12px;
+    color: #f39c12;
+    margin-top: 4px;
+    font-style: italic;
+    width: 100%;
+}
+
+/* Paused-by-repo badge on schedules */
+.badge-paused-repo {
+    background: rgba(243, 156, 18, 0.15);
+    color: #f39c12;
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+/* Task def card paused state */
+.task-def-paused-repo {
+    opacity: 0.6;
+    border-left: 3px solid #f39c12;
+}
+.task-def-paused-link {
+    font-size: 12px;
+    color: #3498db;
+    cursor: pointer;
+}
+.task-def-paused-link:hover { text-decoration: underline; }
 
 /* Text utility */
 .text-muted { color: var(--text-muted); }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -423,12 +423,14 @@
             var r = taskReposList[i];
             var isEnabled = r.enabled === undefined || r.enabled === null || r.enabled === true;
             var displayUrl = (r.url || '').replace(/^https?:\/\//, '').replace(/\.git$/, '');
-            html += '<div class="repo-item' + (isEnabled ? '' : ' repo-item-disabled') + '">';
-            html += '<label class="repo-item-toggle"><input type="checkbox" class="repo-item-enabled" data-index="' + i + '"' + (isEnabled ? ' checked' : '') + '> </label>';
+            var toggleTitle = isEnabled ? 'Pause tasks from this repo' : 'Resume tasks from this repo';
+            html += '<div class="repo-item ' + (isEnabled ? 'repo-active' : 'repo-paused') + '">';
+            html += '<label class="toggle-switch" title="' + toggleTitle + '"><input type="checkbox" class="repo-item-enabled" data-index="' + i + '"' + (isEnabled ? ' checked' : '') + '><span class="toggle-slider"></span></label>';
+            html += '<span class="' + (isEnabled ? 'toggle-label-active' : 'toggle-label-paused') + '">' + (isEnabled ? 'Active' : 'Paused') + '</span>';
             html += '<span class="repo-item-url">' + escapeHtml(displayUrl) + '</span>';
             if (r.ref && r.ref !== 'main') html += ' <span class="repo-item-ref">' + escapeHtml(r.ref) + '</span>';
-            if (!isEnabled) html += ' <span class="repo-item-badge-disabled">disabled</span>';
             html += ' <button class="btn btn-small btn-outline repo-item-remove" data-index="' + i + '" style="color:var(--status-error);border-color:var(--status-error);padding:2px 8px;font-size:11px;">Remove</button>';
+            if (!isEnabled) html += '<div class="repo-paused-message">Tasks from this repo are paused. Schedules and event-driven tasks will not run.</div>';
             html += '</div>';
         }
         listEl.innerHTML = html;
@@ -442,7 +444,7 @@
                 if (statusEl) {
                     statusEl.removeAttribute('hidden');
                     statusEl.style.color = 'var(--text-muted)';
-                    statusEl.textContent = (cb.checked ? 'Enabled' : 'Disabled') + ' ' + (taskReposList[idx].name || taskReposList[idx].url) + '. Changes take effect on next sync.';
+                    statusEl.textContent = (cb.checked ? 'Resumed' : 'Paused') + ' ' + (taskReposList[idx].name || taskReposList[idx].url) + '. Changes take effect on next sync.';
                 }
                 setTimeout(function() { loadUnifiedSchedules(); }, 2000);
             });
@@ -596,12 +598,27 @@
             return;
         }
 
-        // Sort alphabetically by name
+        // Sort: paused-by-repo items to bottom, then alphabetically by name
         allItems.sort(function(a, b) {
+            var aPaused = (a._type === 'task-def' && (a.data.repo_disabled || false)) ? 1 : 0;
+            var bPaused = (b._type === 'task-def' && (b.data.repo_disabled || false)) ? 1 : 0;
+            if (aPaused !== bPaused) return aPaused - bPaused;
             if (a._name < b._name) return -1;
             if (a._name > b._name) return 1;
             return 0;
         });
+
+        // Update Schedules nav tab with paused count
+        var pausedCount = 0;
+        allItems.forEach(function(item) {
+            if (item._type === 'task-def' && (item.data.repo_disabled || false)) {
+                pausedCount++;
+            }
+        });
+        var schedulesTab = document.querySelector('.nav-tab[data-tab="schedules"]');
+        if (schedulesTab) {
+            schedulesTab.textContent = pausedCount > 0 ? 'Schedules (' + pausedCount + ' paused)' : 'Schedules';
+        }
 
         var html = '';
         for (var i = 0; i < allItems.length; i++) {
@@ -749,15 +766,22 @@
         var desc = d.description || '';
         var repo = d.source_repo || d.repo || '';
         var id = d.id || '';
+        var repoPaused = d.repo_disabled || false;
 
-        var html = '<div class="task-def-card">';
+        var html = '<div class="task-def-card' + (repoPaused ? ' task-def-paused-repo' : '') + '">';
+
+        // Paused-by-repo badge
+        if (repoPaused) {
+            html += '<div style="margin-bottom:8px;"><span class="badge-paused-repo">Paused — repo disabled</span></div>';
+        }
 
         // Header row: name + actions
         html += '<div class="task-def-header">';
         html += '<div class="task-def-name">' + escapeHtml(name) + '</div>';
         html += '<div class="task-def-actions">';
-        if (d.sync_error) {
-            html += '<button class="btn btn-small btn-primary task-def-run" data-id="' + escapeHtml(id) + '" disabled title="' + escapeHtml(d.sync_error) + '">Run Now</button>';
+        if (d.sync_error || repoPaused) {
+            var disabledTitle = repoPaused ? 'Repo is paused' : escapeHtml(d.sync_error);
+            html += '<button class="btn btn-small btn-primary task-def-run" data-id="' + escapeHtml(id) + '" disabled title="' + disabledTitle + '" style="' + (repoPaused ? 'opacity:0.4;cursor:not-allowed;' : '') + '">Run Now</button>';
         } else {
             html += '<button class="btn btn-small btn-primary task-def-run" data-id="' + escapeHtml(id) + '">Run Now</button>';
         }
@@ -811,6 +835,11 @@
         // Sync error
         if (d.sync_error) {
             html += '<div class="task-def-error">Sync error: ' + escapeHtml(d.sync_error) + '</div>';
+        }
+
+        // Paused-by-repo link
+        if (repoPaused) {
+            html += '<div style="margin-top:8px;"><a href="#repos" class="task-def-paused-link">Go to Repos to re-enable</a></div>';
         }
 
         html += '</div>';


### PR DESCRIPTION
## Summary

### Repos Page
- Replace bare checkbox with **toggle switch** (right-aligned)
- Label shows "Active" (green) / "Paused" (amber) next to toggle
- Paused repos get 0.6 opacity, amber left border, inline message: "Tasks from this repo are paused"
- Hover tooltip: "Pause tasks from this repo" / "Resume tasks from this repo"

### Schedules Page  
- Paused-by-repo task definitions show amber badge: **"Paused -- repo disabled"**
- Explanatory link: "Go to Repos to re-enable" (navigates to #repos)
- "Run Now" button disabled on paused task definitions
- Paused items sorted to bottom of list
- Nav tab shows count: "Schedules (N paused)" when applicable

### Backend
- `repo_disabled` boolean added to task definitions and schedules API responses
- Computed at query time by cross-referencing source repo with user's disabled repos
- No database changes — purely computed from existing data

## Test plan
- [x] `make build` && `make test` pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)