### PR TITLE
Fix Gate to classify labels under read_issues/update_issue

### DIFF
--- a/internal/gate/proxy_test.go
+++ b/internal/gate/proxy_test.go
@@ -753,8 +753,10 @@ func TestGitHubOperationMapping(t *testing.T) {
 		{"POST", "actions/workflows/ci.yml/dispatches", "write_actions"},
 		{"GET", "releases", "read_releases"},
 		{"POST", "releases", "write_releases"},
-		{"GET", "labels", "read"},
+		{"GET", "labels", "read_issues"},
 		{"POST", "labels", "write"},
+		{"POST", "issues/42/labels", "update_issue"},
+		{"DELETE", "issues/42/labels/bug", "update_issue"},
 	}
 
 	for _, tt := range tests {

--- a/internal/gate/scope.go
+++ b/internal/gate/scope.go
@@ -142,7 +142,7 @@ func mapGitHubOperation(method, subpath string) string {
 	case strings.HasPrefix(normalized, "pulls/N") && method == "PATCH":
 		return "update_pr"
 
-	// Issues
+	// Issues and labels
 	case strings.HasPrefix(normalized, "issues") && method == "GET":
 		return "read_issues"
 	case normalized == "issues" && method == "POST":
@@ -151,6 +151,10 @@ func mapGitHubOperation(method, subpath string) string {
 		return "update_issue"
 	case strings.HasPrefix(normalized, "issues/N/comments") && method == "POST":
 		return "create_comment"
+	case strings.HasPrefix(normalized, "issues/N/labels") && (method == "POST" || method == "DELETE"):
+		return "update_issue"
+	case strings.HasPrefix(normalized, "labels") && method == "GET":
+		return "read_issues"
 
 	// Contents / files
 	case strings.HasPrefix(normalized, "contents") && method == "GET":


### PR DESCRIPTION
## Summary
Labels endpoints were falling through to default `read`/`write` operations in Gate scope classification, causing the reviewer agent to get 403 when trying to list or modify labels. Now:
- `GET /labels` → `read_issues`
- `POST /issues/N/labels` → `update_issue`
- `DELETE /issues/N/labels/name` → `update_issue`

## Root cause
Reviewer proxy log showed `deny GET read 403 /repos/bmbouter/alcove/labels` — the `read` operation isn't in the reviewer profile, but `read_issues` is.

## Test plan
- [x] `make build` && `make test` pass (updated gate operation mapping tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)