### PR TITLE
Redesign transcript: unified tool steps, normalized parsing, step numbers

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2225,3 +2225,108 @@ select.input {
     font-weight: 500;
     font-variant-numeric: tabular-nums;
 }
+
+/* === Transcript Redesign: Unified Tool Steps === */
+
+/* Inline tool output (paired with tool_use card) */
+.tx-tool-output-inline {
+    border-top: 1px solid #334155;
+    padding: 0;
+    margin: 0;
+}
+
+.tx-tool-output-inline pre {
+    margin: 0;
+    padding: 10px 14px;
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+/* Output preview (first 4 lines shown before expand) */
+.tx-tool-output-preview pre {
+    margin: 0;
+    padding: 10px 14px;
+    border-bottom: none;
+}
+
+/* Expand toggle for long outputs */
+.tx-tool-output-expand {
+    border-top: 1px dashed #334155;
+}
+
+.tx-tool-expand-toggle {
+    padding: 6px 14px;
+    font-size: 12px;
+    color: #60a5fa;
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+}
+
+.tx-tool-expand-toggle::-webkit-details-marker {
+    display: none;
+}
+
+.tx-tool-expand-toggle::before {
+    content: "▶ ";
+    font-size: 10px;
+    transition: transform 0.15s;
+}
+
+details[open] > .tx-tool-expand-toggle::before {
+    content: "▼ ";
+}
+
+.tx-tool-output-expand pre {
+    margin: 0;
+    padding: 10px 14px;
+}
+
+/* Step numbers */
+.tx-step-num {
+    display: inline-block;
+    background: rgba(59, 130, 246, 0.2);
+    color: #93c5fd;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 1px 7px;
+    border-radius: 10px;
+    margin-right: 8px;
+    vertical-align: middle;
+}
+
+/* Stderr styling */
+.tx-stderr-block {
+    color: #f87171;
+    border-left: 2px solid #ef4444;
+    padding-left: 10px;
+    margin-bottom: 4px;
+}
+
+/* Error exit code badge */
+.tx-exit-badge {
+    display: inline-block;
+    background: #7f1d1d;
+    color: #fca5a5;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 1px 8px;
+    border-radius: 9999px;
+    margin-left: 8px;
+}
+
+/* Tool card with output gets bottom styling */
+.tx-tool.tx-has-output {
+    margin-bottom: 16px;
+}
+
+/* Diff highlighting for Edit tool results */
+.tx-diff-add {
+    background: rgba(34, 197, 94, 0.15);
+    color: #86efac;
+}
+
+.tx-diff-remove {
+    background: rgba(239, 68, 68, 0.15);
+    color: #fca5a5;
+}

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2736,24 +2736,78 @@
         // --- tool_result ---
         if (type === 'tool_result') {
             var output = '';
-            if (typeof ev.content === 'string') {
+            var stderr = '';
+
+            // Format 2: tool_use_result envelope (the problematic format)
+            if (ev.tool_use_result) {
+                output = ev.tool_use_result.stdout || '';
+                stderr = ev.tool_use_result.stderr || '';
+            }
+            // Format 1: direct content (string or array)
+            else if (typeof ev.content === 'string') {
                 output = ev.content;
             } else if (Array.isArray(ev.content)) {
                 output = ev.content
                     .filter(function(b) { return b.type === 'text'; })
                     .map(function(b) { return b.text; })
                     .join('\n');
-            } else if (ev.content) {
-                output = JSON.stringify(ev.content, null, 2);
+            } else if (ev.content && typeof ev.content === 'object') {
+                // Check if content itself has stdout/stderr
+                if (ev.content.stdout !== undefined) {
+                    output = ev.content.stdout || '';
+                    stderr = ev.content.stderr || '';
+                } else {
+                    output = JSON.stringify(ev.content, null, 2);
+                }
             } else if (ev.output) {
                 output = typeof ev.output === 'string' ? ev.output : JSON.stringify(ev.output, null, 2);
             }
-            if (!output) return; // skip empty tool results
 
-            var div = document.createElement('div');
-            div.className = 'tx-tool-output-block tx-hierarchy-tool';
+            if (!output && !stderr) return; // skip empty tool results
+
+            // Combine stderr + stdout for display
+            if (stderr) {
+                output = '\u26A0 stderr:\n' + stderr + (output ? '\n\n' + output : '');
+            }
+
             var isError = ev.is_error || false;
             var contentType = detectContentType(output);
+
+            // Try to pair with preceding tool_use card
+            var toolUseId = ev.tool_use_id || '';
+            var pairedCard = toolUseId ? container.querySelector('[data-tool-use-id="' + toolUseId + '"]') : null;
+
+            if (pairedCard) {
+                // Append output into the existing tool card
+                var outputDiv = document.createElement('div');
+                outputDiv.className = 'tx-tool-output-inline';
+
+                var autoCollapse = output.split('\n').length > 8 || output.length > 500;
+                var highlightedContent = applySyntaxHighlighting(output, contentType);
+                var contentClass = 'tx-tool-output-pre tx-content-' + contentType;
+                if (isError) contentClass += ' tx-tool-output-error';
+
+                if (autoCollapse) {
+                    var lineCount = output.split('\n').length;
+                    var preview = output.split('\n').slice(0, 4).join('\n');
+                    var previewHighlighted = applySyntaxHighlighting(preview, contentType);
+                    outputDiv.innerHTML =
+                        '<div class="tx-tool-output-preview"><pre class="' + contentClass + '">' + previewHighlighted + '</pre></div>' +
+                        '<details class="tx-tool-output-expand">' +
+                        '<summary class="tx-tool-expand-toggle">Show ' + (lineCount - 4) + ' more lines</summary>' +
+                        '<pre class="' + contentClass + '">' + highlightedContent + '</pre>' +
+                        '</details>';
+                } else {
+                    outputDiv.innerHTML = '<pre class="' + contentClass + '">' + highlightedContent + '</pre>';
+                }
+
+                pairedCard.appendChild(outputDiv);
+                return;
+            }
+
+            // Fallback: render as standalone block (for unpaired results)
+            var div = document.createElement('div');
+            div.className = 'tx-tool-output-block tx-hierarchy-tool';
             var autoCollapse = shouldAutoCollapse(output, contentType);
 
             // Generate intelligent summary
@@ -2847,10 +2901,19 @@
 
                     var div = document.createElement('div');
                     div.className = 'tx-tool tx-hierarchy-tool';
+                    if (block.id) {
+                        div.setAttribute('data-tool-use-id', block.id);
+                    }
+
+                    // Step counter for tool calls
+                    if (!container._stepCount) container._stepCount = 0;
+                    container._stepCount++;
+                    var stepNum = container._stepCount;
 
                     var toolIcon = '&#x1F527;';
 
                     var headerHtml = '<div class="tx-tool-header">' +
+                        '<span class="tx-step-num">Step ' + stepNum + '</span>' +
                         '<span class="tx-tool-icon">' + toolIcon + '</span>' +
                         '<span class="tx-tool-name">' + escapeHtml(toolName) + '</span>' +
                         '</div>';


### PR DESCRIPTION
## Summary

Three changes to make the session transcript much more readable:

### 1. Normalize tool_result parsing
The raw JSON dump problem (Image 2) was caused by `tool_result` events in Format 2 (`tool_use_result.stdout/stderr` envelope) not being parsed. Now extracts stdout/stderr from all formats and strips metadata (tool_use_id, timestamp, session_id, isImage, interrupted, noOutputExpected).

### 2. Pair tool_use + tool_result as unified steps
Tool calls and their results now render as one visual unit. The tool_result output appears directly inside the tool_use card (matched by `data-tool-use-id`). Long outputs (>8 lines) show a 4-line preview with "Show N more lines" expansion.

### 3. Step numbers
Each tool call gets a sequential step number badge ("Step 1", "Step 2", ...) for easy reference and progress tracking.

### New CSS
- `.tx-tool-output-inline` — paired output inside tool cards
- `.tx-tool-output-preview` / `.tx-tool-expand-toggle` — expandable long outputs
- `.tx-step-num` — step number badges
- `.tx-stderr-block` — red-styled stderr
- `.tx-exit-badge` — error exit code badge
- `.tx-diff-add` / `.tx-diff-remove` — diff highlighting

## Test plan
- [x] `make build` passes
- [ ] CI passes
- [ ] Visual verification on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)