### PR TITLE
Add CLI config file support for default flag values

### DIFF
--- a/cmd/alcove/main.go
+++ b/cmd/alcove/main.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -40,7 +41,19 @@ var Version = "dev"
 
 // CLIConfig holds the user-level CLI configuration.
 type CLIConfig struct {
-	Server string `yaml:"server"`
+	Server   string `yaml:"server"`
+	Output   string `yaml:"output,omitempty"`    // "json" or "table"
+	Username string `yaml:"username,omitempty"`  // Basic Auth username
+	Password string `yaml:"password,omitempty"`  // Basic Auth password
+	ProxyURL string `yaml:"proxy_url,omitempty"` // HTTP proxy
+	NoProxy  string `yaml:"no_proxy,omitempty"`  // Comma-separated no-proxy hosts
+	Defaults struct {
+		Repo     string  `yaml:"repo,omitempty"`     // Default repository
+		Provider string  `yaml:"provider,omitempty"` // Default LLM provider
+		Model    string  `yaml:"model,omitempty"`    // Default model
+		Timeout  string  `yaml:"timeout,omitempty"`  // Default timeout (e.g., "30m")
+		Budget   float64 `yaml:"budget,omitempty"`   // Default budget in USD
+	} `yaml:"defaults,omitempty"`
 }
 
 // ProxyConfig holds HTTP proxy configuration.
@@ -100,8 +113,8 @@ func resolveServer(cmd *cobra.Command) (string, error) {
 	return "", fmt.Errorf("no Bridge server configured; use --server, ALCOVE_SERVER, or 'alcove login'")
 }
 
-// resolveBasicAuth determines username/password from flags or environment variables.
-// Returns empty strings if not configured.
+// resolveBasicAuth determines username/password from flags, environment variables,
+// or config file. Returns empty strings if not configured.
 func resolveBasicAuth(cmd *cobra.Command) (string, string) {
 	// 1. Flags
 	username, _ := cmd.Flags().GetString("username")
@@ -113,6 +126,15 @@ func resolveBasicAuth(cmd *cobra.Command) (string, string) {
 	// 2. Environment variables
 	username = os.Getenv("ALCOVE_USERNAME")
 	password = os.Getenv("ALCOVE_PASSWORD")
+	if username != "" {
+		return username, password
+	}
+
+	// 3. Config file
+	if cfg, err := loadConfig(); err == nil {
+		username = cfg.Username
+		password = cfg.Password
+	}
 	return username, password
 }
 
@@ -160,6 +182,18 @@ func resolveProxyConfig(cmd *cobra.Command) (*ProxyConfig, error) {
 		}
 		if noProxy != "" {
 			config.NoProxy = parseNoProxy(noProxy)
+		}
+	}
+
+	// 3. Config file
+	if config.ProxyURL == "" {
+		if cfg, err := loadConfig(); err == nil && cfg.ProxyURL != "" {
+			if err := validateProxyURL(cfg.ProxyURL); err == nil {
+				config.ProxyURL = cfg.ProxyURL
+			}
+			if cfg.NoProxy != "" && len(config.NoProxy) == 0 {
+				config.NoProxy = parseNoProxy(cfg.NoProxy)
+			}
 		}
 	}
 
@@ -361,8 +395,16 @@ func outputJSON(v interface{}) error {
 }
 
 func isJSONOutput(cmd *cobra.Command) bool {
-	o, _ := cmd.Flags().GetString("output")
-	return strings.EqualFold(o, "json")
+	if f, _ := cmd.Flags().GetString("output"); f == "json" {
+		return true
+	}
+	if os.Getenv("ALCOVE_OUTPUT") == "json" {
+		return true
+	}
+	if cfg, err := loadConfig(); err == nil && cfg.Output == "json" {
+		return true
+	}
+	return false
 }
 
 // ---------- run ----------
@@ -412,6 +454,27 @@ func runRun(cmd *cobra.Command, args []string) error {
 		reqBody.Timeout = int(t.Seconds())
 	}
 	reqBody.Debug, _ = cmd.Flags().GetBool("debug")
