### PR TITLE
Rename Tasks to Agents/Sessions across entire codebase

### DIFF
--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -8,7 +8,7 @@ prompt: |
   A GitHub event just occurred — an issue was opened/reopened, or someone
   commented on an issue with new instructions.
 
-  The "ready-for-dev" label is enforced at the trigger level — this task
+  The "ready-for-dev" label is enforced at the trigger level — this agent
   only fires for issues that already have the label.
 
   ## Environment
@@ -61,7 +61,7 @@ prompt: |
 
   Based on the issue, determine what needs to change. Alcove is a Go project
   with these components:
-  - Bridge (cmd/bridge, internal/bridge) — REST API, scheduler, task sync
+  - Bridge (cmd/bridge, internal/bridge) — REST API, scheduler, agent sync
   - Gate (cmd/gate, internal/gate) — auth proxy sidecar
   - Skiff (cmd/skiff-init) — ephemeral worker container
   - Dashboard (web/) — HTML/JS/CSS single-page app
@@ -70,7 +70,7 @@ prompt: |
   - Config (deploy/) — OpenShift/k8s templates
 
   Consider ALL affected areas: Go code, API, dashboard UI, documentation,
-  functional tests, YAML task/profile definitions.
+  functional tests, YAML agent/profile definitions.
 
   ### Risk assessment for changes you cannot validate locally
 

--- a/.alcove/tasks/planning.yml
+++ b/.alcove/tasks/planning.yml
@@ -7,7 +7,7 @@ prompt: |
   You are a planning coordinator for the Alcove project (bmbouter/alcove).
   An issue has been labeled "needs-planning" and needs an implementation plan.
 
-  The "needs-planning" label is enforced at the trigger level — this task
+  The "needs-planning" label is enforced at the trigger level — this agent
   only fires for issues that already have the label.
 
   ## Environment

--- a/.alcove/tasks/release.yml
+++ b/.alcove/tasks/release.yml
@@ -7,7 +7,7 @@ prompt: |
   You are an automated release agent for the Alcove project (bmbouter/alcove).
   Your job is to create releases automatically when there are unreleased commits on main.
 
-  This task can be triggered in two ways:
+  This agent can be triggered in two ways:
   1. **Scheduled**: Runs daily to check for unreleased commits and create releases
   2. **Manual**: Triggered by issues labeled with "immediate-release"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,8 +181,8 @@ jobs:
       - name: Test schedules
         run: ADMIN_PASSWORD=admin ./scripts/test-schedules.sh
 
-      - name: Test task repos
-        run: ADMIN_PASSWORD=admin ./scripts/test-task-repos.sh
+      - name: Test agent repos
+        run: ADMIN_PASSWORD=admin ./scripts/test-agent-repos.sh
 
       - name: Test user isolation
         run: ADMIN_PASSWORD=admin ./scripts/test-user-isolation.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 ## What This Is
 
 Alcove runs AI coding agents (Claude Code) in ephemeral, network-isolated
-containers. Each task gets a fresh container, a scoped authorization proxy, and
-a complete session transcript. No persistent state crosses task boundaries.
+containers. Each session gets a fresh container, a scoped authorization proxy, and
+a complete session transcript. No persistent state crosses session boundaries.
 
 **Language:** Go 1.25 | **License:** Apache-2.0
 
@@ -12,7 +12,7 @@ a complete session transcript. No persistent state crosses task boundaries.
 
 | Name | Role | Binary | k8s Resource |
 |------|------|--------|-------------|
-| **Bridge** | Controller, REST API, dashboard, scheduler | `cmd/bridge` | Deployment |
+| **Bridge** | Controller, REST API, dashboard, scheduler, agent repo syncer | `cmd/bridge` | Deployment |
 | **Skiff** | Ephemeral Claude Code worker | `cmd/skiff-init` | Job / `podman run --rm` / `docker run --rm` |
 | **Gate** | Auth proxy sidecar (token swap, LLM proxy, SCM proxy, scope enforcement) | `cmd/gate` | Sidecar in Skiff pod |
 | **Hail** | Message bus (NATS) | external | Deployment |
@@ -25,7 +25,7 @@ Bridge → Hail (NATS) → Skiff Pod [skiff container + gate sidecar] → Gate �
                                                                   → Ledger (PostgreSQL)
 ```
 
-- Skiff pods are ephemeral: one task, one container, then destroyed
+- Skiff pods are ephemeral: one session, one container, then destroyed
 - Gate is a sidecar (shares network namespace with Skiff)
 - Gate proxies ALL external traffic including LLM API calls (Skiff has no real credentials)
 - NetworkPolicy enforces this on OpenShift; dual-network isolation (`--internal` flag) on podman; no network isolation on Docker (see Key Decisions)
@@ -91,8 +91,8 @@ RUNTIME=docker \
 - **Gate is a sidecar** per Skiff pod (not shared service) — credential isolation
 - **No MITM TLS** — protocol-level interception (HTTP_PROXY, git credential helpers)
 - **LLM keys never enter Skiff** — Gate proxies LLM API calls, injects keys; Gate also translates Anthropic API format to Vertex AI format when using Vertex AI (`GATE_VERTEX_PROJECT`, `GATE_VERTEX_REGION`)
-- **Fresh git clone per task** — `git clone --depth=1`, no persistent volumes
-- **NATS for messaging** — status updates and cancellation only (task config via env vars)
+- **Fresh git clone per session** — `git clone --depth=1`, no persistent volumes
+- **NATS for messaging** — status updates and cancellation only (session config via env vars)
 - **PostgreSQL only** for Ledger (no S3 in Phase 1)
 - **Podman, Docker + k8s** triple runtime via `Runtime` interface in `internal/runtime/` — Docker is for environments where Podman is unavailable (e.g., NAS devices, some CI systems); network isolation is reduced with Docker (no `--internal` flag support), so Skiff containers can reach the internet directly; credential security is maintained (dummy tokens, Gate injection), but adversarial prompt injection could bypass Gate; acceptable for personal/trusted deployments, use Podman or Kubernetes for production/shared deployments
 - **Credential management via Bridge** — Bridge pre-fetches OAuth2 tokens, Gate receives only short-lived tokens

--- a/cmd/alcove/main.go
+++ b/cmd/alcove/main.go
@@ -66,7 +66,7 @@ func main() {
 	root := &cobra.Command{
 		Use:           "alcove",
 		Short:         "Alcove — sandboxed AI coding agents",
-		Long:          "Alcove CLI for dispatching and managing AI coding tasks via the Bridge API.",
+		Long:          "Alcove CLI for dispatching and managing AI coding sessions via the Bridge API.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -440,8 +440,8 @@ func isJSONOutput(cmd *cobra.Command) bool {
 func newRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run [prompt]",
-		Short: "Submit a task to the Bridge",
-		Long:  "Dispatch a coding task. By default returns the session ID immediately. Use --watch for live streaming.",
+		Short: "Submit a new session to the Bridge",
+		Long:  "Dispatch a coding session. By default returns the session ID immediately. Use --watch for live streaming.",
 		Args:  cobra.ExactArgs(1),
 		RunE:  runRun,
 	}
@@ -449,7 +449,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().String("provider", "", "LLM provider name")
 	cmd.Flags().String("model", "", "Model override (e.g., claude-sonnet-4-20250514)")
 	cmd.Flags().Float64("budget", 0, "Budget limit in USD (e.g., 5.00)")
-	cmd.Flags().Duration("timeout", 0, "Task timeout (e.g., 30m, 1h)")
+	cmd.Flags().Duration("timeout", 0, "Session timeout (e.g., 30m, 1h)")
 	cmd.Flags().Bool("watch", false, "Stream transcript via SSE after dispatch")
 	cmd.Flags().Bool("debug", false, "Keep containers after exit for log inspection")
 	return cmd
@@ -504,7 +504,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	resp, err := apiRequest(cmd, http.MethodPost, "/api/v1/tasks", reqBody)
+	resp, err := apiRequest(cmd, http.MethodPost, "/api/v1/sessions", reqBody)
 	if err != nil {
 		return err
 	}

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -178,19 +178,19 @@ func main() {
 		log.Fatalf("subscribing to status updates: %v", err)
 	}
 
-	// Create task definition store.
-	defStore := bridge.NewTaskDefStore(dbpool)
+	// Create agent definition store.
+	defStore := bridge.NewAgentDefStore(dbpool)
 
 	// Create and start the scheduler.
 	scheduler := bridge.NewScheduler(dbpool, dispatcher, cfg, credStore, defStore)
 	scheduler.Start(context.Background())
 	defer scheduler.Stop()
 
-	// Create repo syncer.
-	syncer := bridge.NewTaskRepoSyncer(dbpool, settingsStore, scheduler, defStore, dispatcher, profileStore)
+	// Create agent repo syncer.
+	syncer := bridge.NewAgentRepoSyncer(dbpool, settingsStore, scheduler, defStore, dispatcher, profileStore)
 	syncer.Start(context.Background())
 	defer syncer.Stop()
-	log.Println("task repo syncer started")
+	log.Println("agent repo syncer started")
 
 	api := bridge.NewAPI(dispatcher, dbpool, cfg, scheduler, credStore, toolStore, profileStore, settingsStore, bridgeLLM, defStore, syncer, store)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -170,11 +170,11 @@ curl -X DELETE http://localhost:8080/api/v1/auth/tbr-associations/550e8400-e29b-
 
 ---
 
-## Tasks
+## Sessions (Start)
 
 ### POST /api/v1/tasks
 
-Submit a new task for execution. Bridge creates a session, dispatches the task to a Skiff pod, and returns the session record.
+Start a new session for execution. Bridge creates a session, dispatches it to a Skiff pod, and returns the session record.
 
 The submitter is read from the `X-Alcove-User` header (set automatically by the auth middleware). If absent, defaults to `"anonymous"`.
 
@@ -206,12 +206,12 @@ The submitter is read from the `X-Alcove-User` header (set automatically by the 
 
 | Field       | Type   | Required | Default          | Description |
 |-------------|--------|----------|------------------|-------------|
-| `prompt`    | string | yes      |                  | The task instruction for Claude Code |
+| `prompt`    | string | yes      |                  | The instruction for Claude Code |
 | `repo`      | string | no       |                  | Git repository URL to clone |
 | `provider`  | string | no       | first configured | LLM provider name |
 | `model`     | string | no       | provider default | Model override |
-| `timeout`   | int    | no       | 3600             | Task timeout in seconds |
-| `budget_usd`| float  | no       |                  | Maximum spend for this task |
+| `timeout`   | int    | no       | 3600             | Session timeout in seconds |
+| `budget_usd`| float  | no       |                  | Maximum spend for this session |
 | `debug`     | bool   | no       | false            | Enable debug mode |
 | `scope`     | object | no       | empty (no access)| Authorized external operations |
 
@@ -242,7 +242,7 @@ The submitter is read from the `X-Alcove-User` header (set automatically by the 
 
 | Code | Meaning |
 |------|---------|
-| 201  | Task dispatched, session created |
+| 201  | Session dispatched and created |
 | 400  | Invalid body or missing `prompt` |
 | 401  | Missing or invalid token |
 | 500  | Dispatch failed |
@@ -1459,16 +1459,16 @@ curl -X DELETE http://localhost:8080/api/v1/tools/my-tool \
 
 ## Security
 
-Manage security profiles that define per-tool access rules for tasks. YAML-sourced profiles are read-only and cannot be modified or deleted.
+Manage security profiles that define per-tool access rules for sessions. YAML-sourced profiles are read-only and cannot be modified or deleted.
 
 Each profile includes a `source` field indicating its origin:
 
 | Source    | Description |
 |-----------|-------------|
 | `user`    | Created via the API or dashboard |
-| `yaml`    | Loaded from a `.alcove/security-profiles/*.yml` file in a task repo |
+| `yaml`    | Loaded from a `.alcove/security-profiles/*.yml` file in an agent repo |
 
-YAML-sourced profiles also include `source_repo` (the task repo URL) and
+YAML-sourced profiles also include `source_repo` (the agent repo URL) and
 `source_key` (the file path within the repo, e.g.
 `.alcove/security-profiles/my-profile.yml`).
 
@@ -1796,13 +1796,13 @@ Both system-wide and per-user skill repos are merged at dispatch time and passed
 
 ---
 
-## Task Repos
+## Agent Repos
 
-Configure git repositories containing YAML task definitions (`.alcove/tasks/*.yml`). Task repos are synced automatically every 5 minutes.
+Configure git repositories containing YAML agent definitions (`.alcove/tasks/*.yml`). Agent repos are synced automatically every 5 minutes.
 
 ### GET /api/v1/admin/settings/task-repos
 
-Get the system-wide task repos (admin only).
+Get the system-wide agent repos (admin only).
 
 **Response (200):**
 
@@ -1812,7 +1812,7 @@ Get the system-wide task repos (admin only).
     {
       "url": "https://github.com/org/task-definitions.git",
       "ref": "main",
-      "name": "Org Tasks"
+      "name": "Org Agents"
     }
   ]
 }
@@ -1820,27 +1820,27 @@ Get the system-wide task repos (admin only).
 
 ### PUT /api/v1/admin/settings/task-repos
 
-Set the system-wide task repos (admin only). Replaces the entire list.
+Set the system-wide agent repos (admin only). Replaces the entire list.
 
 **Request/Response:** same shape as skill repos.
 
 ### GET /api/v1/user/settings/task-repos
 
-Get the current user's personal task repos.
+Get the current user's personal agent repos.
 
 ### PUT /api/v1/user/settings/task-repos
 
-Set the current user's personal task repos.
+Set the current user's personal agent repos.
 
 ---
 
-## Task Definitions
+## Agent Definitions
 
-Task definitions are YAML files discovered from registered task repos. They define reusable, parameterized tasks.
+Agent definitions are YAML files discovered from registered agent repos. They define reusable, parameterized agents.
 
 ### GET /api/v1/task-definitions
 
-List all task definitions from synced task repos.
+List all agent definitions from synced agent repos.
 
 **Response (200):**
 
@@ -1867,17 +1867,17 @@ List all task definitions from synced task repos.
 
 ### GET /api/v1/task-definitions/{name}
 
-Get a single task definition by name.
+Get a single agent definition by name.
 
 ### POST /api/v1/task-definitions/{name}/run
 
-Run a task definition immediately as a new task. Returns the created session.
+Run an agent definition immediately as a new session. Returns the created session.
 
 **Response (201):** same shape as `POST /api/v1/tasks`.
 
 ### POST /api/v1/task-definitions/sync
 
-Trigger an immediate sync of all task repos (normally happens every 5 minutes).
+Trigger an immediate sync of all agent repos (normally happens every 5 minutes).
 
 **Response (200):**
 
@@ -1889,7 +1889,7 @@ Trigger an immediate sync of all task repos (normally happens every 5 minutes).
 
 ### Event Trigger Delivery Modes
 
-Task definitions with event triggers (e.g., GitHub `issues.opened`) support two delivery modes via the `delivery_mode` field in the trigger configuration:
+Agent definitions with event triggers (e.g., GitHub `issues.opened`) support two delivery modes via the `delivery_mode` field in the trigger configuration:
 
 - **`polling`** (default) — Alcove polls the GitHub Events API every 60 seconds. No webhook setup required. Suitable for local development and environments without a public URL.
 - **`webhook`** — GitHub pushes events to `POST /api/v1/webhooks/github`. Requires a publicly accessible Bridge URL and a configured webhook secret.
@@ -1913,7 +1913,7 @@ See [Configuration Reference](configuration.md#label-based-trigger-filtering) fo
 
 ### Event Trigger User Filtering
 
-The trigger configuration supports an optional `users` field (string array). When specified, the event is only dispatched if the user who authored the comment or issue matches at least one of the listed GitHub usernames (case-insensitive). This prevents automated agents' own comments from re-triggering tasks and limits dispatch to trusted users.
+The trigger configuration supports an optional `users` field (string array). When specified, the event is only dispatched if the user who authored the comment or issue matches at least one of the listed GitHub usernames (case-insensitive). This prevents automated agents' own comments from re-triggering sessions and limits dispatch to trusted users.
 
 ```yaml
 trigger:
@@ -1931,9 +1931,9 @@ See [Configuration Reference](configuration.md#user-based-trigger-filtering) for
 
 ---
 
-## Task Templates
+## Agent Templates
 
-Starter templates for creating task definitions.
+Starter templates for creating agent definitions.
 
 ### GET /api/v1/task-templates
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@ All notable changes to Alcove are documented here. This project uses
 
 ### Features
 - Add CI Gate: Bridge-driven CI retry loop for autonomous developer tasks.
-  When a task definition includes `ci_gate`, Bridge monitors CI status on PRs
+  When a agent definition includes `ci_gate`, Bridge monitors CI status on PRs
   created by the task and automatically dispatches fresh retry agents on failure,
   using the system LLM to analyze failure logs and compose targeted fix prompts.
 - Add Go 1.25 toolchain to Skiff base image. Autonomous agents can now run
@@ -27,8 +27,8 @@ All notable changes to Alcove are documented here. This project uses
 ## v0.9.0
 
 ### Features
-- Add enable/disable toggle for task repos. When multiple Alcove instances
-  share the same task repo, disable it on one instance to prevent both
+- Add enable/disable toggle for agent repos. When multiple Alcove instances
+  share the same agent repo, disable it on one instance to prevent both
   from competing for the same events. Toggle via checkbox in the Repos page.
 
 ### Bug Fixes
@@ -67,7 +67,7 @@ All notable changes to Alcove are documented here. This project uses
 - PR reviewer agent now self-assigns as reviewer on PRs it reviews.
 
 ### Bug Fixes
-- Fix duplicate task dispatches when GitHub fires multiple events for the
+- Fix duplicate session dispatches when GitHub fires multiple events for the
   same issue (e.g., opened + labeled). Poller now deduplicates by issue/PR
   number within a single poll cycle.
 - Add missing `create_review` operation to alcove-reviewer security profile.
@@ -92,7 +92,7 @@ All notable changes to Alcove are documented here. This project uses
 
 ### Bug Fixes
 - Fix event metadata not reaching tasks. The poller was appending event
-  context (issue number, PR number, etc.) to the database after the task
+  context (issue number, PR number, etc.) to the database after the session
   container had already launched. Metadata is now included in the prompt
   before dispatch.
 - Fix label-on-ci-pass workflow permissions (needs `issues: write`).
@@ -100,7 +100,7 @@ All notable changes to Alcove are documented here. This project uses
 ## v0.5.0
 
 ### Features
-- Add automated release agent task definition. Runs daily at 6 AM UTC
+- Add automated release agent agent definition. Runs daily at 6 AM UTC
   and on-demand via `immediate-release` label. Handles changelog generation,
   PR creation, CI monitoring, tagging, and release build verification.
 - Improve transcript readability with collapsible sections and visual
@@ -111,7 +111,7 @@ All notable changes to Alcove are documented here. This project uses
 - Fix event metadata to include GITHUB_ISSUE_NUMBER for issue events,
   enabling event-triggered tasks to identify the correct issue.
 - Add `labeled` action to autonomous-dev trigger. Previously, adding
-  the `ready-for-dev` label didn't trigger the task.
+  the `ready-for-dev` label didn't trigger the agent.
 
 ### Improvements
 - Revise automated release agent trigger configuration: daily cron
@@ -232,32 +232,32 @@ All notable changes to Alcove are documented here. This project uses
   and includes full URL and response body on POST failures.
 
 ### Features
-- Add autonomous developer task definition and alcove-developer security profile
+- Add autonomous developer agent definition and alcove-developer security profile
   for fully autonomous software development lifecycle.
 
 ## v0.4.0
 
 ### Features
 - **YAML security profiles**: Define security profiles in `.alcove/security-profiles/*.yml`
-  alongside task definitions. Synced from task repos, read-only in UI, with profile
-  validation on task definitions (sync errors block dispatch).
+  alongside agent definitions. Synced from agent repos, read-only in UI, with profile
+  validation on agent definitions (sync errors block dispatch).
 - **GitHub event polling**: Poll GitHub Events API every 60 seconds for event-triggered
   tasks. Works in local dev without webhooks. Supports ETag conditional requests,
   deduplication, and per-user credentials.
-- **Per-user resource ownership**: All resources (task definitions, schedules, security
+- **Per-user resource ownership**: All resources (agent definitions, schedules, security
   profiles, sessions) are owned by real users. Removed `_system` submitter concept.
   Strict user isolation across all pages.
-- **Repos page**: New top-level nav tab for managing Task Repos and Skill / Agent Repos
+- **Repos page**: New top-level nav tab for managing Agent Repos and Skill / Agent Repos
   (moved from dropdown menu).
 - **Proxy log filtering and sorting**: Clickable column headers for sorting, dropdown
   filters for Service and Decision, summary counts.
-- **Task definition cards**: Show security profiles, schedule with next/last run times,
+- **Agent definition cards**: Show security profiles, schedule with next/last run times,
   event triggers, and sync errors with disabled Run button.
 - **PR review template**: New starter template for event-triggered PR reviews.
 
 ### UI/UX Improvements
 - Renamed Profiles section to Security, Sessions to Tasks in dashboard.
-- Unified Schedules page (task definitions + manual schedules in one list).
+- Unified Schedules page (agent definitions + manual schedules in one list).
 - Unified Security page (all profiles in one list, no section separators).
 - Session pagination (15 per page) with relative timestamp "When" column.
 - New Task tab moved to leftmost nav position, admin tabs right-aligned.
@@ -267,22 +267,22 @@ All notable changes to Alcove are documented here. This project uses
 
 ### Backend Changes
 - Removed builtin security profiles (replaced by YAML-defined profiles from repos).
-- Removed system task repos (all repos are per-user).
+- Removed system agent repos (all repos are per-user).
 - Added `GH_PROTOCOL=http` for gh CLI through Gate proxy.
 - Migration 014: YAML profile source tracking columns.
-- Migration 015: Task definition owner column with per-user source keys.
+- Migration 015: Agent definition owner column with per-user source keys.
 - Migration 016: GitHub poll state table for ETag and event ID tracking.
 
 ### Bug Fixes
 - Fix proxy log: gateEnvVars built before URL resolution.
 - Fix SyncAll cleanup for users with empty repo list.
-- Fix profile validation setting empty owner on task definitions.
+- Fix profile validation setting empty owner on agent definitions.
 - Fix `notsecret` annotations on test credentials.
 
 ### CI/CD
 - Added functional tests to CI (70+ API tests across 5 scripts).
 - Added `go vet` to release workflow.
-- Test scripts use per-user task repos endpoint.
+- Test scripts use per-user agent repos endpoint.
 
 ## v0.3.10
 
@@ -483,9 +483,9 @@ All notable changes to Alcove are documented here. This project uses
 - OpenShift deployment template and app-interface configuration for staging
 - Resource requests/limits on dynamically created Job pods
 
-### YAML Task Definitions
+### YAML Agent Definitions
 - Define reusable tasks in `.alcove/tasks/*.yml` files in git repos
-- Register task repos (system-wide or per-user) via API and dashboard
+- Register agent repos (system-wide or per-user) via API and dashboard
 - Auto-sync every 5 minutes with schedule reconciliation
 - Starter templates: dependency audit, code review, test coverage analysis
 - Run Now and View YAML from the dashboard
@@ -496,7 +496,7 @@ All notable changes to Alcove are documented here. This project uses
 - HMAC-SHA256 webhook signature validation
 - Idempotent delivery tracking via X-GitHub-Delivery header
 - Configurable per-schedule: event filters by repo, branch, and action
-- YAML trigger configuration in task definitions
+- YAML trigger configuration in agent definitions
 - Webhook setup modal in dashboard with secret generation
 
 ### Skill/Agent Repos
@@ -510,8 +510,8 @@ All notable changes to Alcove are documented here. This project uses
 - System LLM shown as read-only status in dashboard (configured via
   alcove.yaml only); shows guidance to edit alcove.yaml if not configured
 - SCM options (GitHub/GitLab/Jira) filtered out of the system LLM provider dropdown
-- Task Definitions section on Schedules page with source badges
-- Skill / Agent Repos and Task Repos configuration modals
+- Agent Definitions section on Schedules page with source badges
+- Skill / Agent Repos and Agent Repos configuration modals
 - Webhook configuration modal with setup instructions
 - Trigger type selector (cron, event, both) on schedule form
 
@@ -539,10 +539,10 @@ All notable changes to Alcove are documented here. This project uses
 - Strip trailing hyphens from job names after truncation
 
 ### Documentation
-- API reference: added Tools, Profiles, Admin Settings, Skill / Agent Repos, Task Repos,
-  Task Definitions, Task Templates, Webhook endpoints
+- API reference: added Tools, Profiles, Admin Settings, Skill / Agent Repos, Agent Repos,
+  Agent Definitions, Agent Templates, Webhook endpoints
 - CLI reference: added --model and --budget flags
-- Configuration guide: alcove.yaml format, Kubernetes secrets, skill/task repos
+- Configuration guide: alcove.yaml format, Kubernetes secrets, skill/agent repos
 - Implementation status updated for all new features
 - Test script documentation headers added
 - CONTRIBUTING.md created
@@ -553,14 +553,14 @@ All notable changes to Alcove are documented here. This project uses
 Initial release. Sandboxed AI coding agents on OpenShift/Kubernetes.
 
 ### Core Components
-- **Bridge**: Controller with REST API, web dashboard, and task scheduler
+- **Bridge**: Controller with REST API, web dashboard, and session scheduler
 - **Skiff**: Ephemeral Claude Code worker containers
 - **Gate**: Auth proxy sidecar (LLM API proxy, SCM proxy, scope enforcement)
 - **Hail**: NATS message bus for status updates and real-time streaming
 - **Ledger**: PostgreSQL session store with transcripts and audit trails
 
 ### Features
-- Ephemeral container execution: one task, one container, then destroy
+- Ephemeral container execution: one session, one container, then destroy
 - Podman dual-network isolation (internal + external) with Gate as bridge
 - Credential management with AES-256-GCM encryption at rest
 - OAuth2 token acquisition for Anthropic and Google Vertex AI

--- a/docs/cli-installation.md
+++ b/docs/cli-installation.md
@@ -192,7 +192,7 @@ Once installed, you can start using the CLI:
 
 ### Basic Usage
 
-1. **Submit a task:**
+1. **Start a session:**
    ```bash
    alcove run "Fix the bug in the authentication module"
    ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # Alcove CLI Reference
 
-The `alcove` CLI dispatches and manages AI coding tasks via the Bridge API.
+The `alcove` CLI dispatches and manages AI coding sessions via the Bridge API.
 
 ```
 alcove [command] [flags]
@@ -249,7 +249,7 @@ alcove config validate
 
 ## alcove run
 
-Submit a coding task to the Bridge for execution in an ephemeral Skiff container.
+Start a coding session on the Bridge for execution in an ephemeral Skiff container.
 
 ```
 alcove run [prompt] [flags]
@@ -263,20 +263,20 @@ alcove run [prompt] [flags]
 | `--provider` | string | LLM provider name |
 | `--model` | string | Model override (e.g., `claude-sonnet-4-20250514`) |
 | `--budget` | float | Budget limit in USD (e.g., `5.00`) |
-| `--timeout` | duration | Task timeout (e.g., `30m`, `1h`) |
+| `--timeout` | duration | Session timeout (e.g., `30m`, `1h`) |
 | `--watch` | bool | Stream the session transcript via SSE after dispatch |
 | `--debug` | bool | Keep containers after exit for log inspection |
 
 ### Description
 
-Dispatches a task to the Bridge, which creates a session and launches a Skiff
+Starts a session on the Bridge, which launches a Skiff
 container. By default, the command prints the session ID and exits immediately.
 With `--watch`, it streams the live transcript until the session completes.
 
 ### Examples
 
 ```bash
-# Submit a task and get the session ID
+# Start a session and get the session ID
 alcove run "Fix the failing test in pkg/auth"
 
 # Submit and stream the transcript live

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,7 @@ can also be set in `alcove.yaml` (see [alcove.yaml](#alcoveyaml) above).
 | `BRIDGE_URL` | string | `http://alcove-bridge:<port>` | URL where Bridge can be reached by Skiff/Gate containers. |
 | `SKIFF_HAIL_URL` | string | `nats://alcove-hail:4222` | NATS URL injected into Skiff containers (may differ from Bridge's own `HAIL_URL`). |
 | `ALCOVE_SKILL_REPOS` | string (JSON) | _(unset)_ | JSON array of skill repo objects. Overrides database-configured skill repos. Each object has `url` (required), `ref` (optional, default `main`), and `name` (optional). |
-| `TASK_REPO_SYNC_INTERVAL` | string (duration) | `5m` | How often Bridge syncs YAML task definitions from registered task repos. Accepts Go duration syntax. |
+| `TASK_REPO_SYNC_INTERVAL` | string (duration) | `5m` | How often Bridge syncs YAML agent definitions from registered agent repos. Accepts Go duration syntax. |
 | `BRIDGE_LLM_PROVIDER` | string | _(unset)_ | System LLM provider: `anthropic` or `google-vertex`. Overrides `llm_provider` in alcove.yaml. |
 | `BRIDGE_LLM_API_KEY` | string | _(unset)_ | Anthropic API key for the system LLM. Overrides `llm_api_key` in alcove.yaml. |
 | `BRIDGE_LLM_MODEL` | string | _(unset)_ | Model name for the system LLM. Overrides `llm_model` in alcove.yaml. |
@@ -412,19 +412,19 @@ provide a default list without using the database.
 
 ---
 
-## Task Repos and Task Definitions
+## Agent Repos and Agent Definitions
 
-Task repos are git repositories containing YAML task definitions in
+Agent repos are git repositories containing YAML agent definitions in
 `.alcove/tasks/*.yml`. They allow teams to define reusable, version-controlled
-tasks that appear in the dashboard.
+agents that appear in the dashboard.
 
-Configure task repos in the dashboard or via the API:
+Configure agent repos in the dashboard or via the API:
 
 - **System-wide (admin):** `GET/PUT /api/v1/admin/settings/task-repos`
 - **Per-user:** `GET/PUT /api/v1/user/settings/task-repos`
 
-Bridge syncs task repos automatically every 5 minutes (configurable via
-`TASK_REPO_SYNC_INTERVAL`). Each YAML file defines a task:
+Bridge syncs agent repos automatically every 5 minutes (configurable via
+`TASK_REPO_SYNC_INTERVAL`). Each YAML file defines an agent:
 
 ```yaml
 name: run-tests
@@ -444,8 +444,8 @@ schedule: "0 2 * * *"
 
 | Field       | Type     | Required | Description |
 |-------------|----------|----------|-------------|
-| `name`      | string   | yes      | Unique task name |
-| `prompt`    | string   | yes      | The task instruction |
+| `name`      | string   | yes      | Unique agent name |
+| `prompt`    | string   | yes      | The agent instruction |
 | `repo`      | string   | no       | Git repository URL to clone |
 | `provider`  | string   | no       | LLM provider name |
 | `model`     | string   | no       | Model override |
@@ -459,7 +459,7 @@ schedule: "0 2 * * *"
 
 ### Event Delivery Mode
 
-Task definitions with event triggers support two delivery modes:
+Agent definitions with event triggers support two delivery modes:
 
 - **`polling`** (default) — Alcove polls the GitHub Events API every 60 seconds for new events. Works in any environment including local development. No GitHub webhook configuration required.
 - **`webhook`** — GitHub pushes events to Alcove's webhook endpoint (`/api/v1/webhooks/github`). Requires a publicly accessible URL and webhook secret configuration.
@@ -475,7 +475,7 @@ trigger:
     delivery_mode: polling
 ```
 
-Polling uses GitHub's conditional request support (ETags) to minimize API usage. On first poll, existing events are skipped to avoid a flood of retroactive task dispatches.
+Polling uses GitHub's conditional request support (ETags) to minimize API usage. On first poll, existing events are skipped to avoid a flood of retroactive session dispatches.
 
 ### Label-Based Trigger Filtering
 
@@ -505,8 +505,8 @@ of labels on the issue or PR.
 The `users` field provides a safety gate for event triggers. When specified,
 an event is only dispatched if the user who authored the comment or issue
 matches at least one of the listed GitHub usernames (case-insensitive). This
-prevents automated agents' own comments from re-triggering tasks and limits
-task dispatch to trusted users.
+prevents automated agents' own comments from re-triggering sessions and limits
+session dispatch to trusted users.
 
 ```yaml
 name: auto-fix
@@ -525,7 +525,7 @@ trigger:
 If `users` is omitted or empty, all matching events are dispatched regardless
 of the event author.
 
-Task definitions appear in the dashboard where users can run them directly or
+Agent definitions appear in the dashboard where users can run them directly or
 view the source YAML. Starter templates are also available via
 `GET /api/v1/task-templates`.
 
@@ -533,9 +533,9 @@ view the source YAML. Starter templates are also available via
 
 ## YAML Security Profiles
 
-Security profiles can also be defined in YAML files inside task repos,
-alongside task definitions. Profile files live in `.alcove/security-profiles/*.yml`
-(parallel to `.alcove/tasks/`) and are synced from the same registered task repos.
+Security profiles can also be defined in YAML files inside agent repos,
+alongside agent definitions. Profile files live in `.alcove/security-profiles/*.yml`
+(parallel to `.alcove/tasks/`) and are synced from the same registered agent repos.
 
 ### Format
 
@@ -567,10 +567,10 @@ security profiles (see [API Reference](api-reference.md#security)).
 - YAML security profiles are **read-only** in the dashboard and API. They
   cannot be modified or deleted through the UI.
 - Profile names from YAML take precedence alongside user-created profiles.
-- Task definitions can reference YAML-defined profiles in their `profiles`
-  field. If a task definition references a profile name that does not exist
+- Agent definitions can reference YAML-defined profiles in their `profiles`
+  field. If an agent definition references a profile name that does not exist
   (as a user-created or YAML profile), a sync error is reported.
-- YAML profiles are synced on the same interval as task definitions
+- YAML profiles are synced on the same interval as agent definitions
   (configurable via `TASK_REPO_SYNC_INTERVAL`, default 5 minutes).
 
 ---

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -8,33 +8,33 @@ its columns, and the migration system that manages the schema.
 
 | Table | Purpose |
 |-------|---------|
-| `sessions` | Records of Skiff task executions (prompts, transcripts, outcomes) |
+| `sessions` | Records of Skiff session executions (prompts, transcripts, outcomes) |
 | `provider_credentials` | Encrypted LLM provider credentials (API keys, service account tokens) |
 | `auth_users` | Local user accounts for Bridge authentication |
 | `auth_sessions` | Active login sessions (bearer tokens) |
-| `schedules` | Recurring task definitions (cron-based) |
+| `schedules` | Recurring agent definitions (cron-based) |
 | `schema_migrations` | Tracks which migrations have been applied (auto-created) |
 
 ## sessions
 
-Stores one row per Skiff task execution. This is the primary audit trail for
+Stores one row per Skiff session execution. This is the primary audit trail for
 all agent activity.
 
 | Column | Type | Constraints | Notes |
 |--------|------|-------------|-------|
 | `id` | `UUID` | `PRIMARY KEY` | Session identifier, generated at dispatch time |
 | `task_id` | `UUID` | `NOT NULL` | Logical task ID (may differ from session ID for retries) |
-| `submitter` | `TEXT` | `NOT NULL` | Username of the person or system that submitted the task |
+| `submitter` | `TEXT` | `NOT NULL` | Username of the person or system that started the session |
 | `prompt` | `TEXT` | `NOT NULL` | The natural-language prompt sent to the agent |
-| `scope` | `JSONB` | `NOT NULL DEFAULT '{}'` | Scope definition controlling what services/operations the agent may access |
+| `scope` | `JSONB` | `NOT NULL DEFAULT '{}'` | Scope definition controlling what services/operations the session may access |
 | `provider` | `TEXT` | `NOT NULL` | LLM provider used (e.g., `anthropic`, `google-vertex`) |
 | `started_at` | `TIMESTAMPTZ` | `NOT NULL` | When the Skiff pod was created |
-| `finished_at` | `TIMESTAMPTZ` | nullable | When the task completed (null while running) |
+| `finished_at` | `TIMESTAMPTZ` | nullable | When the session completed (null while running) |
 | `exit_code` | `INT` | nullable | Process exit code from Claude Code (null while running) |
 | `outcome` | `TEXT` | nullable | Final status: `completed`, `error`, `timeout`, `cancelled` |
 | `transcript` | `JSONB` | nullable | Array of transcript events appended during execution |
 | `proxy_log` | `JSONB` | nullable | Array of Gate proxy log entries (method, URL, decision) |
-| `artifacts` | `JSONB` | nullable | Array of artifact descriptors produced by the task |
+| `artifacts` | `JSONB` | nullable | Array of artifact descriptors produced by the session |
 | `parent_id` | `UUID` | `REFERENCES sessions(id)` | Links to a parent session for chained/retry tasks |
 
 **Note:** The `sessions` table has no `repo` column. The `Session` Go struct has
@@ -97,7 +97,7 @@ removed via `ON DELETE CASCADE`.
 
 ## schedules
 
-Defines recurring tasks that Bridge's scheduler executes on a cron schedule.
+Defines recurring sessions that Bridge's scheduler executes on a cron schedule.
 
 | Column | Type | Constraints | Notes |
 |--------|------|-------------|-------|
@@ -105,12 +105,12 @@ Defines recurring tasks that Bridge's scheduler executes on a cron schedule.
 | `name` | `TEXT` | `NOT NULL` | Human-readable schedule name |
 | `cron` | `TEXT` | `NOT NULL` | Cron expression (e.g., `0 */6 * * *` for every 6 hours) |
 | `prompt` | `TEXT` | `NOT NULL` | The prompt to send to the agent on each run |
-| `repo` | `TEXT` | nullable | Git repository URL to clone for the task |
+| `repo` | `TEXT` | nullable | Git repository URL to clone for the session |
 | `provider` | `TEXT` | nullable | LLM provider override (uses default if null) |
 | `scope_preset` | `TEXT` | nullable | Named scope preset to apply to scheduled runs |
-| `timeout` | `INT` | `DEFAULT 3600` | Maximum task duration in seconds |
+| `timeout` | `INT` | `DEFAULT 3600` | Maximum session duration in seconds |
 | `enabled` | `BOOLEAN` | `DEFAULT true` | Whether the schedule is active |
-| `last_run` | `TIMESTAMPTZ` | nullable | When the schedule last triggered a task |
+| `last_run` | `TIMESTAMPTZ` | nullable | When the schedule last triggered a session |
 | `next_run` | `TIMESTAMPTZ` | nullable | Computed next trigger time |
 | `created_at` | `TIMESTAMPTZ` | `NOT NULL DEFAULT NOW()` | When the schedule was created |
 

--- a/docs/design/architecture-decisions.md
+++ b/docs/design/architecture-decisions.md
@@ -12,9 +12,9 @@ and Integration architecture.
 **Rationale** (Security):
 - A shared Gate holds all credentials for all concurrent sessions in one process.
   A memory-disclosure vulnerability exposes everything. A sidecar loads only the
-  credentials for its specific task.
+  credentials for its specific session.
 - A compromised shared Gate affects all Skiff pods. A compromised sidecar affects
-  only one task.
+  only one session.
 - 1:1 session-to-process mapping eliminates session confusion bugs (Skiff A's
   request evaluated against Skiff B's scope).
 - At 3-20 concurrent workers, the resource cost is negligible (~20-50 MB RAM per
@@ -71,12 +71,12 @@ LLM credentials, which could be used for expensive unauthorized API usage.
 | Docker | `docker run --rm` | Bridge calls Docker CLI | Automatic via `--rm` |
 
 **Rationale** (Platform): Jobs provide the exact semantic model needed — run one
-task, exit, report success/failure. Exit code 0 = success, non-zero = failure.
+session, exit, report success/failure. Exit code 0 = success, non-zero = failure.
 `activeDeadlineSeconds` provides hard timeout for free. `ttlSecondsAfterFinished`
 handles garbage collection.
 
 **Warm pool optimization** (Phase 4): For lower latency, maintain 2-3 idle Skiff
-pods as a Deployment with `restart: Always`. Each picks up one task, executes,
+pods as a Deployment with `restart: Always`. Each picks up one session, executes,
 exits. The Deployment controller restarts it, giving a fresh pod. This is a
 self-reprovisioning single-use worker pool.
 
@@ -93,8 +93,8 @@ self-reprovisioning single-use worker pool.
 - JetStream adds persistence later without API changes.
 
 **Security requirement** (Security): Authenticate and encrypt the bus. Use NATS
-credentials + TLS. Sign task messages with HMAC so Skiff pods verify they came
-from Bridge. Encrypt the Gate token in task messages.
+credentials + TLS. Sign session messages with HMAC so Skiff pods verify they came
+from Bridge. Encrypt the Gate token in session messages.
 
 ### 6. Ledger: PostgreSQL Only (Phase 1)
 
@@ -215,10 +215,10 @@ claude \
 Gate sidecar (not Skiff container). Gate proxies LLM calls, adding auth.
 Workload Identity Federation on OpenShift (Phase 2).
 
-### 12. Git Workflow: Fresh Clone Per Task
+### 12. Git Workflow: Fresh Clone Per Session
 
 **Decision**: Claude Code clones repos itself through Gate. `git clone --depth=1`
-per task. No persistent volumes. No pre-cloning by the init process.
+per session. No persistent volumes. No pre-cloning by the init process.
 
 For repos >500MB (Phase 4): read-only git mirror maintained by Bridge, mounted
 into Skiff pods. `git clone --reference /mnt/mirror --dissociate` copies objects
@@ -291,7 +291,7 @@ supported from Phase 1. No separate vault service. HashiCorp Vault or External
 Secrets Operator integration deferred to Phase 5.
 
 Bridge reads service credentials from k8s Secrets (or env vars) and injects them
-into Gate sidecars at task creation time. Defense-in-depth within Bridge is
+into Gate sidecars at session creation time. Defense-in-depth within Bridge is
 sufficient for Phase 1 (minimal RBAC, audit logging on all API endpoints).
 
 
@@ -300,12 +300,12 @@ sufficient for Phase 1 (minimal RBAC, audit logging on all API endpoints).
 ### Phase 1 Commands
 
 ```
