### PR TITLE
Add gopls language server to Skiff image (Phase 2)

### DIFF
--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -230,6 +230,8 @@ plugins:
     source: claude-plugins-official
   - name: commit-commands
     source: claude-plugins-official
+  - name: gopls-lsp
+    source: claude-plugins-official
 
 ci_gate:
   max_retries: 3

--- a/build/Containerfile.skiff-base
+++ b/build/Containerfile.skiff-base
@@ -44,6 +44,9 @@ ENV PATH="/usr/local/go/bin:${PATH}" \
     GOPATH="/home/skiff/go" \
     GOBIN="/home/skiff/go/bin"
 
+# Install Go language server (gopls) for LSP-powered code intelligence
+RUN GOBIN=/usr/local/bin go install golang.org/x/tools/gopls@latest
+
 # Install Node.js (LTS) for Claude Code CLI
 RUN dnf module enable -y nodejs:20 && \
     dnf install -y nodejs npm && \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,6 +160,7 @@ Skiff is the ephemeral worker container (`cmd/skiff-init`). These variables are
 | `ANTHROPIC_BASE_URL` | string | _(injected)_ | Points to Gate for LLM API proxying (`http://gate-<taskID>:8443`). |
 | `ANTHROPIC_API_KEY` | string | `sk-placeholder-routed-through-gate` | Placeholder key that satisfies Claude Code validation. Real key is held by Gate. |
 | `ALCOVE_SKILL_REPOS` | string (JSON) | _(injected)_ | JSON array of skill repo objects. Skiff clones each repo and passes them to Claude Code via `--plugin-dir` flags. |
+| `ALCOVE_PLUGINS` | string (JSON) | _(injected)_ | JSON array of plugin specs from the agent definition. Skiff installs each plugin at startup (marketplace, official, or git-sourced). |
 
 The following SCM-related environment variables are injected by Bridge when the
 task's scope includes a `github` or `gitlab` service. They configure the `gh`


### PR DESCRIPTION
## Summary
- Install `gopls` (Go language server) in the Skiff base image via `go install golang.org/x/tools/gopls@latest`
- Add `gopls-lsp` plugin to autonomous-dev agent definition
- Document `ALCOVE_PLUGINS` env var in configuration reference

This enables the `gopls-lsp` Claude Code plugin to provide real code intelligence for Go projects.

## Test plan
- [x] `make build` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)