+
+	// Fall back to config file defaults
+	if cfg, err := loadConfig(); err == nil {
+		if reqBody.Repo == "" {
+			reqBody.Repo = cfg.Defaults.Repo
+		}
+		if reqBody.Provider == "" {
+			reqBody.Provider = cfg.Defaults.Provider
+		}
+		if reqBody.Model == "" {
+			reqBody.Model = cfg.Defaults.Model
+		}
+		if reqBody.Budget == 0 && cfg.Defaults.Budget > 0 {
+			reqBody.Budget = cfg.Defaults.Budget
+		}
+		if reqBody.Timeout == 0 && cfg.Defaults.Timeout != "" {
+			if d, err := time.ParseDuration(cfg.Defaults.Timeout); err == nil {
+				reqBody.Timeout = int(d.Seconds())
+			}
+		}
+	}
 
 	resp, err := apiRequest(cmd, http.MethodPost, "/api/v1/tasks", reqBody)
 	if err != nil {
@@ -765,27 +828,42 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	}
 
 	// Save config and credentials
-	dir := configDir()
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return fmt.Errorf("creating config dir: %w", err)
+	cfg, _ := loadConfig()
+	if cfg == nil {
+		cfg = &CLIConfig{}
 	}
-
-	cfg := CLIConfig{Server: bridgeURL}
-	cfgData, _ := yaml.Marshal(cfg)
-	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), cfgData, 0600); err != nil {
+	cfg.Server = bridgeURL
+	if err := saveConfig(cfg); err != nil {
 		return fmt.Errorf("saving config: %w", err)
 	}
 
+	dir := configDir()
 	if err := os.WriteFile(filepath.Join(dir, "credentials"), []byte(tokenResp.Token), 0600); err != nil {
 		return fmt.Errorf("saving credentials: %w", err)
 	}
 
 	fmt.Fprintf(os.Stderr, "Logged in to %s\n", bridgeURL)
-	fmt.Fprintf(os.Stderr, "Config saved to %s\n", filepath.Join(dir, "config.yaml"))
 	return nil
 }
 
 // ---------- config ----------
+
+func saveConfig(cfg *CLIConfig) error {
+	dir := configDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("creating config dir: %w", err)
+	}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Configuration saved to %s\n", path)
+	return nil
+}
 
 func newConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -796,6 +874,63 @@ func newConfigCmd() *cobra.Command {
 		Use:   "validate",
 		Short: "Validate the current configuration",
 		RunE:  runConfigValidate,
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "show",
+		Short: "Show current configuration",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "No config file found at %s\n", filepath.Join(configDir(), "config.yaml"))
+				return nil
+			}
+			data, _ := yaml.Marshal(cfg)
+			fmt.Print(string(data))
+			return nil
+		},
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Set a configuration value",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, _ := loadConfig()
+			if cfg == nil {
+				cfg = &CLIConfig{}
+			}
+			key, value := args[0], args[1]
+			switch key {
+			case "server":
+				cfg.Server = value
+			case "output":
+				cfg.Output = value
+			case "username":
+				cfg.Username = value
+			case "password":
+				cfg.Password = value
+			case "proxy_url":
+				cfg.ProxyURL = value
+			case "no_proxy":
+				cfg.NoProxy = value
+			case "defaults.repo":
+				cfg.Defaults.Repo = value
+			case "defaults.provider":
+				cfg.Defaults.Provider = value
+			case "defaults.model":
+				cfg.Defaults.Model = value
+			case "defaults.timeout":
+				cfg.Defaults.Timeout = value
+			case "defaults.budget":
+				if b, err := strconv.ParseFloat(value, 64); err == nil {
+					cfg.Defaults.Budget = b
+				} else {
+					return fmt.Errorf("invalid budget value: %s", value)
+				}
+			default:
+				return fmt.Errorf("unknown config key: %s\nValid keys: server, output, username, password, proxy_url, no_proxy, defaults.repo, defaults.provider, defaults.model, defaults.timeout, defaults.budget", key)
+			}
+			return saveConfig(cfg)
+		},
 	})
 	return cmd
 }

--- a/cmd/alcove/main_test.go
+++ b/cmd/alcove/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -221,4 +223,331 @@ func TestResolveProxyConfig(t *testing.T) {
 			t.Errorf("NoProxy = %v, expected empty slice", config.NoProxy)
 		}
 	})