-alcove run          Submit a task (optionally --watch for live stream)
+alcove run          Start a session (optionally --watch for live stream)
 alcove list         List sessions (filterable by status, repo, date)
 alcove logs         Stream or fetch session transcript / proxy log
 alcove status       Show single session status
 alcove cancel       Cancel a running session
-alcove schedule     Create/list/enable/disable/delete scheduled tasks
+alcove schedule     Create/list/enable/disable/delete scheduled sessions
 alcove login        Authenticate to a Bridge instance
 alcove config       Validate and show effective configuration
 alcove version      Print client and server versions
@@ -313,7 +313,7 @@ alcove version      Print client and server versions
 
 **Design principles**:
 - Session IDs are 8-char alphanumeric (human-friendly), full UUIDs stored internally
-- Default to non-blocking (`alcove run` dispatches and returns; `--watch` for live)
+- Default to non-blocking (`alcove run` starts a session and returns; `--watch` for live)
 - Every command supports `--output json` for machine-readable output
 - Stderr for progress/spinners, stdout for results (enables piping)
 
@@ -339,7 +339,7 @@ The CLI stores its Bridge URL in `~/.config/alcove/config.yaml` (set by
 - PostgreSQL for Ledger (append-only writes)
 - Built-in auth (argon2id, rate limiting, CSRF)
 - CLI: `run`, `list`, `logs`, `status`, `cancel`, `login`
-- Dashboard: task list, new task, scope approval, live monitor, task review
+- Dashboard: session list, new session, scope approval, live monitor, session review
 - Vertex AI provider (key in Gate, not in Skiff)
 - Manual scope configuration (no AI resolution)
 - k8s Secrets + env vars for credentials
@@ -355,24 +355,24 @@ The CLI stores its Bridge URL in `~/.config/alcove/config.yaml` (set by
 - DNS removal from Skiff pods (hostAliases for internal services)
 - NATS authentication + TLS
 - Ledger encryption at rest
-- Token rotation (every 5 min within a task)
+- Token rotation (every 5 min within a session)
 - Anthropic API provider
 - `alcove schedule` command + cron scheduler in Bridge
 - Scope escalation notifications (dashboard modal + CLI prompt)
 
 ### Phase 3: Human-in-the-Loop + Review
-- Task review workflow (approve/reject/follow-up/rerun)
+- Session review workflow (approve/reject/follow-up/rerun)
 - Proxy log correlation with transcripts
-- Task annotation sidebar in dashboard
-- Follow-up task chaining (linked sessions)
+- Session annotation sidebar in dashboard
+- Follow-up session chaining (linked sessions)
 - Claude Pro/Max account support
-- Notification webhooks (Slack, email) for scheduled task approvals
+- Notification webhooks (Slack, email) for scheduled session approvals
 
 ### Phase 4: Dynamic Workers + Scale
 - Custom Skiff images per-project (Containerfile generation)
 - Warm pool (Deployment-based self-reprovisioning workers)
-- Parallel task execution
-- Resource limit configuration per task
+- Parallel session execution
+- Resource limit configuration per session
 - Git mirror volumes for large repos (>500MB)
 - ~~nftables-based network isolation on podman~~ — **Done** (implemented via dual-network with `--internal` flag)
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -18,12 +18,12 @@ future, but the architecture is not designed around that goal today.
 
 The central coordinator. Runs as a long-lived Deployment. Provides:
 
-- **Dashboard** — web UI for submitting tasks, reviewing session transcripts,
+- **Dashboard** — web UI for starting sessions, reviewing session transcripts,
   configuring proxy scopes, and managing workers
 - **REST API** — programmatic access to all dashboard functionality
-- **Task Dispatcher** — interprets incoming prompts, determines authorization
+- **Session Dispatcher** — interprets incoming prompts, determines authorization
   scope (see [Scope Resolution](#scope-resolution)), provisions proxy rules,
-  and dispatches work to the message bus
+  and dispatches sessions to the message bus
 - **Provider Registry** — manages LLM provider credentials (Google Vertex AI,
   Anthropic API keys, Claude Pro accounts) and injects them into worker pods.
   LLM API keys are never placed in Skiff pods — Bridge injects them into the
@@ -33,9 +33,9 @@ The central coordinator. Runs as a long-lived Deployment. Provides:
 
 Bridge never runs LLM prompts itself. It coordinates and observes.
 
-#### Scheduled Tasks (Cron)
+#### Scheduled Sessions (Cron)
 
-Bridge includes a built-in scheduler for recurring tasks. Users define schedules
+Bridge includes a built-in scheduler for recurring sessions. Users define schedules
 via the dashboard or API:
 
 ```yaml
@@ -57,14 +57,14 @@ schedules:
     timeout: 45m
 ```
 
-Bridge evaluates cron expressions and dispatches tasks to Hail at the scheduled
-time. Scheduled tasks follow the same scope resolution, Gate authorization, and
-Ledger recording as interactive tasks. The dashboard shows schedule history
+Bridge evaluates cron expressions and dispatches sessions to Hail at the scheduled
+time. Scheduled sessions follow the same scope resolution, Gate authorization, and
+Ledger recording as interactive sessions. The dashboard shows schedule history
 (last run, next run, outcome) and allows enabling/disabling individual schedules.
 
 Schedules can use either a `scope_preset` (a named, pre-approved scope from the
 service catalog) or go through the normal scope resolution process. For
-autonomous scheduled tasks, scope presets are recommended — they skip the
+autonomous scheduled sessions, scope presets are recommended — they skip the
 approval step because the scope was approved when the schedule was created.
 
 ### Skiff — The Workers
@@ -73,21 +73,21 @@ Ephemeral containers that execute Claude Code prompts. Each Skiff pod:
 
 1. Starts from a clean, purpose-built container image (Claude Code pre-installed,
    project tooling included)
-2. Connects to the message bus and waits for a task message
-3. Receives a task (prompt text + configuration)
+2. Connects to the message bus and receives session configuration
+3. Reads the session config (prompt text + configuration)
 4. Executes `claude` with the prompt
 5. Streams session output to the Ledger
 6. Exits when the prompt concludes (or hits a timeout)
 7. The container terminates, and Kubernetes reprovisions a fresh pod
 
 **Filesystem sandbox**: because each Skiff pod starts clean and is destroyed after
-every task, there is no persistent state that can be poisoned across sessions. The
+every session, there is no persistent state that can be poisoned across sessions. The
 container image is the only input; the session transcript is the only output.
 
 **Stopping conditions** (in priority order):
 
 1. Claude Code exits normally (prompt complete)
-2. Configurable hard timeout (default: 60 minutes, set per-task by Bridge)
+2. Configurable hard timeout (default: 60 minutes, set per-session by Bridge)
 3. Manual cancellation via Bridge dashboard/API
 4. Heartbeat timeout — if Claude Code stops producing output for N minutes
    (default: 10), the pod is terminated
@@ -97,7 +97,7 @@ The Skiff image is built with:
 - Project-specific tooling (language runtimes, build tools, linters)
 - A thin init process that handles message bus connection, session streaming,
   and timeout enforcement
-- Git (for cloning repos at task start)
+- Git (for cloning repos at session start)
 - `gh` and `glab` CLIs (for GitHub/GitLab interaction via Gate's SCM proxy)
 - A git credential helper that routes authentication through Gate
 - **Puppeteer for wireframe generation** — enables planning agents to create
@@ -111,7 +111,7 @@ namespace). Every outbound connection from a Skiff pod routes through its
 Gate sidecar. Gate provides:
 
 - **Operation-level authorization** — not just "can access GitHub" but "can create
-  a PR on repo X but not merge it." Scopes are defined per-task by Bridge.
+  a PR on repo X but not merge it." Scopes are defined per-session by Bridge.
 - **Token replacement** — Skiff pods never hold real credentials. They present a
   session-scoped opaque token. Gate maps this token to actual credentials
   (GitHub PAT, GitLab token, Jira API key, etc.) at request time.
@@ -135,8 +135,8 @@ Gate sidecar. Gate provides:
 **Prompt injection defense**: because neither real service tokens nor LLM API keys
 enter the Skiff pod, a prompt injection attack that exfiltrates environment
 variables or config files gets only the opaque session token, which is:
-- Scoped to a single task's authorized operations
-- Short-lived (expires when the task ends)
+- Scoped to a single session's authorized operations
+- Short-lived (expires when the session ends)
 - Revocable by Bridge at any time
 
 **HTTPS interception approach**: protocol-level, not MITM TLS.
@@ -151,10 +151,10 @@ variables or config files gets only the opaque session token, which is:
 
 ### Ledger — Session Storage
 
-A persistent store for complete session records. Each task execution produces a
+A persistent store for complete session records. Each session produces a
 session record containing:
 
-- **Task metadata** — prompt text, submitter, timestamp, authorization scope,
+- **Session metadata** — prompt text, submitter, timestamp, authorization scope,
   timeout settings, provider used
 - **Claude transcript** — full input/output record from Claude Code (the
   `--output-format stream-json` session dump)
@@ -179,7 +179,7 @@ stream — no updates or deletes to session records.
 
 Connects Bridge to Skiff pods. Carries:
 
-- **Task messages** (Bridge → Skiff) — prompt text, repo URL, branch, Gate token,
+- **Session messages** (Bridge → Skiff) — prompt text, repo URL, branch, Gate token,
   timeout, provider config
 - **Status updates** (Skiff → Bridge) — heartbeats, progress, completion
 - **Control messages** (Bridge → Skiff) — cancellation signals
@@ -191,7 +191,7 @@ needed). Subject-based messaging maps to Alcove's needs: `tasks.dispatch`,
 
 ## Scope Resolution
 
-When a user submits a task, Bridge must determine what external services the Skiff
+When a user starts a session, Bridge must determine what external services the Skiff
 pod should be authorized to access and what operations are permitted. This is
 called **scope resolution**.
 
@@ -209,7 +209,7 @@ called **scope resolution**.
      # jira not included — prompt doesn't mention it
    ```
 4. **In supervised mode** (default): the proposed scope is shown to the user in
-   the dashboard for approval/modification before the task is dispatched
+   the dashboard for approval/modification before the session is dispatched
 5. **In autonomous mode** (opt-in): the proposed scope is applied automatically,
    but logged for audit
 
@@ -429,8 +429,8 @@ equivalents. For production or shared deployments, use Podman or Kubernetes.
 
 ### LLM Provider Configuration
 
-Bridge manages provider credentials and injects them into Gate sidecars at task
-time. Skiff containers never hold LLM API keys.
+Bridge manages provider credentials and injects them into Gate sidecars at session
+dispatch time. Skiff containers never hold LLM API keys.
 
 | Provider | Credential | Gate Behavior |
 |----------|-----------|---------------|
@@ -443,7 +443,7 @@ time. Skiff containers never hold LLM API keys.
 
 ### Phase 1: Foundation
 
-- Bridge with basic dashboard (submit prompt, view tasks)
+- Bridge with basic dashboard (submit prompt, view sessions)
 - Bridge REST API
 - Skiff pods as k8s Jobs / `podman run --rm` / `docker run --rm`
 - Gate as sidecar with HTTP_PROXY + git credential helper + LLM API proxy
@@ -466,25 +466,25 @@ time. Skiff containers never hold LLM API keys.
 - DNS removal from Skiff pods (hostAliases for internal services)
 - NATS authentication + TLS
 - Ledger encryption at rest
-- Token rotation (every 5 min within a task)
+- Token rotation (every 5 min within a session)
 - Anthropic API provider support
 - `alcove schedule` command + cron scheduler in Bridge
 
 ### Phase 3: Human-in-the-Loop + Review
 
 - Scope escalation notifications (Gate block → Bridge notification → user approval)
-- Task review workflow (approve/reject/follow-up/rerun)
+- Session review workflow (approve/reject/follow-up/rerun)
 - Proxy log correlation with session transcripts in dashboard
-- Follow-up task chaining (linked sessions)
+- Follow-up session chaining (linked sessions)
 - Claude Pro/Max account support
-- Notification webhooks (Slack, email) for scheduled task approvals
+- Notification webhooks (Slack, email) for scheduled session approvals
 
 ### Phase 4: Dynamic Workers + Scale
 
 - Custom Skiff images per-project (Containerfile generation)
 - Warm pool (Deployment-based self-reprovisioning workers)
-- Parallel task execution
-- Resource limit configuration per task
+- Parallel session execution
+- Resource limit configuration per session
 - Git mirror volumes for large repos (>500MB)
 - ~~nftables-based network isolation on podman~~ — **Done** (implemented via dual-network with `--internal` flag)
 
@@ -504,6 +504,6 @@ time. Skiff containers never hold LLM API keys.
 |-----------|------|-------------|------------|---------|
 | Controller | **Bridge** | Deployment | Yes | Coordination, dashboard, API, scheduler |
 | Worker | **Skiff** | Job / `podman run --rm` / `docker run --rm` | No (ephemeral) | Execute Claude Code prompts |
-| Auth Proxy | **Gate** | Sidecar in Skiff pod | No (per-task) | Network sandbox, token swap, LLM proxy |
-| Message Bus | **Hail** | Deployment (NATS) | Yes | Task dispatch, status updates |
+| Auth Proxy | **Gate** | Sidecar in Skiff pod | No (per-session) | Network sandbox, token swap, LLM proxy |
+| Message Bus | **Hail** | Deployment (NATS) | Yes | Session dispatch, status updates |
 | Session Store | **Ledger** | Deployment + PVC | Yes | Audit trail, session history |

--- a/docs/design/credential-management-plan.md
+++ b/docs/design/credential-management-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Support Anthropic API keys, Vertex AI service account JSON, and Vertex AI ADC credentials — stored in PostgreSQL, resolved at dispatch time, with token refresh for long-running tasks.
 
-**Architecture:** Bridge stores encrypted credentials in PostgreSQL, pre-fetches OAuth2 tokens at task dispatch, and passes short-lived tokens to Gate. Gate injects headers and retries on 401 by calling Bridge's token refresh endpoint. Raw credentials never enter Gate or Skiff containers.
+**Architecture:** Bridge stores encrypted credentials in PostgreSQL, pre-fetches OAuth2 tokens at session dispatch, and passes short-lived tokens to Gate. Gate injects headers and retries on 401 by calling Bridge's token refresh endpoint. Raw credentials never enter Gate or Skiff containers.
 
 **Tech Stack:** Go 1.25, `golang.org/x/oauth2` + `google.golang.org/api/option`, AES-256-GCM encryption, PostgreSQL BYTEA column, `net/http` REST endpoints.
 

--- a/docs/design/credential-management.md
+++ b/docs/design/credential-management.md
@@ -18,7 +18,7 @@ Bridge to Gate. This works for Anthropic API keys but not for Vertex AI, which
 requires OAuth2 token acquisition and periodic refresh.
 
 In production (OpenShift), multiple users will have different credentials. File
-mounts (SA JSON, ADC) are not viable per-task. Credentials must flow through
+mounts (SA JSON, ADC) are not viable per-session. Credentials must flow through
 the system programmatically.
 
 ## Architecture
@@ -51,13 +51,13 @@ User registers credentials
    libraries, or credential types. It receives a token string and a provider
    type, and injects the appropriate header.
 
-3. **Token refresh via Bridge API.** For tasks that outlast a token's lifetime
+3. **Token refresh via Bridge API.** For sessions that outlast a token's lifetime
    (>1 hour), Gate calls Bridge's token refresh endpoint using its session token
    for authentication.
 
 4. **Multi-user ready.** Credentials are stored per-provider in PostgreSQL,
    associated with the user or team that registered them. At dispatch time,
-   Bridge resolves which credential to use based on the task's provider and
+   Bridge resolves which credential to use based on the session's provider and
    submitter.
 
 ## Credential Storage
@@ -95,10 +95,10 @@ token acquisition time, in memory.
 
 ## Token Flow
 
-### At Task Dispatch (Bridge)
+### At Session Dispatch (Bridge)
 
 ```
-1. Resolve provider for the task (from request or default)
+1. Resolve provider for the session (from request or default)
 2. Look up credential for that provider in provider_credentials table
 3. Decrypt the credential material
 4. Based on auth_type:
@@ -125,7 +125,7 @@ When proxying an LLM request:
       set header "Authorization: Bearer <token>"
 ```
 
-### Token Refresh (for tasks > 1 hour)
+### Token Refresh (for sessions > 1 hour)
 
 ```
 Gate detects a 401 from the upstream LLM provider
@@ -175,7 +175,7 @@ The dashboard credential management page:
 2. **Credentials list** showing name, provider, type, created date.
    Never displays the actual credential material.
 
-3. **New Task form** updated to select a credential (or use default).
+3. **New Session form** updated to select a credential (or use default).
 
 ## Phase 1 Simplification
 

--- a/docs/design/gate-scm-authorization.md
+++ b/docs/design/gate-scm-authorization.md
@@ -497,7 +497,7 @@ The dummy tokens have the following properties:
 
 ### 4.1 Environment variables set by Bridge and skiff-init
 
-For a task with GitHub and GitLab in scope, Skiff receives:
+For a session with GitHub and GitLab in scope, Skiff receives:
 
 ```bash
 # Git configuration (set by skiff-init setupEnv)
@@ -694,7 +694,7 @@ Content-Type: application/json
 }
 ```
 
-### 6.2 Task submission with scope
+### 6.2 Session submission with scope
 
 The existing `POST /api/v1/tasks` endpoint accepts a `scope` field. No API
 changes are needed:
@@ -871,7 +871,7 @@ Ordered list of tasks with file paths. Each task is independently testable.
 - Add `glab` CLI (from binary release)
 
 **Task 3.2: Validate gh/glab work through Gate proxy**
-- Manual testing: submit a task with GitHub scope, verify `gh pr create`
+- Manual testing: start a session with GitHub scope, verify `gh pr create`
   works through Gate
 - Verify `glab mr create` works through Gate
 
@@ -909,7 +909,7 @@ Ordered list of tasks with file paths. Each task is independently testable.
 
 1. **GitHub App vs PAT:** Should we prioritize GitHub App support (installation
    tokens with fine-grained permissions) or PATs (simpler, user-scoped)? PATs
-   are simpler for Phase 1, but Apps provide better security isolation per-task.
+   are simpler for Phase 1, but Apps provide better security isolation per-session.
 
 2. **Push enforcement granularity:** Can we distinguish `push_branch` from
    `push_main` at the Gate level? With PATs, no -- the credential has the same
@@ -921,9 +921,9 @@ Ordered list of tasks with file paths. Each task is independently testable.
    instances, or is one sufficient? Multiple instances would require the scope
    to specify which instance each project belongs to.
 
-4. **Rate limiting:** Should Gate enforce per-task rate limits on SCM API calls
+4. **Rate limiting:** Should Gate enforce per-session rate limits on SCM API calls
    to prevent abuse? This is separate from GitHub/GitLab's own rate limits.
 
-5. **Webhook verification:** If a task creates a PR, should Gate intercept the
+5. **Webhook verification:** If a session creates a PR, should Gate intercept the
    PR creation response and record the PR URL as an artifact? This would enable
    automatic artifact tracking without relying on Claude Code to report it.

--- a/docs/design/implementation-status.md
+++ b/docs/design/implementation-status.md
@@ -13,7 +13,7 @@ all resolved decisions.
 
 | Component | Name | Purpose |
 |-----------|------|---------|
-| Controller | **Bridge** | REST API, dashboard, task dispatch, scheduler, admin settings, security profile builder |
+| Controller | **Bridge** | REST API, dashboard, session dispatch, scheduler, admin settings, security profile builder |
 | Worker | **Skiff** | Ephemeral Claude Code execution |
 | Auth Proxy | **Gate** | Sidecar proxy: token swap, LLM API proxy, SCM proxy (`/github/`, `/gitlab/`), scope enforcement, MCP tool configs |
 | Message Bus | **Hail** | NATS-based status, transcript ingestion, cancellation |
@@ -26,15 +26,15 @@ all resolved decisions.
 ```
 alcove/
 ├── cmd/
-│   ├── bridge/main.go          ✅ Controller: REST API, auth, task dispatch, migration, scheduling, admin settings
+│   ├── bridge/main.go          ✅ Controller: REST API, auth, session dispatch, migration, scheduling, admin settings
 │   ├── gate/main.go            ✅ HTTP proxy with scope enforcement, LLM proxying, SCM proxying (/github/, /gitlab/), token refresh, MCP tool configs
-│   ├── skiff-init/main.go      ✅ PID 1 init: reads task from env, runs claude, streams output, publishes transcript events to NATS
+│   ├── skiff-init/main.go      ✅ PID 1 init: reads session config from env, runs claude, streams output, publishes transcript events to NATS
 │   ├── hashpw/main.go          ✅ Utility: password hashing tool
 │   └── alcove/main.go          ✅ CLI: 8 subcommands (run, list, logs, status, cancel, login, config, version)
 ├── internal/
 │   ├── types.go                ✅ Shared types (Task, Session, Scope, TranscriptEvent, etc.)
 │   ├── runtime/
-│   │   ├── runtime.go          ✅ Runtime interface (RunTask, CancelTask, EnsureService, etc.) with Podman, Docker, and Kubernetes backends
+│   │   ├── runtime.go          ✅ Runtime interface (RunTask, CancelTask, EnsureService, etc.) with Podman, Docker, and Kubernetes backends (RunTask starts a session)
 │   │   ├── podman.go           ✅ PodmanRuntime implementation (podman CLI wrapper)
 │   │   ├── podman_test.go      ✅ 14 tests (TestHelperProcess pattern)
 │   │   ├── docker.go           ✅ DockerRuntime implementation (Docker CLI wrapper, no --internal network isolation)
@@ -42,8 +42,8 @@ alcove/
 │   │   ├── kubernetes.go       ✅ KubernetesRuntime implementation (client-go, Jobs with native sidecars, NetworkPolicy)
 │   │   └── kubernetes_test.go  ✅ Kubernetes runtime tests
 │   ├── bridge/
-│   │   ├── api.go              ✅ REST handlers (tasks, sessions, schedules, credentials, providers, profiles, tools, settings, health, transcript streaming, proxy-log ingestion)
-│   │   ├── dispatcher.go       ✅ Task dispatch: creates session, resolves security profiles, publishes to NATS, starts Skiff+Gate with LLM/SCM credentials and tool configs
+│   │   ├── api.go              ✅ REST handlers (sessions, schedules, credentials, providers, profiles, tools, settings, health, transcript streaming, proxy-log ingestion)
+│   │   ├── dispatcher.go       ✅ Session dispatch: creates session, resolves security profiles, publishes to NATS, starts Skiff+Gate with LLM/SCM credentials and tool configs
 │   │   ├── config.go           ✅ Config loading from env vars, auth backend selection, debug mode
 │   │   ├── runtime.go          ✅ Runtime factory (podman/kubernetes selection)
 │   │   ├── credentials.go      ✅ Credential CRUD, AES-256-GCM encryption, OAuth2 token acquisition, token refresh, AcquireSCMToken, AcquireSystemToken, owner scoping, system credentials, claude-oauth support
@@ -81,7 +81,7 @@ alcove/
 ├── web/
 │   ├── index.html              ✅ Dashboard SPA shell with all page views, setup checklist
 │   ├── css/style.css           ✅ Dark theme dashboard styles
-│   └── js/app.js               ✅ Full SPA: login, task list with pagination, new task form with profile selection, live transcript viewer (5-second polling from database), proxy log viewer, providers page, security profiles page, MCP tools page, schedules with NLP cron input, admin settings, user management, guided setup checklist, contextual warnings
+│   └── js/app.js               ✅ Full SPA: login, session list with pagination, new session form with profile selection, live transcript viewer (5-second polling from database), proxy log viewer, providers page, security profiles page, MCP tools page, schedules with NLP cron input, admin settings, user management, guided setup checklist, contextual warnings
 ├── build/
 │   ├── Containerfile.bridge    ✅ Multi-stage (golang:1.25 → ubi9/ubi)
 │   ├── Containerfile.gate      ✅ Multi-stage (golang:1.25 → ubi9-minimal)
@@ -118,7 +118,7 @@ alcove/
 - Database migrations run automatically on startup ✅
 - Auth works (login, token, rate limiting) with memory, postgres, and rh-identity backends ✅
 - `POST /api/v1/tasks` creates session in DB, publishes to NATS, starts Gate + Skiff containers ✅
-- Skiff containers boot, read task from env vars, attempt to run Claude Code ✅
+- Skiff containers boot, read session config from env vars, attempt to run Claude Code ✅
 - LLM credential flow works end-to-end: Bridge acquires tokens, Gate injects headers ✅
 - Containers exit and are cleaned up by `--rm` (or kept with `ALCOVE_DEBUG=true`) ✅
 - Dashboard accessible at http://localhost:8080 ✅
@@ -133,9 +133,9 @@ alcove/
    Dispatcher injects `GATE_LLM_TOKEN`, `GATE_LLM_PROVIDER`, `GATE_LLM_TOKEN_TYPE`
    into Gate env and `ANTHROPIC_BASE_URL` into Skiff env pointing at the Gate sidecar.
 
-2. **Dashboard Frontend** — Full SPA in `web/` with login form, task list with
-   status filters, search, and pagination, new task form with provider and profile
-   selection and debug toggle, task detail view with live transcript viewer
+2. **Dashboard Frontend** — Full SPA in `web/` with login form, session list with
+   status filters, search, and pagination, new session form with provider and profile
+   selection and debug toggle, session detail view with live transcript viewer
    (5-second polling from database, same as proxy log) and proxy log tabs,
    providers page, security profiles page, MCP tools page, schedules page with
    NLP-style cron input, admin settings page (system LLM shown as read-only
@@ -176,7 +176,7 @@ alcove/
    PostgreSQL advisory locking to prevent concurrent startup races. Schema versioning
    via `schema_migrations` table.
 
-8. **Debug Mode** — `ALCOVE_DEBUG=true` or `--debug` flag on task submission keeps
+8. **Debug Mode** — `ALCOVE_DEBUG=true` or `--debug` flag on session submission keeps
    Skiff containers after exit for log inspection.
 
 9. **Gate Vertex API Translation** — Gate translates Anthropic API requests to
@@ -193,7 +193,7 @@ alcove/
     acquires HTTPS git credentials from Gate. SCM-related environment variables
     (`GITHUB_TOKEN`, `GH_TOKEN`, `GITLAB_TOKEN`, `GITHUB_API_URL`, `GITLAB_API_URL`,
     `GH_HOST`, `GLAB_HOST`, `GATE_CREDENTIAL_URL`, `GIT_SSH_COMMAND`, etc.) are
-    injected by Bridge when the task scope includes a `github` or `gitlab` service.
+    injected by Bridge when the session scope includes a `github` or `gitlab` service.
 
 11. **Transcript Viewing** — Skiff flushes transcript events to the database
     every 5 seconds via `POST /api/v1/sessions/{id}/transcript`. The dashboard
@@ -250,8 +250,8 @@ alcove/
     Plugin structure: `.claude-plugin/plugin.json` with `skills/` and `agents/`
     directories.
 
-20. **YAML Task Definitions** — Tasks defined in `.alcove/tasks/*.yml` in git
-    repos. Task repo registration (system + per-user) via settings API.
+20. **YAML Agent Definitions** — Agents defined in `.alcove/tasks/*.yml` in git
+    repos. Agent repo registration (system + per-user) via settings API.
     YAML schema supports name, prompt, repo, provider, model, timeout, budget,
     profiles, tools, and schedule fields. Auto-sync every 5 minutes. Dashboard
     supports Run Now and View YAML actions. Starter templates available via
@@ -259,7 +259,7 @@ alcove/
 
 21. **Kubernetes Runtime** — `KubernetesRuntime` in `internal/runtime/kubernetes.go`
     implements the `Runtime` interface using direct client-go API calls (no
-    operator needed). Each task runs as a k8s Job with Gate as a native sidecar
+    operator needed). Each session runs as a k8s Job with Gate as a native sidecar
     (init container with `restartPolicy: Always`) and Skiff as the main
     container. Creates a per-task NetworkPolicy restricting egress. Compatible
     with OpenShift restricted-v2 SCC (runs as non-root, drops all capabilities,
@@ -271,27 +271,27 @@ alcove/
     v0.1.0 released.
 
 23. **YAML Security Profiles** — Security profiles defined in
-    `.alcove/security-profiles/*.yml` files in task repos, synced alongside
-    YAML task definitions. Profiles specify tool/repo/operation rules in the
+    `.alcove/security-profiles/*.yml` files in agent repos, synced alongside
+    YAML agent definitions. Profiles specify tool/repo/operation rules in the
     same format as API-created profiles. YAML profiles are read-only in the
     UI and API (PUT/DELETE return 403). Each profile carries a `source` field
     (`user` or `yaml`) plus `source_repo` and `source_key` for
-    traceability. Task definitions referencing unknown profiles receive sync
+    traceability. Agent definitions referencing unknown profiles receive sync
     errors. Profile validation requires `name` and at least one tool entry.
 
-24. **GitHub Event Polling** — Task definitions with event triggers support a
+24. **GitHub Event Polling** — Agent definitions with event triggers support a
     `polling` delivery mode (default) that polls the GitHub Events API every
     60 seconds for new events matching configured event types, actions, and
     repos. Uses GitHub's conditional request support (ETags) to minimize API
     usage. Event deduplication via the `webhook_deliveries` table prevents
-    duplicate task dispatches. On first poll, existing events are skipped to
+    duplicate session dispatches. On first poll, existing events are skipped to
     avoid retroactive dispatches. Works in any environment including local
     development with no webhook configuration required.
 
 25. **Label-Based Trigger Filtering** — Event triggers support an optional
     `labels` field that restricts dispatch to issues or PRs carrying at least
     one of the listed GitHub labels. This provides a safety gate that prevents
-    unauthorized issues from triggering automated development tasks.
+    unauthorized issues from triggering automated sessions.
 
 26. **Docker Runtime** — `DockerRuntime` in `internal/runtime/docker.go`
     implements the `Runtime` interface using the Docker CLI. Works identically
@@ -311,7 +311,7 @@ alcove/
 ### 1. NATS Dead Code
 
 The dispatcher still publishes to `tasks.dispatch` on NATS (line 125 of
-dispatcher.go) but nothing subscribes — Skiff reads tasks from environment
+dispatcher.go) but nothing subscribes — Skiff reads session config from environment
 variables, not NATS. This publish call is the remaining dead code.
 
 ### 2. Gate Log Flushing to Ledger
@@ -419,7 +419,7 @@ See the full roadmap in [architecture-decisions.md](architecture-decisions.md#ro
 | `github.com/nats-io/nats.go` | v1.50.0 | NATS client for Hail |
 | `github.com/jackc/pgx/v5` | v5.9.1 | PostgreSQL client for Ledger |
 | `github.com/spf13/cobra` | v1.10.2 | CLI framework |
-| `github.com/google/uuid` | v1.6.0 | Session/task ID generation |
+| `github.com/google/uuid` | v1.6.0 | Session ID generation |
 | `golang.org/x/crypto` | v0.49.0 | Argon2id password hashing |
 | `golang.org/x/oauth2` | — | Google OAuth2 token acquisition (Vertex AI) |
 | `gopkg.in/yaml.v3` | v3.0.1 | YAML parsing |

--- a/docs/design/mcp-tool-gateway.md
+++ b/docs/design/mcp-tool-gateway.md
@@ -4,7 +4,7 @@
 
 This document designs a generalized MCP tool gateway for Alcove, extending the
 existing SCM proxy pattern (GitHub/GitLab API proxying, git credential helper)
-to support arbitrary MCP tool servers with per-task tool selection and
+to support arbitrary MCP tool servers with per-session tool selection and
 operation-level scoping.
 
 ---
@@ -18,14 +18,14 @@ Adding a new tool (Jira, Slack, a custom internal API) requires modifying Gate's
 Go code in multiple places.
 
 Claude Code supports MCP (Model Context Protocol) tool servers that run as
-child processes. Users want to enable specific MCP tools per task (e.g., "this
-task can use GitHub MCP + Jira MCP but not Slack") with operation-level
+child processes. Users want to enable specific MCP tools per session (e.g., "this
+session can use GitHub MCP + Jira MCP but not Slack") with operation-level
 controls (e.g., "can read Jira issues but not create them").
 
 The design must:
 1. Keep the security invariant: Skiff never holds real credentials.
 2. Allow users to register custom MCP tools without modifying Gate source.
-3. Scope each tool's operations per task (deny by default).
+3. Scope each tool's operations per session (deny by default).
 4. Integrate with the existing proxy/credential/scope architecture.
 
 ---
@@ -66,7 +66,7 @@ external services. Because Skiff's traffic is forced through Gate (via
 
 1. Intercept all API calls from MCP servers
 2. Classify each call by service and operation
-3. Check against the task's scope
+3. Check against the session's scope
 4. Inject real credentials before forwarding
 
 This means MCP servers run with **dummy credentials** and Gate handles the real
@@ -263,7 +263,7 @@ type ServiceScope struct {
 }
 ```
 
-The scope JSON in a task request:
+The scope JSON in a session request:
 ```json
 {
     "services": {
@@ -1120,7 +1120,7 @@ not change this -- read-only enforcement still depends on the token type
 
 ### 10.1 Tool Selection Panel
 
-The task creation form gets a new "Tools" panel that:
+The session creation form gets a new "Tools" panel that:
 
 1. **Lists available tools** from `GET /api/v1/tools`, grouped by type:
    - Builtin tools (GitHub, GitLab) shown first with icons
@@ -1150,10 +1150,10 @@ A new "Tools" page in the dashboard for managing the tool registry:
 3. **Register form**: for adding custom tools
 4. **Credential status**: shows which tools have credentials configured
 
-### 10.3 Task Detail Enhancements
+### 10.3 Session Detail Enhancements
 
-The task detail page shows:
-- Which tools were enabled for the task
+The session detail page shows:
+- Which tools were enabled for the session
 - Proxy log filtered by tool
 - Operation counts by tool (N reads, N writes, N denials)
 
@@ -1227,7 +1227,7 @@ the env var contract). Can be done in parallel with Phase 2 and 3.
 
 | # | File | Change | Depends On |
 |---|------|--------|------------|
-| 5.1 | `web/static/` | Tool selection panel in task creation form | Phase 1 (API) |
+| 5.1 | `web/static/` | Tool selection panel in session creation form | Phase 1 (API) |
 | 5.2 | `web/static/` | Operation picker with tier grouping and presets | 5.1 |
 | 5.3 | `web/static/` | Tool registry management page | Phase 1 (API) |
 | 5.4 | `web/static/` | Scope preview JSON viewer | 5.2 |

--- a/docs/design/problem-statement.md
+++ b/docs/design/problem-statement.md
@@ -7,8 +7,8 @@ that stays alive across multiple tasks, accumulating context and maintaining
 state. This feels natural — it mirrors how humans work — but it creates
 fundamental problems in practice.
 
-Alcove takes the opposite approach: each task gets a fresh agent in a fresh
-container, with a clean context window, clean filesystem, and task-specific
+Alcove takes the opposite approach: each session gets a fresh agent in a fresh
+container, with a clean context window, clean filesystem, and session-specific
 network authorization. This document explains why.
 
 
@@ -37,9 +37,9 @@ partition prior context. Prompt engineering can mitigate this ("ignore all
 previous context") but cannot guarantee it — especially under adversarial
 conditions (prompt injection from Task A influencing behavior in Task B).
 
-**Alcove's approach**: each task starts a new Skiff pod with a completely fresh
-Claude Code session. There is zero context carryover between tasks. The context
-window contains only what is relevant to the current task.
+**Alcove's approach**: each session starts a new Skiff pod with a completely fresh
+Claude Code instance. There is zero context carryover between sessions. The context
+window contains only what is relevant to the current session.
 
 
 ## Problem 2: Network Authorization Drift
@@ -66,10 +66,10 @@ union of everything it has ever been granted. There is no clean way to revoke
 access to a running process that has already received credentials in its
 environment or memory.
 
-**Alcove's approach**: Gate provisions per-task authorization scopes. Each Skiff
+**Alcove's approach**: Gate provisions per-session authorization scopes. Each Skiff
 pod receives only an opaque session token that Gate maps to the specific
-operations authorized for that task. When the task ends, the token expires. The
-next task gets a new token with its own scope. There is no authorization
+operations authorized for that session. When the session ends, the token expires. The
+next session gets a new token with its own scope. There is no authorization
 accumulation.
 
 
@@ -99,10 +99,10 @@ agent behavior non-reproducible — the same prompt can produce different result
 depending on what tasks ran before it.
 
 **Alcove's approach**: each Skiff pod starts from a known-clean container image
-and is destroyed after the task completes. Kubernetes reprovisions a fresh pod
-for the next task. The container image is the only input; the session transcript
+and is destroyed after the session completes. Kubernetes reprovisions a fresh pod
+for the next session. The container image is the only input; the session transcript
 is the only durable output. There is no filesystem state that survives between
-tasks.
+sessions.
 
 
 ## Problem 4: Credential Exposure in Long-Lived Processes
@@ -138,9 +138,9 @@ credentials.
 
 | Problem | Long-running agents | Alcove (ephemeral) |
 |---------|--------------------|--------------------|
-| Context contamination | Prior tasks pollute current reasoning | Fresh context window per task |
-| Authorization drift | Credentials accumulate, scopes widen | Per-task scopes via Gate, token expires at task end |
-| Filesystem poisoning | State persists across tasks | Container destroyed after each task |
+| Context contamination | Prior sessions pollute current reasoning | Fresh context window per session |
+| Authorization drift | Credentials accumulate, scopes widen | Per-session scopes via Gate, token expires at session end |
+| Filesystem poisoning | State persists across sessions | Container destroyed after each session |
 | Credential exposure | All creds available for entire lifetime | Only opaque session token in Skiff pod (no LLM key) |
 | Reproducibility | Same prompt, different results depending on history | Same prompt, same clean starting point every time |
-| Auditability | Unclear which task caused which side effect | Each task is an isolated, fully recorded session |
+| Auditability | Unclear which session caused which side effect | Each session is an isolated, fully recorded unit |

--- a/docs/design/security-principles.md
+++ b/docs/design/security-principles.md
@@ -6,14 +6,14 @@ Alcove's security model is built around five north-star principles that define h
 
 ## 1. Safe Sandboxing
 
-**Principle:** Every task runs in an ephemeral, network-isolated container. Containers are never reused across tasks. NetworkPolicy (OpenShift) and dual-network isolation (podman) enforce this.
+**Principle:** Every session runs in an ephemeral, network-isolated container. Containers are never reused across sessions. NetworkPolicy (OpenShift) and dual-network isolation (podman) enforce this.
 
 ### Implementation
 
 **Ephemeral Containers (Skiff):**
-- Each task spawns a fresh Kubernetes Job or podman container
-- Containers are destroyed immediately after task completion (success or failure)
-- No persistent filesystem state survives between tasks
+- Each session spawns a fresh Kubernetes Job or podman container
+- Containers are destroyed immediately after session completion (success or failure)
+- No persistent filesystem state survives between sessions
 - Container images are read-only base layers plus task-specific volumes
 
 **Network Isolation:**
@@ -76,7 +76,7 @@ See [Credential Management](credential-management.md) for detailed implementatio
 
 ## 3. Human-in-the-Loop Controls
 
-**Principle:** Security profiles define what each task is allowed to do. Scope enforcement, task approval, and label-gated triggers ensure humans remain in control of what automated agents can access and modify.
+**Principle:** Security profiles define what each session is allowed to do. Scope enforcement, session approval, and label-gated triggers ensure humans remain in control of what automated agents can access and modify.
 
 ### Implementation
 
@@ -88,10 +88,10 @@ See [Credential Management](credential-management.md) for detailed implementatio
 - Profile changes require explicit user action
 
 **Scope Enforcement:**
-- Every task specifies its required scope at submission time
+- Every session specifies its required scope at submission time
 - Bridge validates scope against available credentials and user permissions
 - Gate enforces scope at runtime with operation-level granularity
-- No scope escalation possible once task is running
+- No scope escalation possible once session is running
 
 **Operation Classification:**
 - **Read operations:** `clone`, `fetch`, `read_prs`, `read_issues`, `read_contents`
@@ -102,7 +102,7 @@ See [Credential Management](credential-management.md) for detailed implementatio
 - Ready-for-dev label requirement for autonomous issue processing
 - Human review required for dangerous operations
 - Pull request review workflow for code changes
-- Task termination controls in dashboard
+- Session termination controls in dashboard
 
 **Repository Access Controls:**
 - Explicit repository allowlists (no wildcard defaults)
@@ -126,10 +126,10 @@ See [Security Profiles and System LLM](security-profiles-and-system-llm.md) for 
 - Network tunnel creation and termination
 
 **Session Transcripts:**
-- Complete LLM conversation history per task
+- Complete LLM conversation history per session
 - Tool invocations with input parameters and outputs
 - Error conditions and retry attempts
-- Task start/completion timestamps and status
+- Session start/completion timestamps and status
 - Resource usage metrics (CPU, memory, duration)
 
 **Structured Audit Data:**
@@ -164,7 +164,7 @@ See existing session storage implementation in Bridge's PostgreSQL schema.
 
 ## 5. Least Privilege
 
-**Principle:** Gate's network proxy is DENY by default. Only explicitly allowed operations (defined in security profiles) are permitted. Tasks cannot reach arbitrary network endpoints.
+**Principle:** Gate's network proxy is DENY by default. Only explicitly allowed operations (defined in security profiles) are permitted. Sessions cannot reach arbitrary network endpoints.
 
 ### Implementation
 
@@ -189,13 +189,13 @@ See existing session storage implementation in Bridge's PostgreSQL schema.
 **Network Segmentation:**
 - Skiff can only reach Gate sidecar (same pod/network namespace)
 - Gate can only reach explicitly approved external services
-- No cross-task network communication
+- No cross-session network communication
 - No persistent network connections
 
 **Credential Scoping:**
 - Credentials limited to approved repositories/projects
 - Token scopes minimized (read-only when possible)
-- Per-task credential isolation
+- Per-session credential isolation
 - No shared credential state
 
 **Example Scope Validation:**

--- a/docs/design/security-profiles-and-system-llm.md
+++ b/docs/design/security-profiles-and-system-llm.md
@@ -13,7 +13,7 @@ This document designs three related features:
 
 ### 1.1 Problem
 
-Today, every task request must specify its full tool configuration inline:
+Today, every session request must specify its full tool configuration inline:
 
 ```json
 {
@@ -28,11 +28,11 @@ Today, every task request must specify its full tool configuration inline:
 }
 ```
 
-This is tedious and error-prone. Users repeatedly configure the same tool + repo + operation combinations. There is no way to share permission sets across tasks or enforce organizational defaults.
+This is tedious and error-prone. Users repeatedly configure the same tool + repo + operation combinations. There is no way to share permission sets across sessions or enforce organizational defaults.
 
 ### 1.2 Design Overview
 
-A **security profile** is a named, reusable, per-user bundle of tool permissions. Profiles are stored in the database and referenced by name at task submission time. Multiple profiles can be stacked on a single task; their scopes merge via union.
+A **security profile** is a named, reusable, per-user bundle of tool permissions. Profiles are stored in the database and referenced by name at session submission time. Multiple profiles can be stacked on a single session; their scopes merge via union.
 
 ### 1.3 Database Schema
 
@@ -141,7 +141,7 @@ the user's profile wins.
 
 ### 1.6 Profile Stacking (Merge Semantics)
 
-When a task request specifies `"profiles": ["pulp-contributor", "code-reader"]`,
+When a session request specifies `"profiles": ["pulp-contributor", "code-reader"]`,
 Bridge resolves each profile and merges their `tools` maps using **union**
 semantics:
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -441,7 +441,7 @@ To add a new runtime:
    shared networking and proxy configuration.
 3. Wire it into Bridge startup based on the `RUNTIME` environment variable.
 
-## Skill / Agent Repos and Task Definitions
+## Skill / Agent Repos and Agent Definitions
 
 ### Skill / Agent Repos
 
@@ -482,9 +482,9 @@ The relevant code paths:
 - `cmd/skiff-init/main.go` -- `loadSkillRepos()` clones repos and builds
   `--plugin-dir` flags
 
-### Task Definition YAML Format
+### Agent Definition YAML Format
 
-Task definitions are YAML files in `.alcove/tasks/*.yml` within a task repo:
+Agent definitions are YAML files in `.alcove/tasks/*.yml` within an agent repo:
 
 ```yaml
 name: run-tests
@@ -506,17 +506,17 @@ All fields except `name` and `prompt` are optional. The `schedule` field uses
 standard 5-field cron syntax. When a schedule is present, Bridge creates a
 corresponding schedule entry automatically.
 
-### Testing with Task Repos
+### Testing with Agent Repos
 
-To test task repo syncing locally:
+To test agent repo syncing locally:
 
 1. Create a test git repo with a `.alcove/tasks/` directory containing YAML
-   task files.
+   agent files.
 2. Push it to a Git host or use a local bare repo.
 3. Register the repo via the API or dashboard.
 4. Wait for the sync interval (default 5 minutes) or trigger a manual sync
    via `POST /api/v1/task-definitions/sync`.
-5. Check the dashboard or `GET /api/v1/task-definitions` to verify the tasks
+5. Check the dashboard or `GET /api/v1/task-definitions` to verify the agents
    appear.
 
 ## Gate SCM Proxy Endpoints

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,10 +82,10 @@ Change the default password after first login.
 > **Note:** The database is ephemeral. Each `make down` + `make up` cycle wipes
 > all data (containers run with `--rm`).
 
-### 4. Submit your first task
+### 4. Start your first session
 
 From the dashboard:
-1. Click "New Task"
+1. Click "New Session"
 2. Enter a prompt like "Write a hello world Python script"
 3. Select your provider
 4. Click Submit
@@ -98,7 +98,7 @@ make build
 # Login
 ./bin/alcove login http://localhost:8080
 
-# Submit a task
+# Start a session
 ./bin/alcove run "Write a hello world Python script"
 
 # Watch it live
@@ -113,7 +113,7 @@ TOKEN=$(curl -s -X POST http://localhost:8080/api/v1/auth/login \
   -d '{"username":"admin","password":"YOUR_PASSWORD"}' \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
 
-# Submit a task
+# Start a session
 curl -X POST http://localhost:8080/api/v1/tasks \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
@@ -176,10 +176,10 @@ ALCOVE_DEBUG=true
 
 See `docs/configuration.md` for the complete list.
 
-## Skill / Agent Repos and Task Definitions
+## Skill / Agent Repos and Agent Definitions
 
 After configuring your LLM provider, you can optionally set up skill repos and
-task definitions to extend and automate your workflow.
+agent definitions to extend and automate your workflow.
 
 ### Skill / Agent Repos
 
@@ -193,17 +193,17 @@ loaded as a lola module. You just add a repo URL and Skiff figures out the
 format automatically. At task dispatch time, all configured repos are cloned
 into the Skiff container and loaded accordingly.
 
-### Task Definitions
+### Agent Definitions
 
-Task definitions are YAML files stored in git repositories under
-`.alcove/tasks/*.yml`. They let you define reusable, version-controlled tasks
+Agent definitions are YAML files stored in git repositories under
+`.alcove/tasks/*.yml`. They let you define reusable, version-controlled agents
 that appear in the dashboard for one-click execution.
 
 1. Create a git repo with a `.alcove/tasks/` directory
-2. Add YAML task files (see `docs/configuration.md` for the schema)
-3. Register the repo in the dashboard under **Task Repos** (user menu)
+2. Add YAML agent files (see `docs/configuration.md` for the schema)
+3. Register the repo in the dashboard under **Agent Repos** (user menu)
 
-Bridge syncs task repos every 5 minutes. Once synced, task definitions appear
+Bridge syncs agent repos every 5 minutes. Once synced, agent definitions appear
 on the dashboard where you can run them or view the source YAML. Starter
 templates are available to help you get started.
 
@@ -225,11 +225,11 @@ templates are available to help you get started.
 └─────────────────────────────────────────┘
 ```
 
-Each task gets a fresh Skiff container with a Gate sidecar on a dual-network
+Each session gets a fresh Skiff container with a Gate sidecar on a dual-network
 setup. Skiff is attached only to the internal network (`alcove-internal`,
 created with `--internal` so it has no external access). Gate bridges both
 the internal and external (`alcove-external`) networks, proxying all external
-traffic and injecting LLM credentials. When the task finishes, both containers
+traffic and injecting LLM credentials. When the session finishes, both containers
 are destroyed.
 
 ## GitHub/GitLab/JIRA Integration
@@ -244,7 +244,7 @@ curl -X POST http://localhost:8080/api/v1/credentials \
   -H "Content-Type: application/json" \
   -d '{"name":"github","provider":"github","auth_type":"pat","credential":"ghp_your_token"}'
 
-# Submit a task with GitHub scope
+# Start a session with GitHub scope
 curl -X POST http://localhost:8080/api/v1/tasks \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
@@ -256,7 +256,7 @@ curl -X POST http://localhost:8080/api/v1/credentials \
   -H "Content-Type: application/json" \
   -d '{"name":"jira","provider":"jira","auth_type":"basic","credential":"user@example.com:your-api-token"}'
 
-# Submit a task with JIRA scope
+# Start a session with JIRA scope
 curl -X POST http://localhost:8080/api/v1/tasks \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \

--- a/internal/auth/rh_identity_test.go
+++ b/internal/auth/rh_identity_test.go
@@ -558,7 +558,7 @@ func TestAuthMiddleware_RHIdentity_MissingHeader(t *testing.T) {
 		t.Fatal("handler should not be called")
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/tasks", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -607,7 +607,7 @@ func TestAuthMiddleware_RHIdentity_InvalidHeader(t *testing.T) {
 				t.Fatal("handler should not be called for invalid header")
 			}))
 
-			req := httptest.NewRequest(http.MethodGet, "/api/v1/tasks", nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
 			req.Header.Set("X-RH-Identity", tc.header)
 			rr := httptest.NewRecorder()
 			handler.ServeHTTP(rr, req)

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -53,13 +53,13 @@ type API struct {
 	profileStore  *ProfileStore
 	settingsStore *SettingsStore
 	llm           *BridgeLLM
-	defStore      *TaskDefStore
-	syncer        *TaskRepoSyncer
+	defStore      *AgentDefStore
+	syncer        *AgentRepoSyncer
 	authStore     auth.Authenticator // for TBR associations (rh-identity backend)
 }
 
 // NewAPI creates the API handler set.
-func NewAPI(dispatcher *Dispatcher, db *pgxpool.Pool, cfg *Config, scheduler *Scheduler, credStore *CredentialStore, toolStore *ToolStore, profileStore *ProfileStore, settingsStore *SettingsStore, llm *BridgeLLM, defStore *TaskDefStore, syncer *TaskRepoSyncer, authStore auth.Authenticator) *API {
+func NewAPI(dispatcher *Dispatcher, db *pgxpool.Pool, cfg *Config, scheduler *Scheduler, credStore *CredentialStore, toolStore *ToolStore, profileStore *ProfileStore, settingsStore *SettingsStore, llm *BridgeLLM, defStore *AgentDefStore, syncer *AgentRepoSyncer, authStore auth.Authenticator) *API {
 	return &API{
 		dispatcher:    dispatcher,
 		db:            db,
@@ -79,7 +79,6 @@ func NewAPI(dispatcher *Dispatcher, db *pgxpool.Pool, cfg *Config, scheduler *Sc
 // RegisterRoutes registers all API routes on the given mux.
 func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/health", a.handleHealth)
-	mux.HandleFunc("/api/v1/tasks", a.handleTasks)
 	mux.HandleFunc("/api/v1/sessions", a.handleSessions)
 	mux.HandleFunc("/api/v1/sessions/", a.handleSessionByID)
 	mux.HandleFunc("/api/v1/providers", a.handleProviders)
@@ -96,12 +95,12 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/admin/settings/llm", a.handleAdminSettingsLLM)
 	mux.HandleFunc("/api/v1/admin/settings/skill-repos", a.handleAdminSettingsSkillRepos)
 	mux.HandleFunc("/api/v1/user/settings/skill-repos", a.handleUserSettingsSkillRepos)
-	mux.HandleFunc("/api/v1/user/settings/task-repos", a.handleUserSettingsTaskRepos)
-	mux.HandleFunc("/api/v1/task-repos/validate", a.handleTaskRepoValidate)
-	mux.HandleFunc("/api/v1/task-definitions", a.handleTaskDefinitions)
-	mux.HandleFunc("/api/v1/task-definitions/sync", a.handleTaskDefinitionsSync)
-	mux.HandleFunc("/api/v1/task-definitions/", a.handleTaskDefinitionByID)
-	mux.HandleFunc("/api/v1/task-templates", a.handleTaskTemplates)
+	mux.HandleFunc("/api/v1/user/settings/agent-repos", a.handleUserSettingsAgentRepos)
+	mux.HandleFunc("/api/v1/agent-repos/validate", a.handleAgentRepoValidate)
+	mux.HandleFunc("/api/v1/agent-definitions", a.handleAgentDefinitions)
+	mux.HandleFunc("/api/v1/agent-definitions/sync", a.handleAgentDefinitionsSync)
+	mux.HandleFunc("/api/v1/agent-definitions/", a.handleAgentDefinitionByID)
+	mux.HandleFunc("/api/v1/agent-templates", a.handleAgentTemplates)
 	mux.HandleFunc("/api/v1/webhooks/github", a.handleWebhookGitHub)
 	mux.HandleFunc("/api/v1/admin/settings/webhook", a.handleAdminSettingsWebhook)
 	mux.HandleFunc("/api/v1/system-info", a.handleSystemInfo)
@@ -165,46 +164,37 @@ func (a *API) handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// --- Tasks ---
-
-func (a *API) handleTasks(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
-		return
-	}
-
-	var req TaskRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
-		return
-	}
-
-	if req.Prompt == "" {
-		respondError(w, http.StatusBadRequest, "prompt is required")
-		return
-	}
-
-	submitter := r.Header.Get("X-Alcove-User")
-	if submitter == "" {
-		submitter = "anonymous"
-	}
-
-	req.TriggerType = "manual"
-
-	session, err := a.dispatcher.DispatchTask(r.Context(), req, submitter)
-	if err != nil {
-		log.Printf("error: dispatch failed: %v", err)
-		respondError(w, http.StatusInternalServerError, "failed to dispatch task: "+err.Error())
-		return
-	}
-
-	respondJSON(w, http.StatusCreated, session)
-}
-
 // --- Sessions ---
 
 func (a *API) handleSessions(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
+	case http.MethodPost:
+		var req TaskRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+			return
+		}
+
+		if req.Prompt == "" {
+			respondError(w, http.StatusBadRequest, "prompt is required")
+			return
+		}
+
+		submitter := r.Header.Get("X-Alcove-User")
+		if submitter == "" {
+			submitter = "anonymous"
+		}
+
+		req.TriggerType = "manual"
+
+		session, err := a.dispatcher.DispatchTask(r.Context(), req, submitter)
+		if err != nil {
+			log.Printf("error: dispatch failed: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to dispatch session: "+err.Error())
+			return
+		}
+
+		respondJSON(w, http.StatusCreated, session)
 	case http.MethodGet:
 		query := r.URL.Query()
 		status := query.Get("status")
@@ -913,7 +903,7 @@ func (a *API) listSessions(ctx context.Context, status, repo, since, until, subm
 		COALESCE(s.repo, '') as repo
 		FROM sessions s
 		LEFT JOIN schedules sc ON s.prompt LIKE '%[' || sc.source_key || ']%' AND sc.source_key IS NOT NULL AND sc.source_key != ''
-		LEFT JOIN task_definitions td ON sc.source_key = td.source_key` +
+		LEFT JOIN agent_definitions td ON sc.source_key = td.source_key` +
 		whereClause + " ORDER BY s.started_at DESC"
 
 	offset := (page - 1) * perPage
@@ -965,7 +955,7 @@ func (a *API) listSessions(ctx context.Context, status, repo, since, until, subm
 		if taskName != "" {
 			s.TaskName = taskName
 		} else {
-			s.TaskName = "Manual Task"
+			s.TaskName = "Manual Session"
 		}
 
 		// Set trigger type and ref from stored metadata
@@ -1008,7 +998,7 @@ func (a *API) getSession(ctx context.Context, id string) (*internal.Session, err
 		COALESCE(s.repo, '') as repo
 		FROM sessions s
 		LEFT JOIN schedules sc ON s.prompt LIKE '%[' || sc.source_key || ']%' AND sc.source_key IS NOT NULL AND sc.source_key != ''
-		LEFT JOIN task_definitions td ON sc.source_key = td.source_key
+		LEFT JOIN agent_definitions td ON sc.source_key = td.source_key
 		WHERE s.id = $1`, id,
 	).Scan(&s.ID, &s.TaskID, &s.Submitter, &s.Prompt,
 		&scopeJSON, &s.Provider, &s.Status, &s.StartedAt, &finishedAt,
@@ -1041,7 +1031,7 @@ func (a *API) getSession(ctx context.Context, id string) (*internal.Session, err
 	if taskName != "" {
 		s.TaskName = taskName
 	} else {
-		s.TaskName = "Manual Task"
+		s.TaskName = "Manual Session"
 	}
 
 	// Set trigger type and ref from stored metadata
@@ -1075,11 +1065,11 @@ func (a *API) handleSchedules(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Annotate schedules with repo_disabled by joining through task definitions.
+		// Annotate schedules with repo_disabled by joining through agent definitions.
 		disabledRepos := a.buildDisabledReposMap(r.Context(), user)
 		if len(disabledRepos) > 0 {
-			// Build source_key -> source_repo map from task definitions.
-			defs, defErr := a.defStore.ListTaskDefinitions(r.Context(), user)
+			// Build source_key -> source_repo map from agent definitions.
+			defs, defErr := a.defStore.ListAgentDefinitions(r.Context(), user)
 			if defErr == nil {
 				sourceKeyToRepo := make(map[string]string)
 				for _, d := range defs {
@@ -1703,9 +1693,9 @@ func (a *API) handleUserSettingsSkillRepos(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-// --- Task Repos Settings ---
+// --- Agent Repos Settings ---
 
-func (a *API) handleUserSettingsTaskRepos(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleUserSettingsAgentRepos(w http.ResponseWriter, r *http.Request) {
 	username := r.Header.Get("X-Alcove-User")
 	if username == "" {
 		respondError(w, http.StatusUnauthorized, "authentication required")
@@ -1714,7 +1704,7 @@ func (a *API) handleUserSettingsTaskRepos(w http.ResponseWriter, r *http.Request
 
 	switch r.Method {
 	case http.MethodGet:
-		repos, err := a.settingsStore.GetUserTaskRepos(r.Context(), username)
+		repos, err := a.settingsStore.GetUserAgentRepos(r.Context(), username)
 		if err != nil {
 			repos = []SkillRepo{}
 		}
@@ -1730,8 +1720,8 @@ func (a *API) handleUserSettingsTaskRepos(w http.ResponseWriter, r *http.Request
 		if req.Repos == nil {
 			req.Repos = []SkillRepo{}
 		}
-		if err := a.settingsStore.SetUserTaskRepos(r.Context(), username, req.Repos); err != nil {
-			respondError(w, http.StatusInternalServerError, "failed to save task repos")
+		if err := a.settingsStore.SetUserAgentRepos(r.Context(), username, req.Repos); err != nil {
+			respondError(w, http.StatusInternalServerError, "failed to save agent repos")
 			return
 		}
 		go a.syncer.SyncAll(context.Background())
@@ -1741,9 +1731,9 @@ func (a *API) handleUserSettingsTaskRepos(w http.ResponseWriter, r *http.Request
 	}
 }
 
-// --- Task Repo Validation ---
+// --- Agent Repo Validation ---
 
-func (a *API) handleTaskRepoValidate(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleAgentRepoValidate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -1765,29 +1755,29 @@ func (a *API) handleTaskRepoValidate(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusBadRequest, map[string]any{"valid": false, "error": err.Error()})
 		return
 	}
-	respondJSON(w, http.StatusOK, map[string]any{"valid": true, "task_count": len(names), "tasks": names})
+	respondJSON(w, http.StatusOK, map[string]any{"valid": true, "agent_definition_count": len(names), "agent_definitions": names})
 }
 
-// --- Task Definitions ---
+// --- Agent Definitions ---
 
-func (a *API) handleTaskDefinitions(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleAgentDefinitions(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 
 	user := r.Header.Get("X-Alcove-User")
-	defs, err := a.defStore.ListTaskDefinitions(r.Context(), user)
+	defs, err := a.defStore.ListAgentDefinitions(r.Context(), user)
 	if err != nil {
-		log.Printf("error: listing task definitions: %v", err)
-		respondError(w, http.StatusInternalServerError, "failed to list task definitions")
+		log.Printf("error: listing agent definitions: %v", err)
+		respondError(w, http.StatusInternalServerError, "failed to list agent definitions")
 		return
 	}
 
-	// Fetch user's task repos to check disabled status.
+	// Fetch user's agent repos to check disabled status.
 	disabledRepos := a.buildDisabledReposMap(r.Context(), user)
 
-	// Annotate each task definition with repo_disabled.
+	// Annotate each agent definition with repo_disabled.
 	for i := range defs {
 		if disabledRepos[defs[i].SourceRepo] {
 			defs[i].RepoDisabled = true
@@ -1795,24 +1785,24 @@ func (a *API) handleTaskDefinitions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	respondJSON(w, http.StatusOK, map[string]any{
-		"task_definitions": defs,
+		"agent_definitions": defs,
 		"count":            len(defs),
 	})
 }
 
-func (a *API) handleTaskDefinitionsSync(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleAgentDefinitionsSync(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 
 	if a.syncer == nil {
-		respondError(w, http.StatusServiceUnavailable, "task repo syncer not configured")
+		respondError(w, http.StatusServiceUnavailable, "agent repo syncer not configured")
 		return
 	}
 
 	if err := a.syncer.SyncAll(r.Context()); err != nil {
-		log.Printf("error: manual task sync: %v", err)
+		log.Printf("error: manual agent sync: %v", err)
 		respondError(w, http.StatusInternalServerError, "sync failed: "+err.Error())
 		return
 	}
@@ -1820,23 +1810,23 @@ func (a *API) handleTaskDefinitionsSync(w http.ResponseWriter, r *http.Request) 
 	respondJSON(w, http.StatusOK, map[string]bool{"synced": true})
 }
 
-func (a *API) handleTaskDefinitionByID(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/api/v1/task-definitions/")
+func (a *API) handleAgentDefinitionByID(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/agent-definitions/")
 	parts := strings.SplitN(path, "/", 2)
 	id := parts[0]
 
 	if id == "" {
-		respondError(w, http.StatusBadRequest, "task definition id required")
+		respondError(w, http.StatusBadRequest, "agent definition id required")
 		return
 	}
 
-	// Handle /api/v1/task-definitions/{id}/run
+	// Handle /api/v1/agent-definitions/{id}/run
 	if len(parts) == 2 && parts[1] == "run" {
 		if r.Method != http.MethodPost {
 			respondError(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
-		a.handleTaskDefinitionRun(w, r, id)
+		a.handleAgentDefinitionRun(w, r, id)
 		return
 	}
 
@@ -1846,29 +1836,29 @@ func (a *API) handleTaskDefinitionByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user := r.Header.Get("X-Alcove-User")
-	def, err := a.defStore.GetTaskDefinition(r.Context(), id, user)
+	def, err := a.defStore.GetAgentDefinition(r.Context(), id, user)
 	if err != nil {
-		respondError(w, http.StatusNotFound, "task definition not found")
+		respondError(w, http.StatusNotFound, "agent definition not found")
 		return
 	}
 
 	respondJSON(w, http.StatusOK, def)
 }
 
-func (a *API) handleTaskDefinitionRun(w http.ResponseWriter, r *http.Request, id string) {
+func (a *API) handleAgentDefinitionRun(w http.ResponseWriter, r *http.Request, id string) {
 	submitter := r.Header.Get("X-Alcove-User")
 	if submitter == "" {
 		submitter = "anonymous"
 	}
 
-	def, err := a.defStore.GetTaskDefinition(r.Context(), id, submitter)
+	def, err := a.defStore.GetAgentDefinition(r.Context(), id, submitter)
 	if err != nil {
-		respondError(w, http.StatusNotFound, "task definition not found")
+		respondError(w, http.StatusNotFound, "agent definition not found")
 		return
 	}
 
 	if def.SyncError != "" {
-		respondError(w, http.StatusBadRequest, "task definition has sync error: "+def.SyncError)
+		respondError(w, http.StatusBadRequest, "agent definition has sync error: "+def.SyncError)
 		return
 	}
 
@@ -1877,17 +1867,17 @@ func (a *API) handleTaskDefinitionRun(w http.ResponseWriter, r *http.Request, id
 	req.TriggerType = "manual"
 	session, err := a.dispatcher.DispatchTask(r.Context(), req, submitter)
 	if err != nil {
-		log.Printf("error: dispatching task definition %s: %v", id, err)
-		respondError(w, http.StatusInternalServerError, "failed to dispatch task: "+err.Error())
+		log.Printf("error: dispatching agent definition %s: %v", id, err)
+		respondError(w, http.StatusInternalServerError, "failed to dispatch session: "+err.Error())
 		return
 	}
 
 	respondJSON(w, http.StatusCreated, session)
 }
 
-// --- Task Templates ---
+// --- Agent Templates ---
 
-func (a *API) handleTaskTemplates(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleAgentTemplates(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -2358,12 +2348,12 @@ func (a *API) handleTBRAssociationByID(w http.ResponseWriter, r *http.Request) {
 
 // buildDisabledReposMap returns a set of repo URLs that are disabled for the given user.
 func (a *API) buildDisabledReposMap(ctx context.Context, username string) map[string]bool {
-	taskRepos, err := a.settingsStore.GetUserTaskRepos(ctx, username)
+	agentRepos, err := a.settingsStore.GetUserAgentRepos(ctx, username)
 	if err != nil {
 		return nil
 	}
 	disabledRepos := make(map[string]bool)
-	for _, repo := range taskRepos {
+	for _, repo := range agentRepos {
 		if !repo.IsEnabled() {
 			disabledRepos[repo.URL] = true
 		}

--- a/internal/bridge/cigate.go
+++ b/internal/bridge/cigate.go
@@ -88,7 +88,7 @@ func (m *CIGateMonitor) OnTaskCompleted(ctx context.Context, sessionID string, a
 		return
 	}
 
-	// Look up task definition to check for ci_gate config.
+	// Look up agent definition to check for ci_gate config.
 	var sourceKey string
 	var owner string
 	err := m.db.QueryRow(ctx,
@@ -101,11 +101,11 @@ func (m *CIGateMonitor) OnTaskCompleted(ctx context.Context, sessionID string, a
 		_ = m.db.QueryRow(ctx, `SELECT submitter FROM sessions WHERE id = $1`, sessionID).Scan(&owner)
 	}
 
-	// Look up ci_gate config from task definition.
+	// Look up ci_gate config from agent definition.
 	var parsedJSON []byte
 	if sourceKey != "" {
 		_ = m.db.QueryRow(ctx,
-			`SELECT parsed FROM task_definitions WHERE source_key = $1`, sourceKey,
+			`SELECT parsed FROM agent_definitions WHERE source_key = $1`, sourceKey,
 		).Scan(&parsedJSON)
 	}
 
@@ -114,7 +114,7 @@ func (m *CIGateMonitor) OnTaskCompleted(ctx context.Context, sessionID string, a
 		_ = m.db.QueryRow(ctx,
 			`SELECT td.parsed FROM sessions sess
              JOIN schedules sch ON sch.source_key != ''
-             JOIN task_definitions td ON td.source_key = sch.source_key
+             JOIN agent_definitions td ON td.source_key = sch.source_key
              WHERE sess.id = $1 LIMIT 1`, sessionID,
 		).Scan(&parsedJSON)
 	}
@@ -330,13 +330,13 @@ func (m *CIGateMonitor) handleCIFailure(ctx context.Context, sessionID, repo str
 	}
 	json.Unmarshal(prData, &prInfo)
 
-	// Look up original task definition for full prompt, profiles, repo, provider, timeout.
+	// Look up original agent definition for full prompt, profiles, repo, provider, timeout.
 	var taskReq TaskRequest
 	var originalPrompt string
 	if sourceKey != "" {
 		var parsedJSON []byte
 		_ = m.db.QueryRow(ctx,
-			`SELECT parsed FROM task_definitions WHERE source_key = $1`, sourceKey,
+			`SELECT parsed FROM agent_definitions WHERE source_key = $1`, sourceKey,
 		).Scan(&parsedJSON)
 		if parsedJSON != nil {
 			var td TaskDefinition

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -67,7 +67,7 @@ func (d *Dispatcher) SetCIGateMonitor(m *CIGateMonitor) {
 	d.ciGate = m
 }
 
-// TaskRequest is the JSON body for POST /api/v1/tasks.
+// TaskRequest is the JSON body for POST /api/v1/sessions.
 type TaskRequest struct {
 	Prompt   string                `json:"prompt"`
 	Repo     string                `json:"repo,omitempty"`
@@ -80,7 +80,7 @@ type TaskRequest struct {
 	Budget   float64               `json:"budget_usd,omitempty"`
 	Debug    bool                  `json:"debug,omitempty"`
 	// Task metadata — set by dispatch code paths, stored in sessions table.
-	TaskName    string `json:"-"` // Schedule/task definition name
+	TaskName    string `json:"-"` // Schedule/agent definition name
 	TriggerType string `json:"-"` // "event", "cron", "manual", "webhook"
 	TriggerRef  string `json:"-"` // e.g., "bmbouter/alcove#107" for GitHub events
 }

--- a/internal/bridge/migrations/022_rename_task_to_agent.sql
+++ b/internal/bridge/migrations/022_rename_task_to_agent.sql
@@ -1,0 +1,5 @@
+-- Rename task_repos settings key to agent_repos
+UPDATE user_settings SET key = 'agent_repos' WHERE key = 'task_repos';
+
+-- Rename task_definitions table to agent_definitions
+ALTER TABLE IF EXISTS task_definitions RENAME TO agent_definitions;

--- a/internal/bridge/poller.go
+++ b/internal/bridge/poller.go
@@ -53,7 +53,7 @@ type GitHubPoller struct {
 	db         *pgxpool.Pool
 	dispatcher *Dispatcher
 	credStore  *CredentialStore
-	defStore   *TaskDefStore
+	defStore   *AgentDefStore
 	client     *http.Client
 }
 
@@ -445,7 +445,7 @@ func (p *GitHubPoller) pollRepo(ctx context.Context, repo, owner string, schedul
 				}
 			}
 
-			// Build task request. Look up task definition for profiles.
+			// Build session request. Look up agent definition for profiles.
 			taskReq := TaskRequest{
 				Prompt:   sched.Prompt,
 				Repo:     sched.Repo,
@@ -456,7 +456,7 @@ func (p *GitHubPoller) pollRepo(ctx context.Context, repo, owner string, schedul
 			if sched.SourceKey != "" {
 				var parsedJSON []byte
 				_ = p.db.QueryRow(ctx,
-					`SELECT parsed FROM task_definitions WHERE source_key = $1`, sched.SourceKey,
+					`SELECT parsed FROM agent_definitions WHERE source_key = $1`, sched.SourceKey,
 				).Scan(&parsedJSON)
 				if parsedJSON != nil {
 					var td TaskDefinition

--- a/internal/bridge/scheduler.go
+++ b/internal/bridge/scheduler.go
@@ -242,7 +242,7 @@ type Scheduler struct {
 }
 
 // NewScheduler creates a Scheduler with the given dependencies.
-func NewScheduler(db *pgxpool.Pool, dispatcher *Dispatcher, cfg *Config, credStore *CredentialStore, defStore *TaskDefStore) *Scheduler {
+func NewScheduler(db *pgxpool.Pool, dispatcher *Dispatcher, cfg *Config, credStore *CredentialStore, defStore *AgentDefStore) *Scheduler {
 	return &Scheduler{
 		db:         db,
 		dispatcher: dispatcher,

--- a/internal/bridge/settings.go
+++ b/internal/bridge/settings.go
@@ -48,7 +48,7 @@ func NewSettingsStore(db *pgxpool.Pool) *SettingsStore {
 }
 
 // SkillRepo represents a git repository containing Claude Code skills/agents
-// or task definitions.
+// or agent definitions.
 type SkillRepo struct {
 	URL     string `json:"url"`
 	Ref     string `json:"ref,omitempty"`     // branch/tag/commit, default: main
@@ -115,28 +115,28 @@ func (s *SettingsStore) SetUserSkillRepos(ctx context.Context, username string, 
 	return err
 }
 
-// GetUserTaskRepos returns a user's personal task repos.
-func (s *SettingsStore) GetUserTaskRepos(ctx context.Context, username string) ([]SkillRepo, error) {
+// GetUserAgentRepos returns a user's personal agent repos.
+func (s *SettingsStore) GetUserAgentRepos(ctx context.Context, username string) ([]SkillRepo, error) {
 	var value json.RawMessage
-	err := s.db.QueryRow(ctx, "SELECT value FROM user_settings WHERE username = $1 AND key = 'task_repos'", username).Scan(&value)
+	err := s.db.QueryRow(ctx, "SELECT value FROM user_settings WHERE username = $1 AND key = 'agent_repos'", username).Scan(&value)
 	if err != nil {
-		return nil, fmt.Errorf("user task repos not found: %w", err)
+		return nil, fmt.Errorf("user agent repos not found: %w", err)
 	}
 	var repos []SkillRepo
 	if err := json.Unmarshal(value, &repos); err != nil {
-		return nil, fmt.Errorf("unmarshaling user task repos: %w", err)
+		return nil, fmt.Errorf("unmarshaling user agent repos: %w", err)
 	}
 	return repos, nil
 }
 
-// SetUserTaskRepos saves a user's personal task repos.
-func (s *SettingsStore) SetUserTaskRepos(ctx context.Context, username string, repos []SkillRepo) error {
+// SetUserAgentRepos saves a user's personal agent repos.
+func (s *SettingsStore) SetUserAgentRepos(ctx context.Context, username string, repos []SkillRepo) error {
 	value, err := json.Marshal(repos)
 	if err != nil {
-		return fmt.Errorf("marshaling user task repos: %w", err)
+		return fmt.Errorf("marshaling user agent repos: %w", err)
 	}
 	_, err = s.db.Exec(ctx, `
-		INSERT INTO user_settings (username, key, value, updated_at) VALUES ($1, 'task_repos', $2, $3)
+		INSERT INTO user_settings (username, key, value, updated_at) VALUES ($1, 'agent_repos', $2, $3)
 		ON CONFLICT (username, key) DO UPDATE SET value = $2, updated_at = $3
 	`, username, value, time.Now().UTC())
 	return err

--- a/internal/bridge/taskdef.go
+++ b/internal/bridge/taskdef.go
@@ -31,7 +31,7 @@ type CIGate struct {
 	Timeout    int `json:"timeout" yaml:"timeout"` // seconds to wait for CI, default 900
 }
 
-// TaskDefinition represents a task defined in a YAML file within a task repo.
+// TaskDefinition represents an agent definition defined in a YAML file within an agent repo.
 type TaskDefinition struct {
 	ID          string                `json:"id"`
 	Name        string                `json:"name" yaml:"name"`
@@ -62,7 +62,7 @@ type TaskDefinition struct {
 	RepoDisabled bool       `json:"repo_disabled"`
 }
 
-// TaskDefSchedule defines an optional cron schedule for a task definition.
+// TaskDefSchedule defines an optional cron schedule for an agent definition.
 type TaskDefSchedule struct {
 	Cron    string `json:"cron" yaml:"cron"`
 	Enabled bool   `json:"enabled" yaml:"enabled"`
@@ -77,10 +77,10 @@ func ParseTaskDefinition(data []byte) (*TaskDefinition, error) {
 	}
 
 	if td.Name == "" {
-		return nil, fmt.Errorf("task definition missing required field: name")
+		return nil, fmt.Errorf("agent definition missing required field: name")
 	}
 	if td.Prompt == "" {
-		return nil, fmt.Errorf("task definition missing required field: prompt")
+		return nil, fmt.Errorf("agent definition missing required field: prompt")
 	}
 
 	if td.Schedule != nil {
@@ -117,30 +117,30 @@ func (td *TaskDefinition) ToTaskRequest() TaskRequest {
 	}
 }
 
-// TaskDefStore manages task definitions in PostgreSQL.
-type TaskDefStore struct {
+// AgentDefStore manages agent definitions in PostgreSQL.
+type AgentDefStore struct {
 	db *pgxpool.Pool
 }
 
-// NewTaskDefStore creates a TaskDefStore with the given database pool.
-func NewTaskDefStore(db *pgxpool.Pool) *TaskDefStore {
-	return &TaskDefStore{db: db}
+// NewAgentDefStore creates an AgentDefStore with the given database pool.
+func NewAgentDefStore(db *pgxpool.Pool) *AgentDefStore {
+	return &AgentDefStore{db: db}
 }
 
-// ListTaskDefinitions returns task definitions owned by the given user, with parsed data and schedule info.
-func (s *TaskDefStore) ListTaskDefinitions(ctx context.Context, owner string) ([]TaskDefinition, error) {
+// ListAgentDefinitions returns agent definitions owned by the given user, with parsed data and schedule info.
+func (s *AgentDefStore) ListAgentDefinitions(ctx context.Context, owner string) ([]TaskDefinition, error) {
 	rows, err := s.db.Query(ctx, `
 		SELECT td.id, td.name, td.description, td.source_repo, td.source_file, td.source_key,
 		       td.parsed, td.has_schedule, td.sync_error, td.last_synced,
 		       td.created_at, td.updated_at,
 		       s.next_run, s.last_run
-		FROM task_definitions td
+		FROM agent_definitions td
 		LEFT JOIN schedules s ON s.source_key = td.source_key AND s.source = 'yaml'
 		WHERE td.owner = $1
 		ORDER BY td.name ASC
 	`, owner)
 	if err != nil {
-		return nil, fmt.Errorf("querying task definitions: %w", err)
+		return nil, fmt.Errorf("querying agent definitions: %w", err)
 	}
 	defer rows.Close()
 
@@ -158,7 +158,7 @@ func (s *TaskDefStore) ListTaskDefinitions(ctx context.Context, owner string) ([
 			&createdAt, &updatedAt,
 			&td.NextRun, &td.LastRun,
 		); err != nil {
-			return nil, fmt.Errorf("scanning task definition: %w", err)
+			return nil, fmt.Errorf("scanning agent definition: %w", err)
 		}
 
 		if syncError != nil {
@@ -179,7 +179,7 @@ func (s *TaskDefStore) ListTaskDefinitions(ctx context.Context, owner string) ([
 		defs = append(defs, td)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating task definitions: %w", err)
+		return nil, fmt.Errorf("iterating agent definitions: %w", err)
 	}
 
 	if defs == nil {
@@ -188,8 +188,8 @@ func (s *TaskDefStore) ListTaskDefinitions(ctx context.Context, owner string) ([
 	return defs, nil
 }
 
-// GetTaskDefinition retrieves a single task definition by ID, scoped to the given owner.
-func (s *TaskDefStore) GetTaskDefinition(ctx context.Context, id, owner string) (*TaskDefinition, error) {
+// GetAgentDefinition retrieves a single agent definition by ID, scoped to the given owner.
+func (s *AgentDefStore) GetAgentDefinition(ctx context.Context, id, owner string) (*TaskDefinition, error) {
 	var td TaskDefinition
 	var parsedJSON []byte
 	var syncError *string
@@ -201,7 +201,7 @@ func (s *TaskDefStore) GetTaskDefinition(ctx context.Context, id, owner string) 
 		       td.raw_yaml, td.parsed, td.has_schedule, td.sync_error, td.last_synced,
 		       td.created_at, td.updated_at,
 		       s.next_run, s.last_run
-		FROM task_definitions td
+		FROM agent_definitions td
 		LEFT JOIN schedules s ON s.source_key = td.source_key AND s.source = 'yaml'
 		WHERE td.id = $1 AND td.owner = $2
 	`, id, owner).Scan(
@@ -211,7 +211,7 @@ func (s *TaskDefStore) GetTaskDefinition(ctx context.Context, id, owner string) 
 		&td.NextRun, &td.LastRun,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("querying task definition %s: %w", id, err)
+		return nil, fmt.Errorf("querying agent definition %s: %w", id, err)
 	}
 
 	if syncError != nil {
@@ -239,22 +239,22 @@ func (s *TaskDefStore) GetTaskDefinition(ctx context.Context, id, owner string) 
 	return &td, nil
 }
 
-// UpsertTaskDefinition inserts or updates a task definition by source_key.
-func (s *TaskDefStore) UpsertTaskDefinition(ctx context.Context, def *TaskDefinition) error {
+// UpsertAgentDefinition inserts or updates a agent definition by source_key.
+func (s *AgentDefStore) UpsertAgentDefinition(ctx context.Context, def *TaskDefinition) error {
 	if def.ID == "" {
 		def.ID = uuid.New().String()
 	}
 
 	parsedJSON, err := json.Marshal(def)
 	if err != nil {
-		return fmt.Errorf("marshaling parsed task definition: %w", err)
+		return fmt.Errorf("marshaling parsed agent definition: %w", err)
 	}
 
 	hasSchedule := def.Schedule != nil
 	now := time.Now().UTC()
 
 	_, err = s.db.Exec(ctx, `
-		INSERT INTO task_definitions (id, name, description, source_repo, source_file,
+		INSERT INTO agent_definitions (id, name, description, source_repo, source_file,
 		    source_key, raw_yaml, parsed, has_schedule, sync_error, last_synced, owner, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 		ON CONFLICT (source_key) DO UPDATE SET
@@ -274,31 +274,31 @@ func (s *TaskDefStore) UpsertTaskDefinition(ctx context.Context, def *TaskDefini
 		now, def.Owner, now, now,
 	)
 	if err != nil {
-		return fmt.Errorf("upserting task definition: %w", err)
+		return fmt.Errorf("upserting agent definition: %w", err)
 	}
 
 	return nil
 }
 
-// DeleteTaskDefinitionsByRepo removes all task definitions from a given repo URL and owner.
-func (s *TaskDefStore) DeleteTaskDefinitionsByRepo(ctx context.Context, repoURL, owner string) error {
-	_, err := s.db.Exec(ctx, `DELETE FROM task_definitions WHERE source_repo = $1 AND owner = $2`, repoURL, owner)
+// DeleteAgentDefinitionsByRepo removes all agent definitions from a given repo URL and owner.
+func (s *AgentDefStore) DeleteAgentDefinitionsByRepo(ctx context.Context, repoURL, owner string) error {
+	_, err := s.db.Exec(ctx, `DELETE FROM agent_definitions WHERE source_repo = $1 AND owner = $2`, repoURL, owner)
 	if err != nil {
-		return fmt.Errorf("deleting task definitions for repo %s: %w", repoURL, err)
+		return fmt.Errorf("deleting agent definitions for repo %s: %w", repoURL, err)
 	}
 	return nil
 }
 
-// ListTaskDefinitionsByRepo returns all task definitions from a given repo URL and owner.
-func (s *TaskDefStore) ListTaskDefinitionsByRepo(ctx context.Context, repoURL, owner string) ([]TaskDefinition, error) {
+// ListAgentDefinitionsByRepo returns all agent definitions from a given repo URL and owner.
+func (s *AgentDefStore) ListAgentDefinitionsByRepo(ctx context.Context, repoURL, owner string) ([]TaskDefinition, error) {
 	rows, err := s.db.Query(ctx, `
 		SELECT id, name, description, source_repo, source_file, source_key,
 		       has_schedule, sync_error, last_synced, created_at, updated_at, parsed
-		FROM task_definitions WHERE source_repo = $1 AND owner = $2
+		FROM agent_definitions WHERE source_repo = $1 AND owner = $2
 		ORDER BY name ASC
 	`, repoURL, owner)
 	if err != nil {
-		return nil, fmt.Errorf("querying task definitions for repo %s: %w", repoURL, err)
+		return nil, fmt.Errorf("querying agent definitions for repo %s: %w", repoURL, err)
 	}
 	defer rows.Close()
 
@@ -315,7 +315,7 @@ func (s *TaskDefStore) ListTaskDefinitionsByRepo(ctx context.Context, repoURL, o
 			&td.SourceKey, &hasSchedule, &syncError, &td.LastSynced,
 			&createdAt, &updatedAt, &parsedJSON,
 		); err != nil {
-			return nil, fmt.Errorf("scanning task definition: %w", err)
+			return nil, fmt.Errorf("scanning agent definition: %w", err)
 		}
 
 		if syncError != nil {
@@ -330,7 +330,7 @@ func (s *TaskDefStore) ListTaskDefinitionsByRepo(ctx context.Context, repoURL, o
 		defs = append(defs, td)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating task definitions: %w", err)
+		return nil, fmt.Errorf("iterating agent definitions: %w", err)
 	}
 
 	if defs == nil {

--- a/internal/bridge/tasksync.go
+++ b/internal/bridge/tasksync.go
@@ -30,13 +30,13 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// TaskRepoSyncer periodically clones/pulls task repos and syncs YAML task
+// AgentRepoSyncer periodically clones/pulls agent repos and syncs YAML agent
 // definitions and security profiles into the database, reconciling schedules as needed.
-type TaskRepoSyncer struct {
+type AgentRepoSyncer struct {
 	db            *pgxpool.Pool
 	settingsStore *SettingsStore
 	scheduler     *Scheduler
-	defStore      *TaskDefStore
+	defStore      *AgentDefStore
 	dispatcher    *Dispatcher
 	profileStore  *ProfileStore
 	interval      time.Duration
@@ -45,16 +45,16 @@ type TaskRepoSyncer struct {
 	syncMu        sync.Mutex // prevents concurrent SyncAll calls
 }
 
-// NewTaskRepoSyncer creates a TaskRepoSyncer with the given dependencies.
-func NewTaskRepoSyncer(db *pgxpool.Pool, settingsStore *SettingsStore, scheduler *Scheduler, defStore *TaskDefStore, dispatcher *Dispatcher, profileStore *ProfileStore) *TaskRepoSyncer {
+// NewAgentRepoSyncer creates a AgentRepoSyncer with the given dependencies.
+func NewAgentRepoSyncer(db *pgxpool.Pool, settingsStore *SettingsStore, scheduler *Scheduler, defStore *AgentDefStore, dispatcher *Dispatcher, profileStore *ProfileStore) *AgentRepoSyncer {
 	interval := 5 * time.Minute
-	if v := os.Getenv("TASK_REPO_SYNC_INTERVAL"); v != "" {
+	if v := os.Getenv("AGENT_REPO_SYNC_INTERVAL"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
 			interval = d
 		}
 	}
 
-	return &TaskRepoSyncer{
+	return &AgentRepoSyncer{
 		db:            db,
 		settingsStore: settingsStore,
 		scheduler:     scheduler,
@@ -67,14 +67,14 @@ func NewTaskRepoSyncer(db *pgxpool.Pool, settingsStore *SettingsStore, scheduler
 }
 
 // Start begins the sync loop in a background goroutine.
-func (s *TaskRepoSyncer) Start(ctx context.Context) {
+func (s *AgentRepoSyncer) Start(ctx context.Context) {
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
 
 		// Sync immediately on start.
 		if err := s.SyncAll(ctx); err != nil {
-			log.Printf("task-repo-syncer: initial sync error: %v", err)
+			log.Printf("agent-repo-syncer: initial sync error: %v", err)
 		}
 
 		ticker := time.NewTicker(s.interval)
@@ -84,7 +84,7 @@ func (s *TaskRepoSyncer) Start(ctx context.Context) {
 			select {
 			case <-ticker.C:
 				if err := s.SyncAll(ctx); err != nil {
-					log.Printf("task-repo-syncer: sync error: %v", err)
+					log.Printf("agent-repo-syncer: sync error: %v", err)
 				}
 			case <-s.stopCh:
 				return
@@ -96,17 +96,17 @@ func (s *TaskRepoSyncer) Start(ctx context.Context) {
 }
 
 // Stop signals the syncer goroutine to stop and waits for it to finish.
-func (s *TaskRepoSyncer) Stop() {
+func (s *AgentRepoSyncer) Stop() {
 	close(s.stopCh)
 	s.wg.Wait()
 }
 
-// SyncAll collects all user task repos and syncs each per-user.
-func (s *TaskRepoSyncer) SyncAll(ctx context.Context) error {
+// SyncAll collects all user agent repos and syncs each per-user.
+func (s *AgentRepoSyncer) SyncAll(ctx context.Context) error {
 	s.syncMu.Lock()
 	defer s.syncMu.Unlock()
 
-	// Collect per-user task repos.
+	// Collect per-user agent repos.
 	type userRepoSet struct {
 		username string
 		repos    []SkillRepo
@@ -114,9 +114,9 @@ func (s *TaskRepoSyncer) SyncAll(ctx context.Context) error {
 	var userRepoSets []userRepoSet
 	totalRepos := 0
 
-	// Collect all users who have task_repos configured (even if empty — they may need cleanup).
+	// Collect all users who have agent_repos configured (even if empty — they may need cleanup).
 	allUsersWithRepos := make(map[string][]SkillRepo)
-	rows, err := s.db.Query(ctx, `SELECT DISTINCT username FROM user_settings WHERE key = 'task_repos'`)
+	rows, err := s.db.Query(ctx, `SELECT DISTINCT username FROM user_settings WHERE key = 'agent_repos'`)
 	if err == nil {
 		defer rows.Close()
 		for rows.Next() {
@@ -124,7 +124,7 @@ func (s *TaskRepoSyncer) SyncAll(ctx context.Context) error {
 			if err := rows.Scan(&username); err != nil {
 				continue
 			}
-			if userRepos, err := s.settingsStore.GetUserTaskRepos(ctx, username); err == nil {
+			if userRepos, err := s.settingsStore.GetUserAgentRepos(ctx, username); err == nil {
 				allUsersWithRepos[username] = userRepos
 				if len(userRepos) > 0 {
 					userRepoSets = append(userRepoSets, userRepoSet{username: username, repos: userRepos})
@@ -140,13 +140,13 @@ func (s *TaskRepoSyncer) SyncAll(ctx context.Context) error {
 		for _, repo := range repos {
 			configuredURLs[repo.URL] = true
 		}
-		userDefs, err := s.defStore.ListTaskDefinitions(ctx, username)
+		userDefs, err := s.defStore.ListAgentDefinitions(ctx, username)
 		if err == nil {
 			removedRepos := make(map[string]bool)
 			for _, def := range userDefs {
 				if !configuredURLs[def.SourceRepo] && !removedRepos[def.SourceRepo] {
-					log.Printf("task-repo-syncer: removing tasks and profiles from %s for user %s (no longer configured)", def.SourceRepo, username)
-					_ = s.defStore.DeleteTaskDefinitionsByRepo(ctx, def.SourceRepo, username)
+					log.Printf("agent-repo-syncer: removing agent definitions and profiles from %s for user %s (no longer configured)", def.SourceRepo, username)
+					_ = s.defStore.DeleteAgentDefinitionsByRepo(ctx, def.SourceRepo, username)
 					_ = s.profileStore.DeleteYAMLProfilesByRepo(ctx, def.SourceRepo, username)
 					// Also clean up schedules from this repo.
 					s.db.Exec(ctx, `DELETE FROM schedules WHERE source_key LIKE $1 AND owner = $2`, username+"::%", username)
@@ -160,7 +160,7 @@ func (s *TaskRepoSyncer) SyncAll(ctx context.Context) error {
 		return nil
 	}
 
-	log.Printf("task-repo-syncer: syncing %d task repo(s) across %d user(s)", totalRepos, len(userRepoSets))
+	log.Printf("agent-repo-syncer: syncing %d agent repo(s) across %d user(s)", totalRepos, len(userRepoSets))
 
 	var errs []string
 	for _, urs := range userRepoSets {
@@ -171,7 +171,7 @@ func (s *TaskRepoSyncer) SyncAll(ctx context.Context) error {
 				_, _ = s.db.Exec(ctx,
 					`UPDATE schedules SET enabled = false WHERE source_key LIKE $1 || '%' AND source = 'yaml'`,
 					sourceKeyPrefix)
-				log.Printf("task-repo-syncer: repo %s disabled for user %s, schedules paused", repo.URL, urs.username)
+				log.Printf("agent-repo-syncer: repo %s disabled for user %s, schedules paused", repo.URL, urs.username)
 				continue
 			}
 			if err := s.syncRepo(ctx, repo, urs.username); err != nil {
@@ -186,15 +186,15 @@ func (s *TaskRepoSyncer) SyncAll(ctx context.Context) error {
 	return nil
 }
 
-// syncRepo clones or pulls a single repo and syncs its task definitions for the given user.
-func (s *TaskRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username string) error {
+// syncRepo clones or pulls a single repo and syncs its agent definitions for the given user.
+func (s *AgentRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username string) error {
 	// Determine local clone directory.
 	name := repo.Name
 	if name == "" {
 		// Derive name from URL.
 		name = filepath.Base(strings.TrimSuffix(repo.URL, ".git"))
 	}
-	cloneDir := filepath.Join(os.TempDir(), "alcove-task-repos", name)
+	cloneDir := filepath.Join(os.TempDir(), "alcove-agent-repos", name)
 
 	ref := repo.Ref
 	if ref == "" {
@@ -237,11 +237,11 @@ func (s *TaskRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username 
 	entries, err := os.ReadDir(tasksDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("task-repo-syncer: no .alcove/tasks/ directory in %s", repo.URL)
+			log.Printf("agent-repo-syncer: no .alcove/tasks/ directory in %s", repo.URL)
 			// Remove any previously synced definitions from this repo.
-			return s.defStore.DeleteTaskDefinitionsByRepo(ctx, repo.URL, username)
+			return s.defStore.DeleteAgentDefinitionsByRepo(ctx, repo.URL, username)
 		}
-		return fmt.Errorf("reading tasks dir: %w", err)
+		return fmt.Errorf("reading agent definitions dir: %w", err)
 	}
 
 	// Track which source_keys we see in this sync.
@@ -255,7 +255,7 @@ func (s *TaskRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username 
 		filePath := filepath.Join(tasksDir, entry.Name())
 		data, err := os.ReadFile(filePath)
 		if err != nil {
-			log.Printf("task-repo-syncer: error reading %s: %v", filePath, err)
+			log.Printf("agent-repo-syncer: error reading %s: %v", filePath, err)
 			continue
 		}
 
@@ -264,7 +264,7 @@ func (s *TaskRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username 
 
 		td, err := ParseTaskDefinition(data)
 		if err != nil {
-			log.Printf("task-repo-syncer: parse error in %s/%s: %v", repo.URL, entry.Name(), err)
+			log.Printf("agent-repo-syncer: parse error in %s/%s: %v", repo.URL, entry.Name(), err)
 			// Store the definition with sync error.
 			errDef := &TaskDefinition{
 				ID:         uuid.New().String(),
@@ -276,7 +276,7 @@ func (s *TaskRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username 
 				SyncError:  err.Error(),
 				Owner:      username,
 			}
-			_ = s.defStore.UpsertTaskDefinition(ctx, errDef)
+			_ = s.defStore.UpsertAgentDefinition(ctx, errDef)
 			continue
 		}
 
@@ -286,49 +286,49 @@ func (s *TaskRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username 
 		td.RawYAML = string(data)
 		td.Owner = username
 
-		if err := s.defStore.UpsertTaskDefinition(ctx, td); err != nil {
-			log.Printf("task-repo-syncer: upsert error for %s: %v", sourceKey, err)
+		if err := s.defStore.UpsertAgentDefinition(ctx, td); err != nil {
+			log.Printf("agent-repo-syncer: upsert error for %s: %v", sourceKey, err)
 			continue
 		}
 
 		// Reconcile schedule.
 		if err := s.reconcileSchedule(ctx, td, repo.URL, username); err != nil {
-			log.Printf("task-repo-syncer: schedule reconcile error for %s: %v", sourceKey, err)
+			log.Printf("agent-repo-syncer: schedule reconcile error for %s: %v", sourceKey, err)
 		}
 	}
 
 	// Delete definitions that no longer exist in the repo.
-	existing, err := s.defStore.ListTaskDefinitionsByRepo(ctx, repo.URL, username)
+	existing, err := s.defStore.ListAgentDefinitionsByRepo(ctx, repo.URL, username)
 	if err != nil {
 		return fmt.Errorf("listing existing definitions: %w", err)
 	}
 	for _, def := range existing {
 		if !seenKeys[def.SourceKey] {
 			// Remove the definition and its schedule.
-			if _, err := s.db.Exec(ctx, `DELETE FROM task_definitions WHERE source_key = $1`, def.SourceKey); err != nil {
-				log.Printf("task-repo-syncer: error deleting stale definition %s: %v", def.SourceKey, err)
+			if _, err := s.db.Exec(ctx, `DELETE FROM agent_definitions WHERE source_key = $1`, def.SourceKey); err != nil {
+				log.Printf("agent-repo-syncer: error deleting stale definition %s: %v", def.SourceKey, err)
 			}
 			if _, err := s.db.Exec(ctx, `DELETE FROM schedules WHERE source_key = $1`, def.SourceKey); err != nil {
-				log.Printf("task-repo-syncer: error deleting stale schedule for %s: %v", def.SourceKey, err)
+				log.Printf("agent-repo-syncer: error deleting stale schedule for %s: %v", def.SourceKey, err)
 			}
 		}
 	}
 
-	log.Printf("task-repo-syncer: synced %d task(s) from %s", len(seenKeys), repo.URL)
+	log.Printf("agent-repo-syncer: synced %d agent definition(s) from %s", len(seenKeys), repo.URL)
 
-	// Validate profile references in task definitions.
+	// Validate profile references in agent definitions.
 	s.validateProfileReferences(ctx, repo.URL, username)
 
 	return nil
 }
 
 // syncSecurityProfiles syncs .alcove/security-profiles/*.yml from a cloned repo for the given user.
-func (s *TaskRepoSyncer) syncSecurityProfiles(ctx context.Context, cloneDir string, repo SkillRepo, username string) {
+func (s *AgentRepoSyncer) syncSecurityProfiles(ctx context.Context, cloneDir string, repo SkillRepo, username string) {
 	profilesDir := filepath.Join(cloneDir, ".alcove", "security-profiles")
 	entries, err := os.ReadDir(profilesDir)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			log.Printf("task-repo-syncer: error reading security-profiles dir: %v", err)
+			log.Printf("agent-repo-syncer: error reading security-profiles dir: %v", err)
 		}
 		// No profiles dir — clean up any previously synced profiles from this repo.
 		_ = s.profileStore.DeleteYAMLProfilesByRepo(ctx, repo.URL, username)
@@ -345,7 +345,7 @@ func (s *TaskRepoSyncer) syncSecurityProfiles(ctx context.Context, cloneDir stri
 		filePath := filepath.Join(profilesDir, entry.Name())
 		data, err := os.ReadFile(filePath)
 		if err != nil {
-			log.Printf("task-repo-syncer: error reading %s: %v", filePath, err)
+			log.Printf("agent-repo-syncer: error reading %s: %v", filePath, err)
 			continue
 		}
 
@@ -354,7 +354,7 @@ func (s *TaskRepoSyncer) syncSecurityProfiles(ctx context.Context, cloneDir stri
 
 		profile, err := ParseSecurityProfile(data)
 		if err != nil {
-			log.Printf("task-repo-syncer: profile parse error in %s/%s: %v", repo.URL, entry.Name(), err)
+			log.Printf("agent-repo-syncer: profile parse error in %s/%s: %v", repo.URL, entry.Name(), err)
 			continue
 		}
 
@@ -364,34 +364,34 @@ func (s *TaskRepoSyncer) syncSecurityProfiles(ctx context.Context, cloneDir stri
 		profile.Owner = username
 
 		if err := s.profileStore.UpsertYAMLProfile(ctx, profile); err != nil {
-			log.Printf("task-repo-syncer: profile upsert error for %s: %v", sourceKey, err)
+			log.Printf("agent-repo-syncer: profile upsert error for %s: %v", sourceKey, err)
 		}
 	}
 
 	// Delete stale YAML profiles from this repo.
 	existingKeys, err := s.profileStore.ListYAMLProfileKeysByRepo(ctx, repo.URL, username)
 	if err != nil {
-		log.Printf("task-repo-syncer: error listing existing profile keys: %v", err)
+		log.Printf("agent-repo-syncer: error listing existing profile keys: %v", err)
 		return
 	}
 	for _, key := range existingKeys {
 		if !seenKeys[key] {
 			if _, err := s.db.Exec(ctx, `DELETE FROM security_profiles WHERE source_key = $1`, key); err != nil {
-				log.Printf("task-repo-syncer: error deleting stale profile %s: %v", key, err)
+				log.Printf("agent-repo-syncer: error deleting stale profile %s: %v", key, err)
 			}
 		}
 	}
 
-	log.Printf("task-repo-syncer: synced %d security profile(s) from %s", len(seenKeys), repo.URL)
+	log.Printf("agent-repo-syncer: synced %d security profile(s) from %s", len(seenKeys), repo.URL)
 }
 
-// validateProfileReferences checks that all profile references in task definitions
+// validateProfileReferences checks that all profile references in agent definitions
 // from the given repo resolve to known profiles. Sets sync_error on definitions
 // with unknown profile references.
-func (s *TaskRepoSyncer) validateProfileReferences(ctx context.Context, repoURL string, username string) {
-	defs, err := s.defStore.ListTaskDefinitionsByRepo(ctx, repoURL, username)
+func (s *AgentRepoSyncer) validateProfileReferences(ctx context.Context, repoURL string, username string) {
+	defs, err := s.defStore.ListAgentDefinitionsByRepo(ctx, repoURL, username)
 	if err != nil {
-		log.Printf("task-repo-syncer: error listing definitions for validation: %v", err)
+		log.Printf("agent-repo-syncer: error listing definitions for validation: %v", err)
 		return
 	}
 
@@ -405,7 +405,7 @@ func (s *TaskRepoSyncer) validateProfileReferences(ctx context.Context, repoURL 
 			// No profiles referenced — clear any previous profile error.
 			if strings.HasPrefix(def.SyncError, "unknown security profile:") {
 				def.SyncError = ""
-				_ = s.defStore.UpsertTaskDefinition(ctx, &def)
+				_ = s.defStore.UpsertAgentDefinition(ctx, &def)
 			}
 			continue
 		}
@@ -422,20 +422,20 @@ func (s *TaskRepoSyncer) validateProfileReferences(ctx context.Context, repoURL 
 			syncErr := fmt.Sprintf("unknown security profile: %s", strings.Join(missing, ", "))
 			if def.SyncError != syncErr {
 				def.SyncError = syncErr
-				_ = s.defStore.UpsertTaskDefinition(ctx, &def)
-				log.Printf("task-repo-syncer: %s in %s/%s", syncErr, repoURL, def.SourceFile)
+				_ = s.defStore.UpsertAgentDefinition(ctx, &def)
+				log.Printf("agent-repo-syncer: %s in %s/%s", syncErr, repoURL, def.SourceFile)
 			}
 		} else if strings.HasPrefix(def.SyncError, "unknown security profile:") {
 			// All profiles now exist — clear the error.
 			def.SyncError = ""
-			_ = s.defStore.UpsertTaskDefinition(ctx, &def)
+			_ = s.defStore.UpsertAgentDefinition(ctx, &def)
 		}
 	}
 }
 
 // ValidateRepo clones a repo to a temp directory, checks for .alcove/tasks/*.yml,
-// parses each task definition, and returns the task names or an error.
-func (s *TaskRepoSyncer) ValidateRepo(ctx context.Context, repo SkillRepo) ([]string, error) {
+// parses each agent definition, and returns the names or an error.
+func (s *AgentRepoSyncer) ValidateRepo(ctx context.Context, repo SkillRepo) ([]string, error) {
 	dir, err := os.MkdirTemp("", "alcove-validate-*")
 	if err != nil {
 		return nil, fmt.Errorf("creating temp dir: %w", err)
@@ -470,18 +470,18 @@ func (s *TaskRepoSyncer) ValidateRepo(ctx context.Context, repo SkillRepo) ([]st
 		}
 		def, err := ParseTaskDefinition(data)
 		if err != nil {
-			return nil, fmt.Errorf("invalid task %s: %w", e.Name(), err)
+			return nil, fmt.Errorf("invalid agent definition %s: %w", e.Name(), err)
 		}
 		names = append(names, def.Name)
 	}
 	if len(names) == 0 {
-		return nil, fmt.Errorf("no valid task definitions found in .alcove/tasks/")
+		return nil, fmt.Errorf("no valid agent definitions found in .alcove/tasks/")
 	}
 	return names, nil
 }
 
-// reconcileSchedule creates, updates, or removes a schedule for a task definition.
-func (s *TaskRepoSyncer) reconcileSchedule(ctx context.Context, td *TaskDefinition, repoURL string, username string) error {
+// reconcileSchedule creates, updates, or removes a schedule for an agent definition.
+func (s *AgentRepoSyncer) reconcileSchedule(ctx context.Context, td *TaskDefinition, repoURL string, username string) error {
 	hasCron := td.Schedule != nil
 	hasTrigger := td.Trigger != nil
 

--- a/scripts/test-agent-repos.sh
+++ b/scripts/test-agent-repos.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# test-task-repos.sh — Tests for the task repo and task definitions API.
+# test-agent-repos.sh — Tests for the agent repo and agent definitions API.
 #
-# Verifies user task repo CRUD, repo validation, sync lifecycle,
-# and task definition detail endpoints.
+# Verifies user agent repo CRUD, repo validation, sync lifecycle,
+# and agent definition detail endpoints.
 #
 # Prerequisites:
 #   - Bridge running at BRIDGE_URL (default http://localhost:8080)
@@ -11,19 +11,19 @@
 #   - Internet access (tests clone repos from GitHub)
 #
 # Usage:
-#   ADMIN_PASSWORD=<pw> ./scripts/test-task-repos.sh
+#   ADMIN_PASSWORD=<pw> ./scripts/test-agent-repos.sh
 #
 # Manual UI checklist (verify in dashboard after running):
 #   [ ] Repos page > Task Repos shows configured repos
-#   [ ] Task Definitions page lists synced tasks
-#   [ ] Task Definition detail page shows raw YAML
+#   [ ] Agent Definitions page lists synced agents
+#   [ ] Agent Definition detail page shows raw YAML
 #   [ ] Removing repos and re-syncing clears definitions
 #
 # Tests:
 #   Group 1: User Task Repo CRUD (5 tests)
 #   Group 2: Validation (3 tests)
 #   Group 3: Sync Lifecycle (6 tests)
-#   Group 4: Task Definition Detail (2 tests)
+#   Group 4: Agent Definition Detail (2 tests)
 #   Group 5: Cleanup
 
 set -euo pipefail
@@ -49,24 +49,24 @@ ALCOVE_TESTING_URL="https://github.com/bmbouter/alcove-testing.git"
 # =====================================================================
 log "=== Group 1: User Task Repo CRUD ==="
 
-# Test 1.1: GET user/settings/task-repos — empty initially
-log "Test 1.1: GET task-repos — initially empty"
+# Test 1.1: GET user/settings/agent-repos — empty initially
+log "Test 1.1: GET agent-repos — initially empty"
 # Clear any existing repos first
-curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"repos":[]}' > /dev/null
-REPOS=$(curl -s "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+REPOS=$(curl -s "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('repos',[])))")
 if [ "$REPOS" = "0" ]; then
-  pass "Task repos initially empty"
+  pass "Agent repos initially empty"
 else
-  fail "Task repos not empty (got $REPOS)"
+  fail "Agent repos not empty (got $REPOS)"
 fi
 
 # Test 1.2: PUT with alcove-testing repo — 200
 log "Test 1.2: PUT alcove-testing repo"
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{\"repos\":[{\"url\":\"$ALCOVE_TESTING_URL\",\"name\":\"alcove-testing\"}]}")
@@ -78,7 +78,7 @@ fi
 
 # Test 1.3: GET — verify saved
 log "Test 1.3: GET — verify saved"
-SAVED_URL=$(curl -s "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+SAVED_URL=$(curl -s "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" | python3 -c "import json,sys; repos=json.load(sys.stdin).get('repos',[]); print(repos[0]['url'] if repos else 'EMPTY')")
 if [ "$SAVED_URL" = "$ALCOVE_TESTING_URL" ]; then
   pass "Repo URL saved correctly"
@@ -88,7 +88,7 @@ fi
 
 # Test 1.4: PUT with empty — 200
 log "Test 1.4: PUT empty repos"
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"repos":[]}')
@@ -100,12 +100,12 @@ fi
 
 # Test 1.5: GET — verify empty
 log "Test 1.5: GET — verify empty after clearing"
-REPOS=$(curl -s "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+REPOS=$(curl -s "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('repos',[])))")
 if [ "$REPOS" = "0" ]; then
-  pass "Task repos empty after clearing"
+  pass "Agent repos empty after clearing"
 else
-  fail "Task repos not empty after clearing (got $REPOS)"
+  fail "Agent repos not empty after clearing (got $REPOS)"
 fi
 
 # =====================================================================
@@ -113,23 +113,23 @@ fi
 # =====================================================================
 log "=== Group 2: Validation ==="
 
-# Test 2.1: POST validate with alcove-testing — valid=true, task_count=2
+# Test 2.1: POST validate with alcove-testing — valid=true, agent_definition_count=2
 log "Test 2.1: Validate alcove-testing repo"
-VALIDATE=$(curl -s -X POST "$BRIDGE_URL/api/v1/task-repos/validate" \
+VALIDATE=$(curl -s -X POST "$BRIDGE_URL/api/v1/agent-repos/validate" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{\"url\":\"$ALCOVE_TESTING_URL\"}")
 VALID=$(echo "$VALIDATE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('valid',False))")
-TASK_COUNT=$(echo "$VALIDATE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('task_count',0))")
-if [ "$VALID" = "True" ] && [ "$TASK_COUNT" -ge 2 ]; then
-  pass "Validate alcove-testing: valid=true, task_count=$TASK_COUNT"
+AGENT_COUNT=$(echo "$VALIDATE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('agent_definition_count',0))")
+if [ "$VALID" = "True" ] && [ "$AGENT_COUNT" -ge 2 ]; then
+  pass "Validate alcove-testing: valid=true, agent_definition_count=$AGENT_COUNT"
 else
-  fail "Validate alcove-testing: valid=$VALID, task_count=$TASK_COUNT (expected True, >=2)"
+  fail "Validate alcove-testing: valid=$VALID, agent_definition_count=$AGENT_COUNT (expected True, >=2)"
 fi
 
 # Test 2.2: POST validate with nonexistent repo — valid=false
 log "Test 2.2: Validate nonexistent repo"
-VALIDATE=$(curl -s -X POST "$BRIDGE_URL/api/v1/task-repos/validate" \
+VALIDATE=$(curl -s -X POST "$BRIDGE_URL/api/v1/agent-repos/validate" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"url":"https://github.com/this-does-not-exist-ever/no-repo-here.git"}')
@@ -142,7 +142,7 @@ fi
 
 # Test 2.3: POST validate with empty URL — 400
 log "Test 2.3: Validate empty URL"
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BRIDGE_URL/api/v1/task-repos/validate" \
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BRIDGE_URL/api/v1/agent-repos/validate" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"url":""}')
@@ -159,7 +159,7 @@ log "=== Group 3: Sync Lifecycle ==="
 
 # Test 3.1: Add alcove-testing repo
 log "Test 3.1: Add alcove-testing repo for sync"
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{\"repos\":[{\"url\":\"$ALCOVE_TESTING_URL\",\"name\":\"alcove-testing\"}]}")
@@ -171,7 +171,7 @@ fi
 
 # Test 3.2: Trigger sync
 log "Test 3.2: Trigger sync"
-SYNC_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BRIDGE_URL/api/v1/task-definitions/sync" \
+SYNC_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
   -H "Authorization: Bearer $ADMIN_TOKEN")
 if [ "$SYNC_CODE" = "200" ]; then
   pass "Sync triggered successfully"
@@ -179,28 +179,28 @@ else
   fail "Sync returned $SYNC_CODE (expected 200)"
 fi
 
-# Test 3.3: Wait and verify task definitions count=2
-log "Test 3.3: Verify synced task definitions (count=2)"
+# Test 3.3: Wait and verify agent definitions count=2
+log "Test 3.3: Verify synced agent definitions (count=2)"
 COUNT=0
 for attempt in 1 2 3 4 5; do
   sleep 3
-  COUNT=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/task-definitions" | \
+  COUNT=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/agent-definitions" | \
     python3 -c "import sys,json; print(json.load(sys.stdin).get('count',0))")
   if [ "$COUNT" -ge 2 ]; then break; fi
 done
 if [ "$COUNT" -ge 2 ]; then
   pass "Task definitions synced (count=$COUNT)"
 else
-  fail "Expected at least 2 task definitions, got $COUNT"
+  fail "Expected at least 2 agent definitions, got $COUNT"
 fi
 
 # Test 3.4: Verify fields on first definition (name, source_repo, source_file)
-log "Test 3.4: Verify task definition fields"
-DEFS_JSON=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/task-definitions")
+log "Test 3.4: Verify agent definition fields"
+DEFS_JSON=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/agent-definitions")
 FIELDS_OK=$(echo "$DEFS_JSON" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
-defs = data.get('task_definitions', [])
+defs = data.get('agent_definitions', [])
 if not defs:
     print('NO_DEFS')
     sys.exit()
@@ -220,15 +220,15 @@ else
 fi
 
 # Save first definition ID for Group 4
-FIRST_DEF_ID=$(echo "$DEFS_JSON" | python3 -c "import json,sys; defs=json.load(sys.stdin).get('task_definitions',[]); print(defs[0]['id'] if defs else 'NONE')")
+FIRST_DEF_ID=$(echo "$DEFS_JSON" | python3 -c "import json,sys; defs=json.load(sys.stdin).get('agent_definitions',[]); print(defs[0]['id'] if defs else 'NONE')")
 
 # Test 3.5: Remove repo (PUT empty) and sync
 log "Test 3.5: Remove repo and sync"
-curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"repos":[]}' > /dev/null
-SYNC_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BRIDGE_URL/api/v1/task-definitions/sync" \
+SYNC_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
   -H "Authorization: Bearer $ADMIN_TOKEN")
 if [ "$SYNC_CODE" = "200" ]; then
   pass "Sync after removing repos returned 200"
@@ -236,49 +236,49 @@ else
   fail "Sync after removing repos returned $SYNC_CODE"
 fi
 
-# Test 3.6: Verify task definitions cleared (count=0)
+# Test 3.6: Verify agent definitions cleared (count=0)
 log "Test 3.6: Verify definitions cleared after removing repos"
 COUNT=0
 for attempt in 1 2 3 4 5; do
   sleep 3
-  COUNT=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/task-definitions" | \
+  COUNT=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/agent-definitions" | \
     python3 -c "import sys,json; print(json.load(sys.stdin).get('count',0))")
   if [ "$COUNT" = "0" ]; then break; fi
 done
 if [ "$COUNT" = "0" ]; then
   pass "Task definitions cleared (count=0)"
 else
-  fail "Expected 0 task definitions after clearing repos, got $COUNT"
+  fail "Expected 0 agent definitions after clearing repos, got $COUNT"
 fi
 
 # =====================================================================
-# Group 4: Task Definition Detail
+# Group 4: Agent Definition Detail
 # =====================================================================
-log "=== Group 4: Task Definition Detail ==="
+log "=== Group 4: Agent Definition Detail ==="
 
 # Re-add repo and sync so we have definitions to query
-curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{\"repos\":[{\"url\":\"$ALCOVE_TESTING_URL\",\"name\":\"alcove-testing\"}]}" > /dev/null
-curl -s -X POST "$BRIDGE_URL/api/v1/task-definitions/sync" \
+curl -s -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
   -H "Authorization: Bearer $ADMIN_TOKEN" > /dev/null
 for attempt in 1 2 3 4 5; do
   sleep 3
-  DEF_COUNT=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/task-definitions" | \
+  DEF_COUNT=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/agent-definitions" | \
     python3 -c "import sys,json; print(json.load(sys.stdin).get('count',0))")
   if [ "$DEF_COUNT" -gt 0 ]; then break; fi
 done
 
-DEF_ID=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/task-definitions" | \
-  python3 -c "import json,sys; defs=json.load(sys.stdin).get('task_definitions',[]); print(defs[0]['id'] if defs else 'NONE')")
+DEF_ID=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/agent-definitions" | \
+  python3 -c "import json,sys; defs=json.load(sys.stdin).get('agent_definitions',[]); print(defs[0]['id'] if defs else 'NONE')")
 
-# Test 4.1: GET task-definitions/{id} — verify has raw_yaml
-log "Test 4.1: GET task definition by ID"
+# Test 4.1: GET agent-definitions/{id} — verify has raw_yaml
+log "Test 4.1: GET agent definition by ID"
 if [ "$DEF_ID" = "NONE" ]; then
-  fail "No task definition ID available to test detail endpoint"
+  fail "No agent definition ID available to test detail endpoint"
 else
-  HAS_YAML=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/task-definitions/$DEF_ID" | \
+  HAS_YAML=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/agent-definitions/$DEF_ID" | \
     python3 -c "import json,sys; d=json.load(sys.stdin); print('yes' if d.get('raw_yaml','') else 'no')")
   if [ "$HAS_YAML" = "yes" ]; then
     pass "Task definition detail includes raw_yaml"
@@ -287,25 +287,25 @@ else
   fi
 fi
 
-# Test 4.2: GET task-definitions/nonexistent — 404
-log "Test 4.2: GET nonexistent task definition"
+# Test 4.2: GET agent-definitions/nonexistent — 404
+log "Test 4.2: GET nonexistent agent definition"
 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $ADMIN_TOKEN" \
-  "$BRIDGE_URL/api/v1/task-definitions/00000000-0000-0000-0000-000000000000")
+  "$BRIDGE_URL/api/v1/agent-definitions/00000000-0000-0000-0000-000000000000")
 if [ "$HTTP_CODE" = "404" ]; then
-  pass "Nonexistent task definition returns 404"
+  pass "Nonexistent agent definition returns 404"
 else
-  fail "Nonexistent task definition returned $HTTP_CODE (expected 404)"
+  fail "Nonexistent agent definition returned $HTTP_CODE (expected 404)"
 fi
 
 # =====================================================================
 # Group 5: Cleanup
 # =====================================================================
 log "=== Group 5: Cleanup ==="
-curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"repos":[]}' > /dev/null
-curl -s -X POST "$BRIDGE_URL/api/v1/task-definitions/sync" \
+curl -s -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
   -H "Authorization: Bearer $ADMIN_TOKEN" > /dev/null
 log "Cleanup complete: repos cleared, final sync triggered"
 

--- a/scripts/test-gate-real.sh
+++ b/scripts/test-gate-real.sh
@@ -108,7 +108,7 @@ log "Profile created."
 # ---------------------------------------------------------------------------
 log "Dispatching task to start Gate container..."
 
-TASK_RESP=$(curl -s -X POST "${BRIDGE_URL}/api/v1/tasks" \
+TASK_RESP=$(curl -s -X POST "${BRIDGE_URL}/api/v1/sessions" \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Content-Type: application/json" \
     -d "{

--- a/scripts/test-jira-gate.sh
+++ b/scripts/test-jira-gate.sh
@@ -126,7 +126,7 @@ log "Blocked profile created."
 
 # Dispatch a task with the blocked profile
 log "Dispatching task for blocked scope..."
-TASK_RESP=$(curl -s -X POST "${BRIDGE_URL}/api/v1/tasks" \
+TASK_RESP=$(curl -s -X POST "${BRIDGE_URL}/api/v1/sessions" \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Content-Type: application/json" \
     -d "{
@@ -322,7 +322,7 @@ log "Read-only profile created."
 
 # Dispatch a task with the readonly profile
 log "Dispatching task for read-only scope..."
-TASK_RESP=$(curl -s -X POST "${BRIDGE_URL}/api/v1/tasks" \
+TASK_RESP=$(curl -s -X POST "${BRIDGE_URL}/api/v1/sessions" \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Content-Type: application/json" \
     -d "{

--- a/scripts/test-ledger-access.sh
+++ b/scripts/test-ledger-access.sh
@@ -60,12 +60,12 @@ BOB_TOKEN=$(curl -s -X POST "$BRIDGE_URL/api/v1/auth/login" \
 # --- Test 1: Create sessions as different users ---
 log "Test 1: Creating sessions as alice and bob..."
 
-ALICE_SESSION=$(curl -s -X POST "$BRIDGE_URL/api/v1/tasks" \
+ALICE_SESSION=$(curl -s -X POST "$BRIDGE_URL/api/v1/sessions" \
   -H "Authorization: Bearer $ALICE_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"prompt":"Alice test prompt","provider":"default","timeout":10}' | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
 
-BOB_SESSION=$(curl -s -X POST "$BRIDGE_URL/api/v1/tasks" \
+BOB_SESSION=$(curl -s -X POST "$BRIDGE_URL/api/v1/sessions" \
   -H "Authorization: Bearer $BOB_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"prompt":"Bob test prompt","provider":"default","timeout":10}' | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")

--- a/scripts/test-user-isolation.sh
+++ b/scripts/test-user-isolation.sh
@@ -117,14 +117,14 @@ fi
 log "Test: Session isolation"
 
 # Alice creates a session (may fail if no LLM provider configured)
-ALICE_SESSION=$(curl -s -X POST "$BRIDGE_URL/api/v1/tasks" \
+ALICE_SESSION=$(curl -s -X POST "$BRIDGE_URL/api/v1/sessions" \
   -H "Authorization: Bearer $ALICE_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"prompt":"Alice test","provider":"default","timeout":10}' | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
 echo "  Alice session: $ALICE_SESSION"
 
 # Bob creates a session
-BOB_SESSION=$(curl -s -X POST "$BRIDGE_URL/api/v1/tasks" \
+BOB_SESSION=$(curl -s -X POST "$BRIDGE_URL/api/v1/sessions" \
   -H "Authorization: Bearer $BOB_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"prompt":"Bob test","provider":"default","timeout":10}' | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")

--- a/scripts/test-yaml-security-profiles.sh
+++ b/scripts/test-yaml-security-profiles.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# test-yaml-security-profiles.sh — Tests for YAML security profiles synced from task repos.
+# test-yaml-security-profiles.sh — Tests for YAML security profiles synced from agent repos.
 #
-# Verifies that YAML-defined security profiles are synced from task repos,
+# Verifies that YAML-defined security profiles are synced from agent repos,
 # are read-only (cannot be modified or deleted), and are cleaned up when
 # repos are removed.
 #
@@ -39,11 +39,11 @@ ADMIN_TOKEN=$(curl -s -X POST "$BRIDGE_URL/api/v1/auth/login" \
 ALCOVE_TESTING_URL="https://github.com/bmbouter/alcove-testing.git"
 
 # Clear any existing repos first to start clean
-curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"repos":[]}' > /dev/null
-curl -s -X POST "$BRIDGE_URL/api/v1/task-definitions/sync" \
+curl -s -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
   -H "Authorization: Bearer $ADMIN_TOKEN" > /dev/null
 sleep 3
 
@@ -54,7 +54,7 @@ log "=== Group 1: Add repo and sync ==="
 
 # Test 1.1: Add alcove-testing repo
 log "Test 1.1: Add alcove-testing repo"
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{\"repos\":[{\"url\":\"$ALCOVE_TESTING_URL\",\"name\":\"alcove-testing\"}]}")
@@ -66,7 +66,7 @@ fi
 
 # Test 1.2: Trigger sync
 log "Test 1.2: Trigger sync"
-SYNC_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BRIDGE_URL/api/v1/task-definitions/sync" \
+SYNC_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
   -H "Authorization: Bearer $ADMIN_TOKEN")
 if [ "$SYNC_CODE" = "200" ]; then
   pass "Sync triggered successfully (200)"
@@ -162,13 +162,13 @@ fi
 # =====================================================================
 log "=== Group 3: Task definitions have no sync_error ==="
 
-# Test 3.1: Verify synced task definitions do not have sync_error
+# Test 3.1: Verify synced agent definitions do not have sync_error
 log "Test 3.1: Task definitions from alcove-testing have no sync_error"
-DEFS_JSON=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/task-definitions")
+DEFS_JSON=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$BRIDGE_URL/api/v1/agent-definitions")
 SYNC_ERRORS=$(echo "$DEFS_JSON" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
-defs = data.get('task_definitions', [])
+defs = data.get('agent_definitions', [])
 errors = [d['name'] for d in defs if d.get('sync_error', '')]
 if errors:
     print('ERRORS: ' + ', '.join(errors))
@@ -176,7 +176,7 @@ else:
     print('NONE')
 ")
 if [ "$SYNC_ERRORS" = "NONE" ]; then
-  pass "No task definitions have sync_error"
+  pass "No agent definitions have sync_error"
 else
   fail "Task definitions with sync_error: $SYNC_ERRORS"
 fi
@@ -186,21 +186,21 @@ fi
 # =====================================================================
 log "=== Group 4: Cleanup ==="
 
-# Test 4.1: Remove task repos
-log "Test 4.1: Remove task repos"
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$BRIDGE_URL/api/v1/user/settings/task-repos" \
+# Test 4.1: Remove agent repos
+log "Test 4.1: Remove agent repos"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"repos":[]}')
 if [ "$HTTP_CODE" = "200" ]; then
-  pass "Removed task repos (200)"
+  pass "Removed agent repos (200)"
 else
   fail "Failed to remove repos: $HTTP_CODE"
 fi
 
 # Test 4.2: Trigger sync after removing repos
 log "Test 4.2: Trigger sync after cleanup"
-SYNC_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BRIDGE_URL/api/v1/task-definitions/sync" \
+SYNC_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
   -H "Authorization: Bearer $ADMIN_TOKEN")
 if [ "$SYNC_CODE" = "200" ]; then
   pass "Cleanup sync triggered (200)"

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -1337,7 +1337,7 @@ select.input {
 .vertex-guide-panel a { color: var(--accent); text-decoration: underline; }
 .vertex-guide-note { font-size: 12px; color: var(--text-muted); margin-top: 10px; margin-bottom: 4px; }
 
-/* Tools section on New Task form */
+/* Tools section on New Session form */
 .tools-section { margin: 16px 0; }
 .tools-section summary { cursor: pointer; color: var(--accent-light); font-size: 14px; font-weight: 500; }
 .tools-section-content { padding: 12px 0; }
@@ -1606,15 +1606,15 @@ select.input {
 }
 
 
-/* === Task Form Warnings === */
-.task-warnings {
+/* === Session Form Warnings === */
+.session-warnings {
     display: flex;
     flex-direction: column;
     gap: 8px;
     margin-bottom: 12px;
 }
 
-.task-warning {
+.session-warning {
     display: flex;
     align-items: flex-start;
     gap: 8px;
@@ -1624,24 +1624,24 @@ select.input {
     line-height: 1.4;
 }
 
-.task-warning-caution {
+.session-warning-caution {
     background: rgba(243, 156, 18, 0.1);
     border: 1px solid rgba(243, 156, 18, 0.3);
     color: var(--status-cancelled);
 }
 
-.task-warning-info {
+.session-warning-info {
     background: rgba(52, 152, 219, 0.1);
     border: 1px solid rgba(52, 152, 219, 0.3);
     color: var(--status-running);
 }
 
-.task-warning-icon {
+.session-warning-icon {
     flex-shrink: 0;
     font-size: 14px;
 }
 
-.task-warning a {
+.session-warning a {
     color: inherit;
     text-decoration: underline;
 }
@@ -1711,8 +1711,8 @@ select.input {
     padding: 12px 0;
 }
 
-/* Task Repos */
-.task-repo-item {
+/* Agent Repos */
+.agent-repo-item {
     display: flex;
     align-items: center;
     gap: 12px;
@@ -1722,23 +1722,23 @@ select.input {
     margin-bottom: 8px;
 }
 
-.task-repo-item .task-repo-url {
+.agent-repo-item .agent-repo-url {
     flex: 1;
     font-family: var(--font-mono);
     font-size: 13px;
 }
 
-.task-repo-item .task-repo-ref {
+.agent-repo-item .agent-repo-ref {
     color: var(--text-muted);
     font-size: 12px;
 }
 
-.task-repo-item .task-repo-name {
+.agent-repo-item .agent-repo-name {
     color: var(--text-muted);
     font-size: 12px;
 }
 
-.task-repo-item .task-repo-delete {
+.agent-repo-item .agent-repo-delete {
     cursor: pointer;
     color: var(--status-error);
     background: none;
@@ -1746,24 +1746,24 @@ select.input {
     font-size: 16px;
 }
 
-.task-repo-item .task-repo-delete:hover {
+.agent-repo-item .agent-repo-delete:hover {
     opacity: 0.8;
 }
 
-.task-repo-add h4 {
+.agent-repo-add h4 {
     color: var(--text);
     font-size: 14px;
     margin-bottom: 12px;
 }
 
-.task-repos-empty {
+.agent-repos-empty {
     color: var(--text-muted);
     font-size: 13px;
     padding: 12px 0;
 }
 
-/* Task Definition Cards */
-.task-def-card {
+/* Agent Definition Cards */
+.agent-def-card {
     background: var(--bg-card);
     border-radius: 8px;
     padding: 16px;
@@ -1771,38 +1771,38 @@ select.input {
     border: 1px solid var(--border);
 }
 
-.task-def-header {
+.agent-def-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     gap: 16px;
 }
 
-.task-def-name {
+.agent-def-name {
     font-weight: 600;
     font-size: 15px;
 }
 
-.task-def-actions {
+.agent-def-actions {
     display: flex;
     gap: 8px;
     flex-shrink: 0;
 }
 
-.task-def-desc {
+.agent-def-desc {
     font-size: 13px;
     color: var(--text-muted);
     margin-top: 4px;
 }
 
-.task-def-tags {
+.agent-def-tags {
     display: flex;
     flex-wrap: wrap;
     gap: 6px;
     margin-top: 10px;
 }
 
-.task-def-tag {
+.agent-def-tag {
     display: inline-block;
     padding: 2px 8px;
     border-radius: 4px;
@@ -1810,27 +1810,27 @@ select.input {
     font-weight: 500;
 }
 
-.task-def-tag-profile {
+.agent-def-tag-profile {
     background: rgba(46, 204, 113, 0.15);
     color: #2ecc71;
 }
 
-.task-def-tag-repo {
+.agent-def-tag-repo {
     background: rgba(52, 152, 219, 0.15);
     color: var(--status-running);
 }
 
-.task-def-tag-yaml {
+.agent-def-tag-yaml {
     background: rgba(46, 204, 113, 0.15);
     color: #2ecc71;
 }
 
-.task-def-tag-manual {
+.agent-def-tag-manual {
     background: rgba(243, 156, 18, 0.15);
     color: var(--status-cancelled);
 }
 
-.task-def-details {
+.agent-def-details {
     display: flex;
     flex-wrap: wrap;
     gap: 16px;
@@ -1839,14 +1839,14 @@ select.input {
     color: var(--text-muted);
 }
 
-.task-def-detail-item code {
+.agent-def-detail-item code {
     background: var(--bg-input);
     padding: 1px 5px;
     border-radius: 3px;
     font-size: 11px;
 }
 
-.task-def-label {
+.agent-def-label {
     color: var(--text-secondary);
     font-weight: 600;
     text-transform: uppercase;
@@ -1855,11 +1855,11 @@ select.input {
     margin-right: 4px;
 }
 
-.task-def-dim {
+.agent-def-dim {
     opacity: 0.6;
 }
 
-.task-def-error {
+.agent-def-error {
     color: var(--status-error);
     font-size: 12px;
     margin-top: 8px;
@@ -2081,25 +2081,25 @@ select.input {
     font-weight: 600;
 }
 
-/* Task def card paused state */
-.task-def-paused-repo {
+/* Agent def card paused state */
+.agent-def-paused-repo {
     opacity: 0.6;
     border-left: 3px solid #f39c12;
 }
-.task-def-paused-link {
+.agent-def-paused-link {
     font-size: 12px;
     color: #3498db;
     cursor: pointer;
 }
-.task-def-paused-link:hover { text-decoration: underline; }
+.agent-def-paused-link:hover { text-decoration: underline; }
 
 /* Text utility */
 .text-muted { color: var(--text-muted); }
 
-/* === Task List Redesign === */
+/* === Session List Redesign === */
 
-/* Task type pills */
-.task-type-pill {
+/* Agent type pills */
+.agent-type-pill {
     display: inline-block;
     font-size: 10px;
     padding: 2px 6px;
@@ -2110,11 +2110,11 @@ select.input {
     vertical-align: middle;
     text-transform: uppercase;
 }
-.task-type-dev { background: rgba(52,152,219,0.15); color: #3498db; }
-.task-type-review { background: rgba(155,89,182,0.15); color: #9b59b6; }
-.task-type-plan { background: rgba(46,204,113,0.15); color: #2ecc71; }
-.task-type-release { background: rgba(243,156,18,0.15); color: #f39c12; }
-.task-type-neutral { background: rgba(127,127,127,0.12); color: #888; }
+.agent-type-dev { background: rgba(52,152,219,0.15); color: #3498db; }
+.agent-type-review { background: rgba(155,89,182,0.15); color: #9b59b6; }
+.agent-type-plan { background: rgba(46,204,113,0.15); color: #2ecc71; }
+.agent-type-release { background: rgba(243,156,18,0.15); color: #f39c12; }
+.agent-type-neutral { background: rgba(127,127,127,0.12); color: #888; }
 
 /* Status left border on rows */
 .session-row { border-left: 4px solid transparent; transition: background 0.15s; }
@@ -2168,7 +2168,7 @@ select.input {
 }
 .trigger-link:hover { text-decoration: underline; }
 
-/* Empty state (task list redesign) */
+/* Empty state (session list redesign) */
 .empty-state-redesign {
     text-align: center;
     padding: 60px 20px;

--- a/web/index.html
+++ b/web/index.html
@@ -38,8 +38,8 @@
                 <h1 class="brand">Alcove</h1>
             </div>
             <nav class="top-bar-nav" aria-label="Main navigation">
-                <a href="#task/new" class="nav-tab" data-tab="task/new">New Task</a>
-                <a href="#sessions" class="nav-tab" data-tab="sessions">Tasks</a>
+                <a href="#task/new" class="nav-tab" data-tab="task/new">New Session</a>
+                <a href="#sessions" class="nav-tab" data-tab="sessions">Sessions</a>
                 <a href="#schedules" class="nav-tab" data-tab="schedules">Schedules</a>
                 <a href="#credentials" class="nav-tab" data-tab="credentials">Credentials</a>
                 <a href="#security" class="nav-tab" data-tab="security">Security</a>
@@ -83,7 +83,7 @@
             <div id="page-sessions" class="page" hidden>
 
                 <div class="page-header">
-                    <h2>Tasks</h2>
+                    <h2>Sessions</h2>
                     <div class="filters">
                         <select id="filter-status" class="input input-small" aria-label="Filter by status">
                             <option value="">All Statuses</option>
@@ -93,7 +93,7 @@
                             <option value="cancelled">Cancelled</option>
                             <option value="timeout">Timeout</option>
                         </select>
-                        <input type="text" id="filter-search" class="input input-small" placeholder="Search tasks..." aria-label="Search tasks">
+                        <input type="text" id="filter-search" class="input input-small" placeholder="Search sessions..." aria-label="Search sessions">
                     </div>
                 </div>
                 <div id="sessions-table-container" class="table-container">
@@ -101,7 +101,7 @@
                         <thead>
                             <tr>
                                 <th style="width:40px"></th>
-                                <th>Task</th>
+                                <th>Session</th>
                                 <th>Submitter</th>
                                 <th>When</th>
                                 <th>Duration</th>
@@ -114,20 +114,20 @@
                     </div>
                     <div id="sessions-loading" class="loading-state" hidden>
                         <div class="spinner"></div>
-                        <p>Loading tasks...</p>
+                        <p>Loading sessions...</p>
                     </div>
                 </div>
             </div>
 
-            <!-- New Task -->
+            <!-- New Session -->
             <div id="page-task-new" class="page" hidden>
                 <div class="page-header">
-                    <h2>New Task</h2>
+                    <h2>New Session</h2>
                 </div>
                 <form id="task-form" class="form-card">
                     <div class="form-group">
                         <label for="task-prompt">Prompt <span class="required">*</span></label>
-                        <textarea id="task-prompt" class="input" rows="6" required placeholder="Describe the task for the AI agent..."></textarea>
+                        <textarea id="task-prompt" class="input" rows="6" required placeholder="Describe what the agent should do..."></textarea>
                     </div>
                     <div class="form-row">
                         <div class="form-group form-group-half">
@@ -145,14 +145,14 @@
                         <div class="form-group form-group-half">
                             <label for="task-timeout">Timeout (minutes): <span id="timeout-value">60</span></label>
                             <input type="range" id="task-timeout" class="input-range" min="5" max="240" value="60" step="5">
-                            <small class="form-help">Task will be stopped if it exceeds this duration.</small>
+                            <small class="form-help">Session will be stopped if it exceeds this duration.</small>
                         </div>
                         <div class="form-group form-group-half">
                             <label class="checkbox-label">
                                 <input type="checkbox" id="task-debug">
                                 <span>Debug mode</span>
                             </label>
-                            <small class="form-help">Preserves worker containers after completion for debugging failed tasks.</small>
+                            <small class="form-help">Preserves worker containers after completion for debugging failed sessions.</small>
                         </div>
                     </div>
                     <div class="form-group">
@@ -169,10 +169,10 @@
                             <strong>Tip: Stack profiles for mixed repo scoping.</strong> For example, use a "read-all" profile (all repos) with a "pulp-contributor" profile (specific repos) to read broadly but write only to selected repos.
                         </div>
                     </div>
-                    <div id="task-warnings" class="task-warnings" hidden></div>
+                    <div id="task-warnings" class="session-warnings" hidden></div>
                     <div id="task-error" class="error-message" role="alert" hidden></div>
                     <div id="task-success" class="success-message" role="status" hidden></div>
-                    <button type="submit" class="btn btn-primary">Submit Task</button>
+                    <button type="submit" class="btn btn-primary">Start Session</button>
                 </form>
             </div>
 
@@ -305,7 +305,7 @@
                     <button id="browse-templates" class="btn btn-small btn-primary">Browse Templates</button>
                 </div>
                 <div id="unified-schedules-list"></div>
-                <div id="unified-schedules-empty" class="empty-state" hidden><p>No schedules or task definitions found.</p></div>
+                <div id="unified-schedules-empty" class="empty-state" hidden><p>No schedules or agent definitions found.</p></div>
                 <div id="unified-schedules-loading" class="loading-state" hidden><div class="spinner"></div><p>Loading...</p></div>
 
             </div>
@@ -424,12 +424,12 @@
 
                 <div class="profile-stacking-hint" style="margin-bottom:16px;">
                     <strong>How profiles work:</strong> Each profile grants a set of operations, optionally scoped to specific repositories.
-                    To allow broad read access but restrict writes to certain repos, create separate profiles and select them together on a task.
+                    To allow broad read access but restrict writes to certain repos, create separate profiles and select them together on a session.
                     Permissions are merged (union) across all selected profiles.
                 </div>
 
                 <div id="security-profiles-list"></div>
-                <div id="security-empty" class="empty-state" hidden><p>No security profiles yet. Create one or add profiles to a task repo.</p></div>
+                <div id="security-empty" class="empty-state" hidden><p>No security profiles yet. Create one or add profiles to an agent repo.</p></div>
                 <div id="security-loading" class="loading-state" hidden><div class="spinner"></div><p>Loading profiles...</p></div>
 
                 <div style="margin-top:24px;">
@@ -443,10 +443,10 @@
                     <h2>Repos</h2>
                 </div>
 
-                <!-- Task Repos section -->
+                <!-- Agent Repos section -->
                 <div style="margin-bottom:32px;">
-                    <h3>Task Repos</h3>
-                    <p class="form-help" style="margin-bottom:12px;">Git repositories containing <code>.alcove/tasks/</code> with YAML task definitions and <code>.alcove/security-profiles/</code> with security profiles.</p>
+                    <h3>Agent Repos</h3>
+                    <p class="form-help" style="margin-bottom:12px;">Git repositories containing <code>.alcove/tasks/</code> with YAML agent definitions and <code>.alcove/security-profiles/</code> with security profiles.</p>
                     <div id="task-repos-inline-list"></div>
                     <div class="repo-add-form" style="margin-top:12px;">
                         <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end;">
@@ -469,7 +469,7 @@
                 <!-- Skill / Agent Repos section -->
                 <div>
                     <h3>Skill / Agent Repos</h3>
-                    <p class="form-help" style="margin-bottom:12px;">Git repositories with Claude Code plugins or lola modules, loaded into task containers.</p>
+                    <p class="form-help" style="margin-bottom:12px;">Git repositories with Claude Code plugins or lola modules, loaded into session containers.</p>
                     <div id="skill-repos-inline-list"></div>
                     <div class="repo-add-form" style="margin-top:12px;">
                         <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end;">
@@ -676,7 +676,7 @@
             <!-- Session Detail -->
             <div id="page-session-detail" class="page" hidden>
                 <div class="page-header">
-                    <button id="back-to-sessions" class="btn btn-small btn-outline">Back to Tasks</button>
+                    <button id="back-to-sessions" class="btn btn-small btn-outline">Back to Sessions</button>
                     <h2 id="detail-title">Session Detail</h2>
                 </div>
                 <div class="session-meta-grid" id="session-meta"></div>
@@ -791,7 +791,7 @@
     <!-- View YAML Modal -->
     <div id="view-yaml-modal" class="modal-overlay" hidden>
         <div class="modal-card modal-card-wide">
-            <h3 id="view-yaml-title">Task Definition</h3>
+            <h3 id="view-yaml-title">Agent Definition</h3>
             <pre id="view-yaml-content" style="background:var(--bg-input);padding:16px;border-radius:8px;overflow-x:auto;font-size:13px;max-height:60vh;overflow-y:auto;"></pre>
             <div style="display:flex;gap:8px;margin-top:16px;justify-content:flex-end;">
                 <button id="view-yaml-copy" class="btn btn-small btn-outline">Copy YAML</button>
@@ -834,7 +834,7 @@
     <div id="templates-modal" class="modal-overlay" hidden>
         <div class="modal-card modal-card-wide">
             <h3>Starter Templates</h3>
-            <p class="form-help">Copy these YAML templates into your repo's <code>.alcove/tasks/</code> directory.</p>
+            <p class="form-help">Copy these YAML templates into your repo's <code>.alcove/tasks/</code> directory to create agent definitions.</p>
             <div id="templates-list"></div>
             <div style="display:flex;gap:8px;margin-top:16px;justify-content:flex-end;">
                 <button id="templates-close" class="btn btn-outline">Close</button>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -415,7 +415,7 @@
     });
 
     // ---------------------
-    // Task Repos (inline on Schedules page)
+    // Agent Repos (inline on Repos page)
     // ---------------------
     var taskReposList = [];
 
@@ -424,16 +424,16 @@
         if (!listEl) return;
         listEl.innerHTML = '<div class="loading-state"><div class="spinner"></div><p>Loading...</p></div>';
         try {
-            var resp = await api('GET', '/api/v1/user/settings/task-repos');
+            var resp = await api('GET', '/api/v1/user/settings/agent-repos');
             if (!resp.ok) {
-                listEl.innerHTML = '<p class="error-message">Failed to load task repos.</p>';
+                listEl.innerHTML = '<p class="error-message">Failed to load agent repos.</p>';
                 return;
             }
             var data = await resp.json();
             taskReposList = data.repos || [];
             renderTaskRepos();
         } catch (err) {
-            listEl.innerHTML = '<p class="error-message">Failed to load task repos.</p>';
+            listEl.innerHTML = '<p class="error-message">Failed to load agent repos.</p>';
         }
     }
 
@@ -441,7 +441,7 @@
         var listEl = $('#task-repos-inline-list');
         if (!listEl) return;
         if (taskReposList.length === 0) {
-            listEl.innerHTML = '<p style="color:var(--text-muted);font-size:13px;">No task repos configured.</p>';
+            listEl.innerHTML = '<p style="color:var(--text-muted);font-size:13px;">No agent repos configured.</p>';
             return;
         }
         var html = '';
@@ -449,14 +449,14 @@
             var r = taskReposList[i];
             var isEnabled = r.enabled === undefined || r.enabled === null || r.enabled === true;
             var displayUrl = (r.url || '').replace(/^https?:\/\//, '').replace(/\.git$/, '');
-            var toggleTitle = isEnabled ? 'Pause tasks from this repo' : 'Resume tasks from this repo';
+            var toggleTitle = isEnabled ? 'Pause sessions from this repo' : 'Resume sessions from this repo';
             html += '<div class="repo-item ' + (isEnabled ? 'repo-active' : 'repo-paused') + '">';
             html += '<label class="toggle-switch" title="' + toggleTitle + '"><input type="checkbox" class="repo-item-enabled" data-index="' + i + '"' + (isEnabled ? ' checked' : '') + '><span class="toggle-slider"></span></label>';
             html += '<span class="' + (isEnabled ? 'toggle-label-active' : 'toggle-label-paused') + '">' + (isEnabled ? 'Active' : 'Paused') + '</span>';
             html += '<span class="repo-item-url">' + escapeHtml(displayUrl) + '</span>';
             if (r.ref && r.ref !== 'main') html += ' <span class="repo-item-ref">' + escapeHtml(r.ref) + '</span>';
             html += ' <button class="btn btn-small btn-outline repo-item-remove" data-index="' + i + '" style="color:var(--status-error);border-color:var(--status-error);padding:2px 8px;font-size:11px;">Remove</button>';
-            if (!isEnabled) html += '<div class="repo-paused-message">Tasks from this repo are paused. Schedules and event-driven tasks will not run.</div>';
+            if (!isEnabled) html += '<div class="repo-paused-message">Sessions from this repo are paused. Schedules and event-driven sessions will not run.</div>';
             html += '</div>';
         }
         listEl.innerHTML = html;
@@ -486,9 +486,9 @@
                 if (statusEl) {
                     statusEl.removeAttribute('hidden');
                     statusEl.style.color = 'var(--text-muted)';
-                    statusEl.textContent = 'Removed ' + (removed.name || removed.url) + '. Task definitions from this repo have been deleted.';
+                    statusEl.textContent = 'Removed ' + (removed.name || removed.url) + '. Agent definitions from this repo have been deleted.';
                 }
-                // Reload task definitions after sync cleans up (2s delay for background sync)
+                // Reload agent definitions after sync cleans up (2s delay for background sync)
                 setTimeout(function() { loadUnifiedSchedules(); }, 2000);
             });
         });
@@ -496,13 +496,13 @@
 
     async function saveTaskRepos() {
         try {
-            var resp = await api('PUT', '/api/v1/user/settings/task-repos', { repos: taskReposList });
+            var resp = await api('PUT', '/api/v1/user/settings/agent-repos', { repos: taskReposList });
             if (!resp.ok) {
-                alert('Failed to save task repos.');
+                alert('Failed to save agent repos.');
             }
             renderTaskRepos();
         } catch (err) {
-            alert('Failed to save task repos.');
+            alert('Failed to save agent repos.');
         }
     }
 
@@ -523,7 +523,7 @@
         statusEl.textContent = 'Cloning and validating repository...';
 
         try {
-            var resp = await api('POST', '/api/v1/task-repos/validate', { url: url, ref: ref, name: name });
+            var resp = await api('POST', '/api/v1/agent-repos/validate', { url: url, ref: ref, name: name });
             var data = await resp.json();
             if (!data.valid) {
                 statusEl.style.color = 'var(--status-error)';
@@ -536,9 +536,9 @@
             $('#task-repo-url-inline').value = '';
             $('#task-repo-ref-inline').value = '';
             statusEl.style.color = 'var(--status-running)';
-            statusEl.textContent = 'Found ' + data.task_count + ' task definition(s): ' + data.tasks.join(', ');
+            statusEl.textContent = 'Found ' + data.task_count + ' agent definition(s): ' + data.tasks.join(', ');
             await saveTaskRepos();
-            // Reload task definitions after sync completes (auto-triggered by save)
+            // Reload agent definitions after sync completes (auto-triggered by save)
             setTimeout(function() { loadUnifiedSchedules(); }, 2000);
         } catch (err) {
             statusEl.style.color = 'var(--status-error)';
@@ -550,7 +550,7 @@
     });
 
     // ---------------------
-    // Unified Schedules (task definitions + manual schedules)
+    // Unified Schedules (agent definitions + manual schedules)
     // ---------------------
     function formatRelativeTime(dateStr) {
         if (!dateStr) return '';
@@ -587,14 +587,14 @@
 
         try {
             var results = await Promise.allSettled([
-                api('GET', '/api/v1/task-definitions'),
+                api('GET', '/api/v1/agent-definitions'),
                 api('GET', '/api/v1/schedules')
             ]);
 
-            // Process task definitions
+            // Process agent definitions
             if (results[0].status === 'fulfilled' && results[0].value.ok) {
                 var data = await results[0].value.json();
-                var defs = Array.isArray(data) ? data : (data.task_definitions || data.definitions || data.items || []);
+                var defs = Array.isArray(data) ? data : (data.agent_definitions || data.task_definitions || data.definitions || data.items || []);
                 defs.forEach(function(d) {
                     allItems.push({ _type: 'task-def', _name: (d.name || 'Unnamed').toLowerCase(), data: d });
                 });
@@ -605,7 +605,7 @@
                 var data2 = await results[1].value.json();
                 var schedules = Array.isArray(data2) ? data2 : (data2.schedules || data2.items || []);
                 schedules.forEach(function(s) {
-                    // Skip YAML-sourced schedules — they're already shown as task definition cards.
+                    // Skip YAML-sourced schedules — they're already shown as agent definition cards.
                     if (s.source === 'yaml') return;
                     allItems.push({ _type: 'schedule', _name: (s.name || '').toLowerCase(), data: s });
                 });
@@ -657,17 +657,17 @@
         }
         listEl.innerHTML = html;
 
-        // Attach event handlers for task definition cards
-        listEl.querySelectorAll('.task-def-run').forEach(function(btn) {
+        // Attach event handlers for agent definition cards
+        listEl.querySelectorAll('.agent-def-run').forEach(function(btn) {
             btn.addEventListener('click', async function() {
                 var defId = btn.getAttribute('data-id');
                 btn.disabled = true;
                 btn.textContent = 'Running...';
                 try {
-                    var resp = await api('POST', '/api/v1/task-definitions/' + defId + '/run');
+                    var resp = await api('POST', '/api/v1/agent-definitions/' + defId + '/run');
                     if (!resp.ok) {
                         var data = await resp.json().catch(function() { return {}; });
-                        alert(data.error || data.message || 'Failed to run task.');
+                        alert(data.error || data.message || 'Failed to start session.');
                     } else {
                         var session = await resp.json();
                         var sessionId = session.id || session.session_id || '';
@@ -675,7 +675,7 @@
                         var link = document.createElement('a');
                         link.href = '#session/' + sessionId;
                         link.className = 'btn btn-small btn-outline';
-                        link.textContent = 'View Task';
+                        link.textContent = 'View Session';
                         link.addEventListener('click', function(e) {
                             e.preventDefault();
                             navigate('session/' + sessionId);
@@ -685,7 +685,7 @@
                     }
                 } catch (err) {
                     if (err.message !== 'unauthorized') {
-                        alert('Failed to run task.');
+                        alert('Failed to start session.');
                     }
                 }
                 btn.textContent = 'Run Now';
@@ -693,7 +693,7 @@
             });
         });
 
-        listEl.querySelectorAll('.task-def-yaml').forEach(function(btn) {
+        listEl.querySelectorAll('.agent-def-yaml').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var repo = btn.getAttribute('data-repo') || '';
                 var file = btn.getAttribute('data-file') || '';
@@ -701,7 +701,7 @@
                 if (webUrl && file) {
                     window.open(webUrl + '/blob/main/.alcove/tasks/' + file, '_blank');
                 } else {
-                    showYaml(btn.closest('.task-def-card').querySelector('.task-def-run').getAttribute('data-id'));
+                    showYaml(btn.closest('.agent-def-card').querySelector('.agent-def-run').getAttribute('data-id'));
                 }
             });
         });
@@ -794,7 +794,7 @@
         var id = d.id || '';
         var repoPaused = d.repo_disabled || false;
 
-        var html = '<div class="task-def-card' + (repoPaused ? ' task-def-paused-repo' : '') + '">';
+        var html = '<div class="agent-def-card' + (repoPaused ? ' agent-def-paused-repo' : '') + '">';
 
         // Paused-by-repo badge
         if (repoPaused) {
@@ -802,70 +802,70 @@
         }
 
         // Header row: name + actions
-        html += '<div class="task-def-header">';
-        html += '<div class="task-def-name">' + escapeHtml(name) + '</div>';
-        html += '<div class="task-def-actions">';
+        html += '<div class="agent-def-header">';
+        html += '<div class="agent-def-name">' + escapeHtml(name) + '</div>';
+        html += '<div class="agent-def-actions">';
         if (d.sync_error || repoPaused) {
             var disabledTitle = repoPaused ? 'Repo is paused' : escapeHtml(d.sync_error);
-            html += '<button class="btn btn-small btn-primary task-def-run" data-id="' + escapeHtml(id) + '" disabled title="' + disabledTitle + '" style="' + (repoPaused ? 'opacity:0.4;cursor:not-allowed;' : '') + '">Run Now</button>';
+            html += '<button class="btn btn-small btn-primary agent-def-run" data-id="' + escapeHtml(id) + '" disabled title="' + disabledTitle + '" style="' + (repoPaused ? 'opacity:0.4;cursor:not-allowed;' : '') + '">Run Now</button>';
         } else {
-            html += '<button class="btn btn-small btn-primary task-def-run" data-id="' + escapeHtml(id) + '">Run Now</button>';
+            html += '<button class="btn btn-small btn-primary agent-def-run" data-id="' + escapeHtml(id) + '">Run Now</button>';
         }
-        html += '<button class="btn btn-small btn-outline task-def-yaml" data-repo="' + escapeHtml(d.source_repo || '') + '" data-file="' + escapeHtml(d.source_file || '') + '">View YAML</button>';
+        html += '<button class="btn btn-small btn-outline agent-def-yaml" data-repo="' + escapeHtml(d.source_repo || '') + '" data-file="' + escapeHtml(d.source_file || '') + '">View YAML</button>';
         html += '</div>';
         html += '</div>';
 
         // Description
         if (desc) {
-            html += '<div class="task-def-desc">' + escapeHtml(desc) + '</div>';
+            html += '<div class="agent-def-desc">' + escapeHtml(desc) + '</div>';
         }
 
         // Tags row: yaml tag, profiles, repo
         var tags = [];
-        tags.push('<span class="task-def-tag task-def-tag-yaml">yaml</span>');
+        tags.push('<span class="agent-def-tag agent-def-tag-yaml">yaml</span>');
         if (d.profiles && d.profiles.length > 0) {
             d.profiles.forEach(function(p) {
-                tags.push('<span class="task-def-tag task-def-tag-profile">' + escapeHtml(p) + '</span>');
+                tags.push('<span class="agent-def-tag agent-def-tag-profile">' + escapeHtml(p) + '</span>');
             });
         }
         if (repo) {
             var shortRepo = repo.replace(/^https?:\/\//, '').replace(/\.git$/, '');
-            tags.push('<span class="task-def-tag task-def-tag-repo">' + escapeHtml(shortRepo) + '</span>');
+            tags.push('<span class="agent-def-tag agent-def-tag-repo">' + escapeHtml(shortRepo) + '</span>');
         }
-        html += '<div class="task-def-tags">' + tags.join('') + '</div>';
+        html += '<div class="agent-def-tags">' + tags.join('') + '</div>';
 
         // Schedule and trigger details
         var details = [];
         if (d.schedule && d.schedule.cron) {
             var schedParts = ['<code>' + escapeHtml(d.schedule.cron) + '</code>'];
             if (!d.schedule.enabled) {
-                schedParts.push('<span class="task-def-dim">disabled</span>');
+                schedParts.push('<span class="agent-def-dim">disabled</span>');
             } else if (d.next_run) {
                 schedParts.push('next ' + formatRelativeTime(d.next_run));
             }
             if (d.last_run) {
                 schedParts.push('last ran ' + formatRelativeTime(d.last_run));
             }
-            details.push('<span class="task-def-detail-item"><span class="task-def-label">Schedule</span> ' + schedParts.join(' &middot; ') + '</span>');
+            details.push('<span class="agent-def-detail-item"><span class="agent-def-label">Schedule</span> ' + schedParts.join(' &middot; ') + '</span>');
         }
         if (d.trigger && d.trigger.github) {
             var gh = d.trigger.github;
             var evts = (gh.events || []).join(', ');
             var acts = (gh.actions || []).length > 0 ? ' (' + gh.actions.join(', ') + ')' : '';
-            details.push('<span class="task-def-detail-item"><span class="task-def-label">Trigger</span> ' + escapeHtml(evts + acts) + '</span>');
+            details.push('<span class="agent-def-detail-item"><span class="agent-def-label">Trigger</span> ' + escapeHtml(evts + acts) + '</span>');
         }
         if (details.length > 0) {
-            html += '<div class="task-def-details">' + details.join('') + '</div>';
+            html += '<div class="agent-def-details">' + details.join('') + '</div>';
         }
 
         // Sync error
         if (d.sync_error) {
-            html += '<div class="task-def-error">Sync error: ' + escapeHtml(d.sync_error) + '</div>';
+            html += '<div class="agent-def-error">Sync error: ' + escapeHtml(d.sync_error) + '</div>';
         }
 
         // Paused-by-repo link
         if (repoPaused) {
-            html += '<div style="margin-top:8px;"><a href="#repos" class="task-def-paused-link">Go to Repos to re-enable</a></div>';
+            html += '<div style="margin-top:8px;"><a href="#repos" class="agent-def-paused-link">Go to Repos to re-enable</a></div>';
         }
 
         html += '</div>';
@@ -881,12 +881,12 @@
         var enabled = s.enabled !== false;
         var triggerType = s.trigger_type || 'cron';
 
-        var html = '<div class="task-def-card">';
+        var html = '<div class="agent-def-card">';
 
         // Header row: name + actions
-        html += '<div class="task-def-header">';
-        html += '<div class="task-def-name">' + escapeHtml(name) + '</div>';
-        html += '<div class="task-def-actions">';
+        html += '<div class="agent-def-header">';
+        html += '<div class="agent-def-name">' + escapeHtml(name) + '</div>';
+        html += '<div class="agent-def-actions">';
         if (isYaml) {
             html += '<button class="btn btn-small btn-outline view-schedule-yaml-btn" data-id="' + escapeHtml(id) + '">View</button>';
         } else {
@@ -899,21 +899,21 @@
         // Tags row: source tag, repo
         var tags = [];
         if (isYaml) {
-            tags.push('<span class="task-def-tag task-def-tag-yaml">yaml</span>');
+            tags.push('<span class="agent-def-tag agent-def-tag-yaml">yaml</span>');
         } else {
-            tags.push('<span class="task-def-tag task-def-tag-manual">manual</span>');
+            tags.push('<span class="agent-def-tag agent-def-tag-manual">manual</span>');
         }
         if (s.repo) {
             var shortRepo = s.repo.replace(/^https?:\/\//, '').replace(/\.git$/, '');
-            tags.push('<span class="task-def-tag task-def-tag-repo">' + escapeHtml(shortRepo) + '</span>');
+            tags.push('<span class="agent-def-tag agent-def-tag-repo">' + escapeHtml(shortRepo) + '</span>');
         }
-        html += '<div class="task-def-tags">' + tags.join('') + '</div>';
+        html += '<div class="agent-def-tags">' + tags.join('') + '</div>';
 
         // Details: cron, trigger type, next run, last run, enabled/disabled
         var details = [];
         if (cron) {
             var cronDesc = describeCron(cron);
-            details.push('<span class="task-def-detail-item"><span class="task-def-label">Cron</span> <code>' + escapeHtml(cron) + '</code> <small>' + escapeHtml(cronDesc) + '</small></span>');
+            details.push('<span class="agent-def-detail-item"><span class="agent-def-label">Cron</span> <code>' + escapeHtml(cron) + '</code> <small>' + escapeHtml(cronDesc) + '</small></span>');
         }
 
         // Trigger type
@@ -922,51 +922,51 @@
             if (s.event_config && s.event_config.events && s.event_config.events.length > 0) {
                 triggerLabel += ' (' + s.event_config.events.join(', ') + ')';
             }
-            details.push('<span class="task-def-detail-item"><span class="task-def-label">Trigger</span> ' + escapeHtml(triggerLabel) + '</span>');
+            details.push('<span class="agent-def-detail-item"><span class="agent-def-label">Trigger</span> ' + escapeHtml(triggerLabel) + '</span>');
         } else if (triggerType === 'cron-and-event') {
             var triggerLabel2 = 'cron + event';
             if (s.event_config && s.event_config.events && s.event_config.events.length > 0) {
                 triggerLabel2 += ' (' + s.event_config.events.join(', ') + ')';
             }
-            details.push('<span class="task-def-detail-item"><span class="task-def-label">Trigger</span> ' + escapeHtml(triggerLabel2) + '</span>');
+            details.push('<span class="agent-def-detail-item"><span class="agent-def-label">Trigger</span> ' + escapeHtml(triggerLabel2) + '</span>');
         }
 
         var nextRun = s.next_run || s.next_run_at;
         var lastRun = s.last_run || s.last_run_at;
         if (nextRun) {
-            details.push('<span class="task-def-detail-item"><span class="task-def-label">Next</span> ' + formatRelativeTime(nextRun) + '</span>');
+            details.push('<span class="agent-def-detail-item"><span class="agent-def-label">Next</span> ' + formatRelativeTime(nextRun) + '</span>');
         }
         if (lastRun) {
-            details.push('<span class="task-def-detail-item"><span class="task-def-label">Last</span> ' + formatRelativeTime(lastRun) + '</span>');
+            details.push('<span class="agent-def-detail-item"><span class="agent-def-label">Last</span> ' + formatRelativeTime(lastRun) + '</span>');
         }
 
         // Enabled/disabled
         if (!enabled) {
-            details.push('<span class="task-def-detail-item"><span class="task-def-dim">disabled</span></span>');
+            details.push('<span class="agent-def-detail-item"><span class="agent-def-dim">disabled</span></span>');
         }
 
         if (details.length > 0) {
-            html += '<div class="task-def-details">' + details.join('') + '</div>';
+            html += '<div class="agent-def-details">' + details.join('') + '</div>';
         }
 
         html += '</div>';
         return html;
     }
 
-    // Sync task definitions
+    // Sync agent definitions
     $('#sync-task-defs').addEventListener('click', async function() {
         var btn = $('#sync-task-defs');
         btn.disabled = true;
         btn.textContent = 'Syncing...';
         try {
-            var resp = await api('POST', '/api/v1/task-definitions/sync');
+            var resp = await api('POST', '/api/v1/agent-definitions/sync');
             if (!resp.ok) {
                 var data = await resp.json().catch(function() { return {}; });
-                alert(data.error || data.message || 'Failed to sync task definitions.');
+                alert(data.error || data.message || 'Failed to sync agent definitions.');
             }
         } catch (err) {
             if (err.message !== 'unauthorized') {
-                alert('Failed to sync task definitions.');
+                alert('Failed to sync agent definitions.');
             }
         }
         btn.textContent = 'Sync Now';
@@ -984,23 +984,23 @@
         var titleEl = $('#view-yaml-title');
         var contentEl = $('#view-yaml-content');
 
-        titleEl.textContent = 'Task Definition';
+        titleEl.textContent = 'Agent Definition';
         contentEl.textContent = 'Loading...';
         show(modal);
 
         try {
-            var resp = await api('GET', '/api/v1/task-definitions/' + id);
+            var resp = await api('GET', '/api/v1/agent-definitions/' + id);
             if (!resp.ok) {
-                contentEl.textContent = 'Failed to load task definition.';
+                contentEl.textContent = 'Failed to load agent definition.';
                 return;
             }
             var data = await resp.json();
             currentYamlContent = data.raw_yaml || data.yaml || '';
-            titleEl.textContent = data.name || 'Task Definition';
+            titleEl.textContent = data.name || 'Agent Definition';
             contentEl.textContent = currentYamlContent || '(no YAML content)';
         } catch (err) {
             if (err.message !== 'unauthorized') {
-                contentEl.textContent = 'Failed to load task definition.';
+                contentEl.textContent = 'Failed to load agent definition.';
             }
         }
     }
@@ -1036,7 +1036,7 @@
         listEl.innerHTML = '<div class="loading-state"><div class="spinner"></div><p>Loading templates...</p></div>';
 
         try {
-            var resp = await api('GET', '/api/v1/task-templates');
+            var resp = await api('GET', '/api/v1/agent-templates');
             if (!resp.ok) {
                 listEl.innerHTML = '<p class="error-message">Failed to load templates.</p>';
                 return;
@@ -1234,7 +1234,7 @@
     // ---------------------
 
     function getTaskType(taskName) {
-        if (!taskName) return { label: 'TASK', color: 'neutral' };
+        if (!taskName) return { label: 'SESSION', color: 'neutral' };
         var name = taskName.toLowerCase();
         if (name.includes('review')) return { label: 'REVIEW', color: 'review' };
         if (name.includes('plan')) return { label: 'PLAN', color: 'plan' };
@@ -1315,7 +1315,7 @@
         } catch (err) {
             hide(loading);
             if (err.message !== 'unauthorized') {
-                tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;color:var(--status-error);padding:24px;">Failed to load tasks. Check your connection and try again.</td></tr>';
+                tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;color:var(--status-error);padding:24px;">Failed to load sessions. Check your connection and try again.</td></tr>';
             }
         }
     }
@@ -1327,18 +1327,18 @@
         tbody.innerHTML = '';
         if (table) table.hidden = true;
         empty.innerHTML = '<div class="empty-state-redesign">' +
-            '<h2>No tasks yet</h2>' +
-            '<p>Tasks appear here when they run -- triggered by events, on a schedule, or submitted manually.</p>' +
+            '<h2>No sessions yet</h2>' +
+            '<p>Sessions appear here when they run -- triggered by events, on a schedule, or started manually.</p>' +
             '<div class="empty-state-cards">' +
                 '<a href="#task/new" class="empty-card">' +
                     '<div class="empty-card-icon">&gt;_</div>' +
-                    '<div class="empty-card-title">Run a task</div>' +
+                    '<div class="empty-card-title">Start a session</div>' +
                     '<div class="empty-card-desc">Submit a prompt to an AI agent</div>' +
                 '</a>' +
                 '<a href="#repos" class="empty-card">' +
                     '<div class="empty-card-icon">&#9201;</div>' +
                     '<div class="empty-card-title">Set up automation</div>' +
-                    '<div class="empty-card-desc">Connect a task repo for event-driven agents</div>' +
+                    '<div class="empty-card-desc">Connect an agent repo for event-driven agents</div>' +
                 '</a>' +
                 '<a href="#credentials" class="empty-card">' +
                     '<div class="empty-card-icon">&#128273;</div>' +
@@ -1352,7 +1352,7 @@
 
     function renderSessionRow(s) {
         var status = s.status || 'unknown';
-        var taskName = s.task_name || 'Manual Task';
+        var taskName = s.task_name || 'Manual Session';
         var taskType = getTaskType(s.task_name);
         var submitter = formatSubmitter(s.submitter);
         var when = formatRelativeTime(s.started_at);
@@ -1370,7 +1370,7 @@
 
         return '<tr class="clickable session-row session-row-' + escapeHtml(status) + '" data-session-id="' + escapeHtml(s.id) + '" tabindex="0" role="link">' +
             '<td><span class="status-dot status-dot-' + escapeHtml(status) + '" title="' + escapeHtml(status) + '"></span></td>' +
-            '<td><span class="task-type-pill task-type-' + escapeHtml(taskType.color) + '">' + escapeHtml(taskType.label) + '</span>' + escapeHtml(taskName) + '</td>' +
+            '<td><span class="agent-type-pill agent-type-' + escapeHtml(taskType.color) + '">' + escapeHtml(taskType.label) + '</span>' + escapeHtml(taskName) + '</td>' +
             '<td>' + escapeHtml(submitter) + '</td>' +
             '<td>' + escapeHtml(when) + '</td>' +
             '<td class="mono">' + durationHtml + '</td>' +
@@ -1398,7 +1398,7 @@
         var empty = $('#sessions-empty');
         if (filtered.length === 0) {
             tbody.innerHTML = '';
-            empty.innerHTML = '<p>No tasks match your filters.</p>';
+            empty.innerHTML = '<p>No sessions match your filters.</p>';
             show(empty);
             return;
         }
@@ -1463,7 +1463,7 @@
             tableContainer.parentNode.insertBefore(paginationEl, tableContainer.nextSibling);
         }
         if (pages <= 1) {
-            paginationEl.innerHTML = '<span>' + total + ' task' + (total !== 1 ? 's' : '') + '</span>';
+            paginationEl.innerHTML = '<span>' + total + ' session' + (total !== 1 ? 's' : '') + '</span>';
             return;
         }
         paginationEl.innerHTML =
@@ -1508,7 +1508,7 @@
     }
 
     // ---------------------
-    // New Task
+    // New Session
     // ---------------------
     async function loadProviders() {
         const select = $('#task-provider');
@@ -1540,7 +1540,7 @@
         $('#timeout-value').textContent = e.target.value;
     });
 
-    // Submit task
+    // Start session
     $('#task-form').addEventListener('submit', async (e) => {
         e.preventDefault();
         const errEl = $('#task-error');
@@ -1560,7 +1560,7 @@
             return c.provider !== 'github' && c.provider !== 'gitlab' && c.provider !== 'jira';
         });
         if (llmCreds.length === 0) {
-            errEl.textContent = 'No LLM provider configured. Add an LLM credential on the Credentials page before submitting tasks.';
+            errEl.textContent = 'No LLM provider configured. Add an LLM credential on the Credentials page before starting sessions.';
             show(errEl);
             return;
         }
@@ -1581,18 +1581,18 @@
 
         const btn = e.target.querySelector('button[type="submit"]');
         btn.disabled = true;
-        btn.textContent = 'Submitting...';
+        btn.textContent = 'Starting...';
 
         try {
-            const resp = await api('POST', '/api/v1/tasks', payload);
+            const resp = await api('POST', '/api/v1/sessions', payload);
             if (!resp.ok) {
                 const data = await resp.json().catch(() => ({}));
-                throw new Error(data.error || data.message || 'Failed to submit task.');
+                throw new Error(data.error || data.message || 'Failed to start session.');
             }
             const data = await resp.json();
             const sessionId = data.session_id || data.id || '';
 
-            successEl.innerHTML = 'Task submitted! Task ID: <span class="mono">' +
+            successEl.innerHTML = 'Session started! Session ID: <span class="mono">' +
                 escapeHtml(sessionId) + '</span> &mdash; ' +
                 '<a href="#session/' + escapeHtml(sessionId) + '" style="color:var(--status-running)">Watch live</a>';
             show(successEl);
@@ -1618,7 +1618,7 @@
             }
         } finally {
             btn.disabled = false;
-            btn.textContent = 'Submit Task';
+            btn.textContent = 'Start Session';
         }
     });
 
@@ -2081,7 +2081,7 @@
             hide($('#transcript-loading'));
             hide($('#proxy-log-loading'));
             if (err.message !== 'unauthorized') {
-                $('#session-meta').innerHTML = '<div class="meta-card"><div class="meta-value" style="color:var(--status-error)">Failed to load task.</div></div>';
+                $('#session-meta').innerHTML = '<div class="meta-card"><div class="meta-value" style="color:var(--status-error)">Failed to load session.</div></div>';
             }
         }
     }
@@ -2125,9 +2125,9 @@
             const cancelBtn = document.createElement('button');
             cancelBtn.className = 'btn btn-small btn-outline';
             cancelBtn.style.cssText = 'margin-left: 1rem; color: var(--status-error); border-color: var(--status-error);';
-            cancelBtn.textContent = 'Cancel Task';
+            cancelBtn.textContent = 'Cancel Session';
             cancelBtn.addEventListener('click', async () => {
-                if (!confirm('Are you sure you want to cancel this task? The running task will be terminated.')) return;
+                if (!confirm('Are you sure you want to cancel this session? The running session will be terminated.')) return;
                 cancelBtn.disabled = true;
                 cancelBtn.textContent = 'Cancelling...';
                 try {
@@ -2136,15 +2136,15 @@
                         loadSessionDetail(s.id);
                     } else {
                         const data = await resp.json().catch(() => ({}));
-                        alert(data.error || data.message || 'Failed to cancel task.');
+                        alert(data.error || data.message || 'Failed to cancel session.');
                         cancelBtn.disabled = false;
-                        cancelBtn.textContent = 'Cancel Task';
+                        cancelBtn.textContent = 'Cancel Session';
                     }
                 } catch (err) {
                     if (err.message !== 'unauthorized') {
-                        alert('Failed to cancel task.');
+                        alert('Failed to cancel session.');
                         cancelBtn.disabled = false;
-                        cancelBtn.textContent = 'Cancel Task';
+                        cancelBtn.textContent = 'Cancel Session';
                     }
                 }
             });
@@ -2681,7 +2681,7 @@
             if (!model && ev.message) model = ev.message;
             var div = document.createElement('div');
             div.className = 'tx-system';
-            div.innerHTML = '<span class="tx-system-icon">&#9654;</span> Task started' +
+            div.innerHTML = '<span class="tx-system-icon">&#9654;</span> Session started' +
                 (model ? ' &middot; <span class="tx-system-model">' + escapeHtml(String(model)) + '</span>' : '') +
                 (toolCount ? ' &middot; ' + toolCount + ' tools available' : '');
             container.appendChild(div);
@@ -2721,7 +2721,7 @@
             div.className = 'tx-result ' + (isError ? 'tx-result-error' : 'tx-result-success');
 
             var headerParts = [];
-            headerParts.push(isError ? '<span class="tx-result-icon">&#10007;</span> Task failed' : '<span class="tx-result-icon">&#10003;</span> Task completed');
+            headerParts.push(isError ? '<span class="tx-result-icon">&#10007;</span> Session failed' : '<span class="tx-result-icon">&#10003;</span> Session completed');
             if (cost != null) headerParts.push(parseFloat(cost).toFixed(3) + ' USD');
             if (ev.num_turns) headerParts.push(ev.num_turns + (ev.num_turns === 1 ? ' turn' : ' turns'));
             if (ev.duration_seconds) headerParts.push(ev.duration_seconds.toFixed(1) + 's');
@@ -3946,7 +3946,7 @@
             typeBadge = '<span class="badge badge-custom">custom</span>';
         }
 
-        var actions = '<button class="btn btn-small btn-primary profile-use-btn" data-name="' + escapeHtml(name) + '">Use in New Task</button> ';
+        var actions = '<button class="btn btn-small btn-primary profile-use-btn" data-name="' + escapeHtml(name) + '">Use in New Session</button> ';
         actions += '<button class="btn btn-small btn-outline profile-duplicate-btn" data-name="' + escapeHtml(name) + '">Duplicate</button>';
         if (!isReadOnly) {
             actions += ' <button class="btn btn-small btn-outline profile-edit-btn" data-name="' + escapeHtml(name) + '">Edit</button>';
@@ -3964,7 +3964,7 @@
     }
 
     function attachProfileCardHandlers() {
-        // Use in New Task
+        // Use in New Session
         $$('.profile-use-btn').forEach(function (btn) {
             btn.addEventListener('click', function () {
                 var name = btn.dataset.name;
@@ -4565,7 +4565,7 @@
     });
 
     // ---------------------
-    // Task Profile Selector
+    // Session Profile Selector
     // ---------------------
     async function loadTaskProfiles() {
         var select = $('#task-profile-add');
@@ -4935,7 +4935,7 @@
     });
 
     // ---------------------
-    // Task Tools (New Task form)
+    // Session Tools (New Session form)
     // ---------------------
     async function loadTaskTools() {
         const content = $('#task-tools-content');
@@ -5233,7 +5233,7 @@
     }
 
     // ---------------------
-    // Task Prerequisites & Warnings
+    // Session Prerequisites & Warnings
     // ---------------------
     function checkTaskPrerequisites() {
         var container = $('#task-warnings');
@@ -5255,7 +5255,7 @@
         if (llmCreds.length === 0) {
             warnings.push({
                 type: 'caution',
-                text: 'No LLM provider configured. Your task won\'t be able to reach an AI model. <a href="#credentials">Add one on the Credentials page.</a>'
+                text: 'No LLM provider configured. Your session won\'t be able to reach an AI model. <a href="#credentials">Add one on the Credentials page.</a>'
             });
         }
 
@@ -5301,11 +5301,11 @@
         if (submitBtn) {
             if (llmCreds.length === 0) {
                 submitBtn.disabled = true;
-                submitBtn.textContent = 'Submit Task (LLM credential required)';
-                submitBtn.title = 'Add an LLM credential on the Credentials page before submitting tasks.';
+                submitBtn.textContent = 'Start Session (LLM credential required)';
+                submitBtn.title = 'Add an LLM credential on the Credentials page before starting sessions.';
             } else {
                 submitBtn.disabled = false;
-                submitBtn.textContent = 'Submit Task';
+                submitBtn.textContent = 'Start Session';
                 submitBtn.title = '';
             }
         }
@@ -5319,8 +5319,8 @@
 
         container.innerHTML = warnings.map(function (w) {
             var icon = w.type === 'caution' ? '&#9888;' : '&#8505;';
-            return '<div class="task-warning task-warning-' + w.type + '">' +
-                '<span class="task-warning-icon">' + icon + '</span>' +
+            return '<div class="session-warning session-warning-' + w.type + '">' +
+                '<span class="session-warning-icon">' + icon + '</span>' +
                 '<span>' + w.text + '</span>' +
                 '</div>';
         }).join('');
@@ -5342,7 +5342,7 @@
             if (!container) return;
 
             // Remove any previous prompt suggestions
-            container.querySelectorAll('.task-warning-prompt-hint').forEach(function (el) {
+            container.querySelectorAll('.session-warning-prompt-hint').forEach(function (el) {
                 el.remove();
             });
 
@@ -5415,8 +5415,8 @@
                 show(container);
                 suggestions.forEach(function (s) {
                     var div = document.createElement('div');
-                    div.className = 'task-warning task-warning-info task-warning-prompt-hint';
-                    div.innerHTML = '<span class="task-warning-icon">&#128161;</span><span>' + s + '</span>';
+                    div.className = 'session-warning session-warning-info session-warning-prompt-hint';
+                    div.innerHTML = '<span class="session-warning-icon">&#128161;</span><span>' + s + '</span>';
                     container.appendChild(div);
                 });
             }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -536,7 +536,7 @@
             $('#task-repo-url-inline').value = '';
             $('#task-repo-ref-inline').value = '';
             statusEl.style.color = 'var(--status-running)';
-            statusEl.textContent = 'Found ' + data.task_count + ' agent definition(s): ' + data.tasks.join(', ');
+            statusEl.textContent = 'Found ' + data.agent_definition_count + ' agent definition(s): ' + data.agent_definitions.join(', ');
             await saveTaskRepos();
             // Reload agent definitions after sync completes (auto-triggered by save)
             setTimeout(function() { loadUnifiedSchedules(); }, 2000);


### PR DESCRIPTION
## Summary

Comprehensive rename of user-facing "task" terminology to "agent" (for definitions) and "session" (for executions), reflecting that Alcove runs autonomous AI agents, not manual to-do items.

## Terminology mapping

| Before | After | Meaning |
|--------|-------|---------|
| Task definitions | Agent definitions | YAML templates defining agent personas |
| Tasks (list) | Sessions | Running/completed executions |
| New Task | New Session | Manual dispatch form |
| Submit Task | Start Session | Submit button |
| Task repos | Agent repos | Git repos containing `.alcove/tasks/` |

## Changes

### Backend (Go)
- API endpoints renamed: `/api/v1/tasks` → merged into `/api/v1/sessions`, `/task-definitions` → `/agent-definitions`, `/task-repos` → `/agent-repos`
- Go types: `TaskDefStore` → `AgentDefStore`, `TaskRepoSyncer` → `AgentRepoSyncer`, settings functions renamed
- DB migration 022: renames `task_definitions` table → `agent_definitions`, `task_repos` setting key → `agent_repos`
- CLI: `alcove run` posts to `/api/v1/sessions`, help text updated
- Log messages updated throughout

### Frontend (HTML/JS/CSS)
- All nav items, headings, buttons, messages, placeholders updated
- All API endpoint URLs updated in JS fetch calls
- CSS classes renamed: `.task-*` → `.agent-*` / `.session-*`

### Documentation (22 files)
- CLAUDE.md, all design docs, API reference, CLI reference, getting started, changelog updated
- `.alcove/tasks/*.yml` description text updated

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] All `internal/` tests pass
- [x] Pre-existing CLI test failures confirmed on main (environment-specific, not from this PR)
- [ ] Functional tests pass in CI

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)