### PR TITLE
Add pre-built plugin bundles for agent definitions (Phase 3)

### DIFF
--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -226,12 +226,8 @@ profiles:
   - alcove-developer
 
 plugins:
-  - name: code-review
-    source: claude-plugins-official
-  - name: commit-commands
-    source: claude-plugins-official
-  - name: gopls-lsp
-    source: claude-plugins-official
+  - name: sdlc-go
+    source: bundle
 
 ci_gate:
   max_retries: 3

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -624,6 +624,38 @@ Git-sourced plugins are cloned and loaded via `--plugin-dir` flags passed to
 Claude Code. The `ALCOVE_PLUGINS` environment variable is set on the Skiff
 container with the JSON-serialized plugin list.
 
+### Plugin Bundles
+
+Bundles are pre-configured sets of plugins for common workflows. Reference a
+bundle by setting `source: bundle`:
+
+```yaml
+plugins:
+  - name: sdlc-go
+    source: bundle
+```
+
+Available bundles:
+
+| Bundle | Plugins Included | Use Case |
+|--------|-----------------|----------|
+| `sdlc-go` | code-review, gopls-lsp, commit-commands | Go development |
+| `sdlc-python` | code-review, commit-commands | Python development |
+| `sdlc-typescript` | code-review, commit-commands | TypeScript/JavaScript development |
+| `content` | claude-md-management | Documentation and content creation |
+
+Bundles can be combined with individual plugins:
+
+```yaml
+plugins:
+  - name: sdlc-go
+    source: bundle
+  - name: my-custom-plugin
+    source: https://github.com/org/plugin.git
+```
+
+Duplicate plugins are automatically deduplicated.
+
 ---
 
 ## Complete Environment Variable Example

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -556,8 +556,10 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 
 	// Resolve plugins from agent definition.
 	// Plugins are specified in the task definition and passed to Skiff for installation.
-	if len(req.Plugins) > 0 {
-		pluginsJSON, _ := json.Marshal(req.Plugins)
+	// Resolve plugin bundles before passing to Skiff.
+	plugins := ResolvePluginBundles(req.Plugins)
+	if len(plugins) > 0 {
+		pluginsJSON, _ := json.Marshal(plugins)
 		skiffEnv["ALCOVE_PLUGINS"] = string(pluginsJSON)
 	}
 

--- a/internal/bridge/taskdef.go
+++ b/internal/bridge/taskdef.go
@@ -349,6 +349,52 @@ func (s *AgentDefStore) ListAgentDefinitionsByRepo(ctx context.Context, repoURL,
 	return defs, nil
 }
 
+// PluginBundles maps bundle names to their constituent plugins.
+var PluginBundles = map[string][]PluginSpec{
+	"sdlc-go": {
+		{Name: "code-review", Source: "claude-plugins-official"},
+		{Name: "gopls-lsp", Source: "claude-plugins-official"},
+		{Name: "commit-commands", Source: "claude-plugins-official"},
+	},
+	"sdlc-python": {
+		{Name: "code-review", Source: "claude-plugins-official"},
+		{Name: "commit-commands", Source: "claude-plugins-official"},
+	},
+	"sdlc-typescript": {
+		{Name: "code-review", Source: "claude-plugins-official"},
+		{Name: "commit-commands", Source: "claude-plugins-official"},
+	},
+	"content": {
+		{Name: "claude-md-management", Source: "claude-plugins-official"},
+	},
+}
+
+// ResolvePluginBundles expands any bundle references in the plugin list.
+// A bundle is referenced by setting Source to "bundle".
+func ResolvePluginBundles(plugins []PluginSpec) []PluginSpec {
+	var resolved []PluginSpec
+	seen := make(map[string]bool) // deduplicate by name
+
+	for _, p := range plugins {
+		if p.Source == "bundle" {
+			if bundle, ok := PluginBundles[p.Name]; ok {
+				for _, bp := range bundle {
+					if !seen[bp.Name] {
+						resolved = append(resolved, bp)
+						seen[bp.Name] = true
+					}
+				}
+			}
+			continue
+		}
+		if !seen[p.Name] {
+			resolved = append(resolved, p)
+			seen[p.Name] = true
+		}
+	}
+	return resolved
+}
+
 // nilIfEmpty returns nil if the string is empty, otherwise a pointer to it.
 func nilIfEmpty(s string) *string {
 	if s == "" {

--- a/internal/bridge/taskdef_test.go
+++ b/internal/bridge/taskdef_test.go
@@ -2,6 +2,58 @@ package bridge
 
 import "testing"
 
+func TestResolvePluginBundles(t *testing.T) {
+	// Test bundle expansion
+	plugins := []PluginSpec{
+		{Name: "sdlc-go", Source: "bundle"},
+		{Name: "my-custom", Source: "https://github.com/org/plugin.git"},
+	}
+	resolved := ResolvePluginBundles(plugins)
+
+	// sdlc-go expands to 3 plugins + 1 custom = 4 total
+	if len(resolved) != 4 {
+		t.Fatalf("expected 4 plugins, got %d: %v", len(resolved), resolved)
+	}
+	// First 3 should be from the bundle
+	if resolved[0].Name != "code-review" {
+		t.Errorf("expected code-review first, got %s", resolved[0].Name)
+	}
+	// Last should be custom
+	if resolved[3].Name != "my-custom" {
+		t.Errorf("expected my-custom last, got %s", resolved[3].Name)
+	}
+}
+
+func TestResolvePluginBundles_Dedup(t *testing.T) {
+	// Test deduplication when bundle plugin overlaps with explicit plugin
+	plugins := []PluginSpec{
+		{Name: "code-review", Source: "claude-plugins-official"},
+		{Name: "sdlc-go", Source: "bundle"}, // also contains code-review
+	}
+	resolved := ResolvePluginBundles(plugins)
+
+	// code-review should only appear once
+	count := 0
+	for _, p := range resolved {
+		if p.Name == "code-review" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 code-review, got %d", count)
+	}
+}
+
+func TestResolvePluginBundles_UnknownBundle(t *testing.T) {
+	plugins := []PluginSpec{
+		{Name: "nonexistent-bundle", Source: "bundle"},
+	}
+	resolved := ResolvePluginBundles(plugins)
+	if len(resolved) != 0 {
+		t.Errorf("expected 0 plugins for unknown bundle, got %d", len(resolved))
+	}
+}
+
 func TestParseAgentDefinitionWithPlugins(t *testing.T) {
 	yamlData := `
 name: Test Agent


### PR DESCRIPTION
## Summary

Pre-built plugin bundles for common workflows. Reference with `source: bundle`:

```yaml
plugins:
  - name: sdlc-go
    source: bundle
```

### Available bundles

| Bundle | Plugins | Use Case |
|--------|---------|----------|
| `sdlc-go` | code-review, gopls-lsp, commit-commands | Go development |
| `sdlc-python` | code-review, commit-commands | Python development |
| `sdlc-typescript` | code-review, commit-commands | TypeScript/JS |
| `content` | claude-md-management | Documentation/content |

### Changes
- `taskdef.go`: `PluginBundles` map + `ResolvePluginBundles()` with deduplication
- `dispatcher.go`: Resolve bundles before passing to Skiff
- `taskdef_test.go`: 3 new tests (expansion, dedup, unknown bundle)
- `configuration.md`: Bundle documentation
- `autonomous-dev.yml`: Simplified to use `sdlc-go` bundle

## Test plan
- [x] `make build` passes
- [x] All 4 plugin tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)