+}
+func setupConfigDir(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	alcoveDir := filepath.Join(tmpDir, "alcove")
+	if err := os.MkdirAll(alcoveDir, 0700); err != nil {
+		t.Fatalf("creating alcove config dir: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	return alcoveDir
+}
+
+func TestLoadConfigWithDefaults(t *testing.T) {
+	alcoveDir := setupConfigDir(t)
+
+	configYAML := `server: https://alcove.example.com
+output: table
+username: myuser
+password: mypass
+proxy_url: http://proxy:3128
+no_proxy: localhost,127.0.0.1
+defaults:
+  repo: https://github.com/org/repo.git
+  provider: google-vertex
+  model: claude-sonnet-4-20250514
+  timeout: 30m
+  budget: 5.00
+`
+	if err := os.WriteFile(filepath.Join(alcoveDir, "config.yaml"), []byte(configYAML), 0600); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if cfg.Server != "https://alcove.example.com" {
+		t.Errorf("expected server %q, got %q", "https://alcove.example.com", cfg.Server)
+	}
+	if cfg.Output != "table" {
+		t.Errorf("expected output %q, got %q", "table", cfg.Output)
+	}
+	if cfg.Username != "myuser" {
+		t.Errorf("expected username %q, got %q", "myuser", cfg.Username)
+	}
+	if cfg.Password != "mypass" {
+		t.Errorf("expected password %q, got %q", "mypass", cfg.Password)
+	}
+	if cfg.ProxyURL != "http://proxy:3128" {
+		t.Errorf("expected proxy_url %q, got %q", "http://proxy:3128", cfg.ProxyURL)
+	}
+	if cfg.NoProxy != "localhost,127.0.0.1" {
+		t.Errorf("expected no_proxy %q, got %q", "localhost,127.0.0.1", cfg.NoProxy)
+	}
+	if cfg.Defaults.Repo != "https://github.com/org/repo.git" {
+		t.Errorf("expected defaults.repo %q, got %q", "https://github.com/org/repo.git", cfg.Defaults.Repo)
+	}
+	if cfg.Defaults.Provider != "google-vertex" {
+		t.Errorf("expected defaults.provider %q, got %q", "google-vertex", cfg.Defaults.Provider)
+	}
+	if cfg.Defaults.Model != "claude-sonnet-4-20250514" {
+		t.Errorf("expected defaults.model %q, got %q", "claude-sonnet-4-20250514", cfg.Defaults.Model)
+	}
+	if cfg.Defaults.Timeout != "30m" {
+		t.Errorf("expected defaults.timeout %q, got %q", "30m", cfg.Defaults.Timeout)
+	}
+	if cfg.Defaults.Budget != 5.00 {
+		t.Errorf("expected defaults.budget %v, got %v", 5.00, cfg.Defaults.Budget)
+	}
+}
+
+func TestLoadConfigPartial(t *testing.T) {
+	alcoveDir := setupConfigDir(t)
+
+	configYAML := `server: https://partial.example.com
+defaults:
+  repo: https://github.com/org/repo.git
+`
+	if err := os.WriteFile(filepath.Join(alcoveDir, "config.yaml"), []byte(configYAML), 0600); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if cfg.Server != "https://partial.example.com" {
+		t.Errorf("expected server %q, got %q", "https://partial.example.com", cfg.Server)
+	}
+	if cfg.Defaults.Repo != "https://github.com/org/repo.git" {
+		t.Errorf("expected defaults.repo %q, got %q", "https://github.com/org/repo.git", cfg.Defaults.Repo)
+	}
+
+	// All other fields should be zero values
+	if cfg.Output != "" {
+		t.Errorf("expected output to be empty, got %q", cfg.Output)
+	}
+	if cfg.Username != "" {
+		t.Errorf("expected username to be empty, got %q", cfg.Username)
+	}
+	if cfg.Password != "" {
+		t.Errorf("expected password to be empty, got %q", cfg.Password)
+	}
+	if cfg.ProxyURL != "" {
+		t.Errorf("expected proxy_url to be empty, got %q", cfg.ProxyURL)
+	}
+	if cfg.NoProxy != "" {
+		t.Errorf("expected no_proxy to be empty, got %q", cfg.NoProxy)
+	}
+	if cfg.Defaults.Provider != "" {
+		t.Errorf("expected defaults.provider to be empty, got %q", cfg.Defaults.Provider)
+	}
+	if cfg.Defaults.Model != "" {
+		t.Errorf("expected defaults.model to be empty, got %q", cfg.Defaults.Model)
+	}
+	if cfg.Defaults.Timeout != "" {
+		t.Errorf("expected defaults.timeout to be empty, got %q", cfg.Defaults.Timeout)
+	}
+	if cfg.Defaults.Budget != 0 {
+		t.Errorf("expected defaults.budget to be 0, got %v", cfg.Defaults.Budget)
+	}
+}
+
+func TestLoadConfigEmpty(t *testing.T) {
+	alcoveDir := setupConfigDir(t)
+
+	if err := os.WriteFile(filepath.Join(alcoveDir, "config.yaml"), []byte(""), 0600); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if cfg.Server != "" {
+		t.Errorf("expected server to be empty, got %q", cfg.Server)
+	}
+	if cfg.Output != "" {
+		t.Errorf("expected output to be empty, got %q", cfg.Output)
+	}
+	if cfg.Username != "" {
+		t.Errorf("expected username to be empty, got %q", cfg.Username)
+	}
+	if cfg.Password != "" {
+		t.Errorf("expected password to be empty, got %q", cfg.Password)
+	}
+	if cfg.ProxyURL != "" {
+		t.Errorf("expected proxy_url to be empty, got %q", cfg.ProxyURL)
+	}
+	if cfg.NoProxy != "" {
+		t.Errorf("expected no_proxy to be empty, got %q", cfg.NoProxy)
+	}
+	if cfg.Defaults.Repo != "" {
+		t.Errorf("expected defaults.repo to be empty, got %q", cfg.Defaults.Repo)
+	}
+	if cfg.Defaults.Provider != "" {
+		t.Errorf("expected defaults.provider to be empty, got %q", cfg.Defaults.Provider)
+	}
+	if cfg.Defaults.Model != "" {
+		t.Errorf("expected defaults.model to be empty, got %q", cfg.Defaults.Model)
+	}
+	if cfg.Defaults.Timeout != "" {
+		t.Errorf("expected defaults.timeout to be empty, got %q", cfg.Defaults.Timeout)
+	}
+	if cfg.Defaults.Budget != 0 {
+		t.Errorf("expected defaults.budget to be 0, got %v", cfg.Defaults.Budget)
+	}
+}
+
+func TestSaveAndLoadConfig(t *testing.T) {
+	setupConfigDir(t)
+
+	original := &CLIConfig{
+		Server:   "https://save-test.example.com",
+		Output:   "json",
+		Username: "testuser",
+		Password: "testpass",
+		ProxyURL: "http://proxy:8080",
+		NoProxy:  "localhost,10.0.0.0/8",
+	}
+	original.Defaults.Repo = "https://github.com/test/repo.git"
+	original.Defaults.Provider = "google-vertex"
+	original.Defaults.Model = "claude-sonnet-4-20250514"
+	original.Defaults.Timeout = "1h"
+	original.Defaults.Budget = 10.50
+
+	if err := saveConfig(original); err != nil {
+		t.Fatalf("saveConfig error: %v", err)
+	}
+
+	loaded, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig error: %v", err)
+	}
+
+	if loaded.Server != original.Server {
+		t.Errorf("server: got %q, want %q", loaded.Server, original.Server)
+	}
+	if loaded.Output != original.Output {
+		t.Errorf("output: got %q, want %q", loaded.Output, original.Output)
+	}
+	if loaded.Username != original.Username {
+		t.Errorf("username: got %q, want %q", loaded.Username, original.Username)
+	}
+	if loaded.Password != original.Password {
+		t.Errorf("password: got %q, want %q", loaded.Password, original.Password)
+	}
+	if loaded.ProxyURL != original.ProxyURL {
+		t.Errorf("proxy_url: got %q, want %q", loaded.ProxyURL, original.ProxyURL)
+	}
+	if loaded.NoProxy != original.NoProxy {
+		t.Errorf("no_proxy: got %q, want %q", loaded.NoProxy, original.NoProxy)
+	}
+	if loaded.Defaults.Repo != original.Defaults.Repo {
+		t.Errorf("defaults.repo: got %q, want %q", loaded.Defaults.Repo, original.Defaults.Repo)
+	}
+	if loaded.Defaults.Provider != original.Defaults.Provider {
+		t.Errorf("defaults.provider: got %q, want %q", loaded.Defaults.Provider, original.Defaults.Provider)
+	}
+	if loaded.Defaults.Model != original.Defaults.Model {
+		t.Errorf("defaults.model: got %q, want %q", loaded.Defaults.Model, original.Defaults.Model)
+	}
+	if loaded.Defaults.Timeout != original.Defaults.Timeout {
+		t.Errorf("defaults.timeout: got %q, want %q", loaded.Defaults.Timeout, original.Defaults.Timeout)
+	}
+	if loaded.Defaults.Budget != original.Defaults.Budget {
+		t.Errorf("defaults.budget: got %v, want %v", loaded.Defaults.Budget, original.Defaults.Budget)
+	}
+}
+
+func TestConfigPriorityFlagsOverrideConfig(t *testing.T) {
+	alcoveDir := setupConfigDir(t)
+
+	// Write config with a server value
+	configYAML := `server: https://config-server.example.com
+`
+	if err := os.WriteFile(filepath.Join(alcoveDir, "config.yaml"), []byte(configYAML), 0600); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	// Clear env to avoid interference
+	t.Setenv("ALCOVE_SERVER", "")
+
+	// Create a command with the server flag set
+	cmd := &cobra.Command{}
+	cmd.PersistentFlags().String("server", "", "")
+	cmd.PersistentFlags().String("output", "", "")
+	cmd.PersistentFlags().StringP("username", "u", "", "")
+	cmd.PersistentFlags().StringP("password", "p", "", "")
+	cmd.PersistentFlags().String("proxy-url", "", "")
+	cmd.PersistentFlags().String("no-proxy", "", "")
+	cmd.ParseFlags([]string{"--server", "https://flag-server.example.com"})
+
+	// resolveServer should pick up the flag value, not the config file value
+	server, err := resolveServer(cmd)
+	if err != nil {
+		t.Fatalf("resolveServer error: %v", err)
+	}
+	if server != "https://flag-server.example.com" {
+		t.Errorf("expected flag server %q, got %q", "https://flag-server.example.com", server)
+	}
+}
+
+func TestConfigPriorityEnvOverrideConfig(t *testing.T) {
+	alcoveDir := setupConfigDir(t)
+
+	// Write config with a server value
+	configYAML := `server: https://config-server.example.com
+`
+	if err := os.WriteFile(filepath.Join(alcoveDir, "config.yaml"), []byte(configYAML), 0600); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	// Set env var to override
+	t.Setenv("ALCOVE_SERVER", "https://env-server.example.com")
+
+	// Create a command with no flags set
+	cmd := &cobra.Command{}
+	cmd.PersistentFlags().String("server", "", "")
+	cmd.PersistentFlags().String("output", "", "")
+	cmd.PersistentFlags().StringP("username", "u", "", "")
+	cmd.PersistentFlags().StringP("password", "p", "", "")
+	cmd.PersistentFlags().String("proxy-url", "", "")
+	cmd.PersistentFlags().String("no-proxy", "", "")
+
+	// resolveServer should pick up the env var, not the config file value
+	server, err := resolveServer(cmd)
+	if err != nil {
+		t.Fatalf("resolveServer error: %v", err)
+	}
+	if server != "https://env-server.example.com" {
+		t.Errorf("expected env server %q, got %q", "https://env-server.example.com", server)
+	}
+}
+
+
+
+func TestLoadConfigNoFile(t *testing.T) {
+	setupConfigDir(t)
+
+	// Don't create any config file
+	_, err := loadConfig()
+	if err == nil {
+		t.Error("expected error when config file does not exist, got nil")
+	}
+}
+
+func TestSaveConfigCreatesDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Point to a subdir that doesn't exist yet (alcove dir not pre-created)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "nested", "dir"))
+
+	cfg := &CLIConfig{Server: "https://test.example.com"}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("saveConfig error: %v", err)
+	}
+
+	loaded, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig error after save: %v", err)
+	}
+	if loaded.Server != "https://test.example.com" {
+		t.Errorf("server: got %q, want %q", loaded.Server, "https://test.example.com")
+	}
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -77,9 +77,10 @@ supports both environment variables and command-line flags.
 
 ### Configuration Precedence
 
