### PR TITLE
Add YAML plugin declaration for agent definitions (Phase 1)

### DIFF
--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -225,6 +225,12 @@ timeout: 7200
 profiles:
   - alcove-developer
 
+plugins:
+  - name: code-review
+    source: claude-plugins-official
+  - name: commit-commands
+    source: claude-plugins-official
+
 ci_gate:
   max_retries: 3
   timeout: 900

--- a/.alcove/tasks/pr-reviewer.yml
+++ b/.alcove/tasks/pr-reviewer.yml
@@ -394,6 +394,10 @@ timeout: 1800
 profiles:
   - alcove-reviewer
 
+plugins:
+  - name: code-review
+    source: claude-plugins-official
+
 trigger:
   github:
     events:

--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -451,6 +451,9 @@ func setupEnv(task internal.Task) {
 	// Load skill/agent repos if specified.
 	loadSkillRepos()
 
+	// Install plugins declared in agent definition.
+	installPlugins()
+
 	// Apply task-specific env vars
 	for k, v := range task.Env {
 		os.Setenv(k, v)
@@ -639,6 +642,78 @@ func installLolaModules() {
 	}
 
 	log.Printf("installed %d lola module(s)", len(lolaModuleDirs))
+}
+
+// installPlugins reads ALCOVE_PLUGINS and installs each plugin.
+// Marketplace plugins use "claude plugin install <name>".
+// Git-sourced plugins are cloned and loaded via --plugin-dir.
+func installPlugins() {
+	pluginsJSON := os.Getenv("ALCOVE_PLUGINS")
+	if pluginsJSON == "" {
+		return
+	}
+
+	type pluginSpec struct {
+		Name   string `json:"name"`
+		Source string `json:"source,omitempty"`
+		Ref    string `json:"ref,omitempty"`
+	}
+
+	var plugins []pluginSpec
+	if err := json.Unmarshal([]byte(pluginsJSON), &plugins); err != nil {
+		log.Printf("warning: invalid ALCOVE_PLUGINS JSON: %v", err)
+		return
+	}
+
+	for _, p := range plugins {
+		if p.Name == "" {
+			continue
+		}
+
+		switch {
+		case p.Source == "" || p.Source == "marketplace":
+			// Install from Claude Code marketplace.
+			log.Printf("installing plugin from marketplace: %s", p.Name)
+			cmd := exec.Command("claude", "plugin", "install", p.Name)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				log.Printf("warning: failed to install marketplace plugin %s: %v", p.Name, err)
+			}
+
+		case p.Source == "claude-plugins-official":
+			// Install from the official Anthropic plugin repo.
+			log.Printf("installing official plugin: %s", p.Name)
+			cmd := exec.Command("claude", "plugin", "install", p.Name+"@claude-plugins-official")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				log.Printf("warning: failed to install official plugin %s: %v", p.Name, err)
+			}
+
+		default:
+			// Git URL source -- clone and use as --plugin-dir.
+			log.Printf("cloning plugin from git: %s (%s)", p.Name, p.Source)
+			cloneDir := filepath.Join("/tmp/alcove-plugins", p.Name)
+			args := []string{"clone", "--depth=1"}
+			if p.Ref != "" {
+				args = append(args, "--branch", p.Ref)
+			}
+			args = append(args, p.Source, cloneDir)
+
+			cmd := exec.Command("git", args...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				log.Printf("warning: failed to clone plugin %s: %v", p.Name, err)
+				continue
+			}
+
+			// Add to plugin dirs for --plugin-dir flag.
+			skillPluginDirs = append(skillPluginDirs, cloneDir)
+			log.Printf("loaded git plugin: %s from %s", p.Name, p.Source)
+		}
+	}
 }
 
 // cloneRepo performs a shallow clone of the given repo.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -439,6 +439,12 @@ profiles:
   - read-only-github
 tools:
   - github