-1. CLI flags (`--proxy-url`, `--no-proxy`) — highest priority
+1. CLI flags (`--proxy-url`, `--no-proxy`) -- highest priority
 2. Environment variables (`HTTPS_PROXY`/`HTTP_PROXY`, `NO_PROXY`)
-3. No proxy (default)
+3. Config file (`~/.config/alcove/config.yaml`)
+4. No proxy (default)
 
 ### Proxy URL Format
 
@@ -140,6 +141,52 @@ The CLI resolves the Bridge server URL using the following precedence:
 3. Config file at `~/.config/alcove/config.yaml` (set by `alcove login`)
 
 If none are configured, commands that contact the Bridge will fail with an error.
+
+## Configuration File
+
+Alcove CLI reads configuration from `~/.config/alcove/config.yaml` (or
+`$XDG_CONFIG_HOME/alcove/config.yaml`). Settings in the config file are used as
+defaults when flags and environment variables are not set.
+
+### Example config.yaml
+
+```yaml
+server: https://alcove.example.com
+output: table
+username: myuser
+password: mypassword
+proxy_url: http://proxy.example.com:8080
+no_proxy: localhost,127.0.0.1,.internal.com
+defaults:
+  repo: https://github.com/myorg/myrepo.git
+  provider: google-vertex
+  model: claude-sonnet-4-20250514
+  timeout: 30m
+  budget: 5.00
+```
+
+### Priority Order (highest to lowest)
+
+1. CLI flags (e.g., `--server`, `--repo`)
+2. Environment variables (e.g., `ALCOVE_SERVER`, `ALCOVE_OUTPUT`)
+3. Config file (`~/.config/alcove/config.yaml`)
+4. Built-in defaults
+
+### Managing Configuration
+
+```bash
+# Show current configuration
+alcove config show
+
+# Set individual values
+alcove config set server https://alcove.example.com
+alcove config set defaults.repo https://github.com/myorg/myrepo.git
+alcove config set defaults.timeout 30m
+alcove config set defaults.budget 5.00
+
+# Validate configuration
+alcove config validate
+```
 
 ---
 
@@ -384,6 +431,94 @@ alcove login https://alcove.example.com
 
 # Log in to a local development Bridge
 alcove login http://localhost:8080
+```
+
+---
+
+## alcove config show
+
+Show the current configuration file contents.
+
+```
+alcove config show
+```
+
+### Flags
+
+No command-specific flags.
+
+### Description
+
+Displays the parsed contents of the config file at `~/.config/alcove/config.yaml`.
+If no config file exists, prints a message to stderr indicating the expected path.
+
+### Examples
+
+```bash
+# Show current config
+alcove config show
+```
+
+Sample output:
+
+```yaml
+server: https://alcove.example.com
+output: table
+defaults:
+  repo: https://github.com/myorg/myrepo.git
+  provider: google-vertex
+  timeout: 30m
+  budget: 5
+```
+
+---
+
+## alcove config set
+
+Set a configuration value.
+
+```
+alcove config set <key> <value>
+```
+
+### Flags
+
+No command-specific flags.
+
+### Description
+
+Sets a single configuration key in the config file. Creates the config file and
+directory if they don't exist. Valid keys:
+
+| Key | Description |
+|-----|-------------|
+| `server` | Bridge server URL |
+| `output` | Output format (`json` or `table`) |
+| `username` | Basic Auth username |
+| `password` | Basic Auth password |
+| `proxy_url` | HTTP/HTTPS proxy URL |
+| `no_proxy` | Comma-separated no-proxy hosts |
+| `defaults.repo` | Default repository |
+| `defaults.provider` | Default LLM provider |
+| `defaults.model` | Default model |
+| `defaults.timeout` | Default timeout (e.g., `30m`, `1h`) |
+| `defaults.budget` | Default budget in USD |
+
+### Examples
+
+```bash
+# Set the default server
+alcove config set server https://alcove.example.com
+
+# Set default repository and provider
+alcove config set defaults.repo https://github.com/myorg/myrepo.git
+alcove config set defaults.provider google-vertex
+
+# Set a budget limit
+alcove config set defaults.budget 5.00
+
+# Set a timeout
+alcove config set defaults.timeout 30m
 ```
 
 ---


### PR DESCRIPTION
Fixes #107

## Summary
Extend `~/.config/alcove/config.yaml` to persist default values for common CLI flags:
- `output`, `username`, `password`, `proxy_url`, `no_proxy`
- `defaults.repo`, `defaults.provider`, `defaults.model`, `defaults.timeout`, `defaults.budget`

### New commands
- `alcove config show` — display current config
- `alcove config set <key> <value>` — set a config value (11 supported keys)

### Priority order
1. CLI flags (highest)
2. Environment variables
3. Config file
4. Built-in defaults

### Tests
8 new tests: config loading (full, partial, empty), save/load round-trip, flag override, env override, missing file, directory creation.

## Test plan
- [x] `make build` && `make test` pass (12 CLI tests total)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)