+plugins:
+  - name: code-review
+    source: claude-plugins-official
+  - name: my-custom-plugin
+    source: https://github.com/org/my-plugin.git
+    ref: main
 schedule: "0 2 * * *"
 ```
 
@@ -453,6 +459,7 @@ schedule: "0 2 * * *"
 | `budget_usd`| float    | no       | Maximum spend |
 | `profiles`  | string[] | no       | Security profile names to apply |
 | `tools`     | string[] | no       | MCP tool names to enable |
+| `plugins`   | PluginSpec[] | no   | Claude Code plugins to install (see [Plugins](#plugins)) |
 | `schedule`  | string   | no       | Cron expression for automatic execution |
 | `labels`    | string[] | no       | GitHub issue/PR labels for event filtering (see below) |
 | `users`     | string[] | no       | GitHub usernames for event filtering (see below) |
@@ -572,6 +579,49 @@ security profiles (see [API Reference](api-reference.md#security)).
   (as a user-created or YAML profile), a sync error is reported.
 - YAML profiles are synced on the same interval as agent definitions
   (configurable via `TASK_REPO_SYNC_INTERVAL`, default 5 minutes).
+
+---
+
+## Plugins
+
+Agent definitions can declare Claude Code plugins to install at Skiff startup.
+Plugins are installed before Claude Code runs, so all declared plugins are
+available for the entire session.
+
+```yaml
+name: my-developer-agent
+prompt: |
+  Review the codebase and suggest improvements.
+plugins:
+  - name: code-review
+    source: claude-plugins-official
+  - name: gopls-lsp
+    source: claude-plugins-official
+  - name: my-custom-plugin
+    source: https://github.com/org/my-plugin.git
+    ref: main
+```
+
+### Plugin Sources
+
+| Source | Description | Example |
+|--------|-------------|---------|
+| `claude-plugins-official` | Official Anthropic plugins | `code-review`, `gopls-lsp` |
+| `marketplace` (or empty) | Claude Code plugin marketplace | Any published plugin |
+| Git URL | Custom plugin from a git repo | `https://github.com/org/plugin.git` |
+
+### PluginSpec Fields
+
+| Field    | Type   | Required | Description |
+|----------|--------|----------|-------------|
+| `name`   | string | yes      | Plugin name |
+| `source` | string | no       | Plugin source: `claude-plugins-official`, `marketplace`, a git URL, or empty (defaults to marketplace) |
+| `ref`    | string | no       | Branch or tag for git-sourced plugins |
+
+Marketplace and official plugins are installed via `claude plugin install`.
+Git-sourced plugins are cloned and loaded via `--plugin-dir` flags passed to
+Claude Code. The `ALCOVE_PLUGINS` environment variable is set on the Skiff
+container with the JSON-serialized plugin list.
 
 ---
 

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -79,6 +79,7 @@ type TaskRequest struct {
 	Model    string                `json:"model,omitempty"`
 	Budget   float64               `json:"budget_usd,omitempty"`
 	Debug    bool                  `json:"debug,omitempty"`
+	Plugins  []PluginSpec `json:"-"` // Set internally from agent definition
 	// Task metadata — set by dispatch code paths, stored in sessions table.
 	TaskName    string `json:"-"` // Schedule/agent definition name
 	TriggerType string `json:"-"` // "event", "cron", "manual", "webhook"
@@ -551,6 +552,13 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 	if len(skillRepos) > 0 {
 		reposJSON, _ := json.Marshal(skillRepos)
 		skiffEnv["ALCOVE_SKILL_REPOS"] = string(reposJSON)
+	}
+
+	// Resolve plugins from agent definition.
+	// Plugins are specified in the task definition and passed to Skiff for installation.
+	if len(req.Plugins) > 0 {
+		pluginsJSON, _ := json.Marshal(req.Plugins)
+		skiffEnv["ALCOVE_PLUGINS"] = string(pluginsJSON)
 	}
 
 	// Start Skiff pod via Runtime.

--- a/internal/bridge/taskdef.go
+++ b/internal/bridge/taskdef.go
@@ -51,11 +51,11 @@ type TaskDefinition struct {
 	BudgetUSD   float64               `json:"budget_usd,omitempty" yaml:"budget_usd"`
 	Debug       bool                  `json:"debug,omitempty" yaml:"debug"`
 	Profiles    []string              `json:"profiles,omitempty" yaml:"profiles"`
+	Plugins     []PluginSpec          `json:"plugins,omitempty" yaml:"plugins"`
 	Tools       map[string]ToolConfig `json:"tools,omitempty" yaml:"tools"`
 	Schedule    *TaskDefSchedule      `json:"schedule,omitempty" yaml:"schedule"`
 	Trigger     *EventTrigger         `json:"trigger,omitempty" yaml:"trigger"`
 	CIGate      *CIGate               `json:"ci_gate,omitempty" yaml:"ci_gate"`
-	Plugins     []PluginSpec          `json:"plugins,omitempty" yaml:"plugins,omitempty"`
 
 	// Metadata (not from YAML).
 	Owner      string     `json:"owner,omitempty"`

--- a/internal/bridge/taskdef.go
+++ b/internal/bridge/taskdef.go
@@ -25,6 +25,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// PluginSpec declares a Claude Code plugin to install for an agent.
+type PluginSpec struct {
+	Name   string `json:"name" yaml:"name"`                           // Plugin name (e.g., "code-review")
+	Source string `json:"source,omitempty" yaml:"source,omitempty"`   // "claude-plugins-official", git URL, or empty (marketplace default)
+	Ref    string `json:"ref,omitempty" yaml:"ref,omitempty"`         // Branch/tag for git sources
+}
+
 // CIGate configures Bridge-driven CI monitoring for PRs created by a task.
 type CIGate struct {
 	MaxRetries int `json:"max_retries" yaml:"max_retries"`
@@ -48,6 +55,7 @@ type TaskDefinition struct {
 	Schedule    *TaskDefSchedule      `json:"schedule,omitempty" yaml:"schedule"`
 	Trigger     *EventTrigger         `json:"trigger,omitempty" yaml:"trigger"`
 	CIGate      *CIGate               `json:"ci_gate,omitempty" yaml:"ci_gate"`
+	Plugins     []PluginSpec          `json:"plugins,omitempty" yaml:"plugins,omitempty"`
 
 	// Metadata (not from YAML).
 	Owner      string     `json:"owner,omitempty"`
@@ -114,6 +122,7 @@ func (td *TaskDefinition) ToTaskRequest() TaskRequest {
 		Model:    td.Model,
 		Budget:   td.BudgetUSD,
 		Debug:    td.Debug,
+		Plugins:  td.Plugins,
 	}
 }
 
@@ -233,6 +242,7 @@ func (s *AgentDefStore) GetAgentDefinition(ctx context.Context, id, owner string
 			td.Tools = parsed.Tools
 			td.Schedule = parsed.Schedule
 			td.Trigger = parsed.Trigger
+			td.Plugins = parsed.Plugins
 		}
 	}
 

--- a/internal/bridge/taskdef_test.go
+++ b/internal/bridge/taskdef_test.go
@@ -1,0 +1,36 @@
+package bridge
+
+import "testing"
+
+func TestParseAgentDefinitionWithPlugins(t *testing.T) {
+	yamlData := `
+name: Test Agent
+prompt: "Do something"
+plugins:
+  - name: code-review
+    source: claude-plugins-official
+  - name: my-plugin
+    source: https://github.com/org/plugin.git
+    ref: v1.0
+  - name: marketplace-plugin
+`
+	def, err := ParseTaskDefinition([]byte(yamlData))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(def.Plugins) != 3 {
+		t.Fatalf("expected 3 plugins, got %d", len(def.Plugins))
+	}
+	if def.Plugins[0].Name != "code-review" {
+		t.Errorf("plugin 0 name: got %q, want %q", def.Plugins[0].Name, "code-review")
+	}
+	if def.Plugins[0].Source != "claude-plugins-official" {
+		t.Errorf("plugin 0 source: got %q, want %q", def.Plugins[0].Source, "claude-plugins-official")
+	}
+	if def.Plugins[1].Ref != "v1.0" {
+		t.Errorf("plugin 1 ref: got %q, want %q", def.Plugins[1].Ref, "v1.0")
+	}
+	if def.Plugins[2].Source != "" {
+		t.Errorf("plugin 2 source should be empty for marketplace, got %q", def.Plugins[2].Source)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of Anthropic plugin support. Agent definitions can now declare Claude Code plugins:

```yaml
name: Autonomous Developer
plugins:
  - name: code-review
    source: claude-plugins-official
  - name: my-plugin
    source: https://github.com/org/plugin.git
    ref: main
```

### Plugin sources
- `claude-plugins-official` — official Anthropic plugins
- `marketplace` (or empty) — Claude Code marketplace
- Git URL — custom plugins from any git repo

### Changes
- **taskdef.go**: `PluginSpec` struct + `Plugins` field on `TaskDefinition`
- **dispatcher.go**: Serialize plugins to `ALCOVE_PLUGINS` env var for Skiff
- **skiff-init**: `installPlugins()` handles marketplace install, official install, and git clone
- **configuration.md**: Plugin documentation
- **taskdef_test.go**: Plugin parsing test
- **autonomous-dev.yml**: Example plugins (code-review, commit-commands)
- **pr-reviewer.yml**: Example plugin (code-review)

## Test plan
- [x] `make build` passes
- [x] Plugin parsing test passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)