### PR TITLE
Add system state API for dispatch pause/resume during upgrades

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -188,7 +188,7 @@ func main() {
 	defStore := bridge.NewAgentDefStore(dbpool)
 
 	// Create and start the scheduler.
-	scheduler := bridge.NewScheduler(dbpool, dispatcher, cfg, credStore, defStore)
+	scheduler := bridge.NewScheduler(dbpool, dispatcher, cfg, credStore, defStore, settingsStore)
 	scheduler.Start(context.Background())
 	defer scheduler.Stop()
 

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -59,3 +59,33 @@ Bridge runs a reconciliation loop every 2 minutes that:
 
 This ensures no session is stuck as "running" forever, even if a NATS
 status update was lost during a Bridge restart.
+
+## Maintenance Mode
+
+Admins can pause session dispatching before an upgrade:
+
+### API
+
+```bash
+# Pause dispatching
+curl -X PUT /api/v1/admin/system-state -d '{"mode": "paused"}'
+
+# Check status
+curl /api/v1/admin/system-state
+# {"mode": "paused", "running_sessions": 3}
+
+# Resume after upgrade
+curl -X PUT /api/v1/admin/system-state -d '{"mode": "active"}'
+```
+
+When paused:
+- Scheduler skips cron dispatches
+- Poller skips event processing (events remain in GitHub API)
+- Manual dispatch returns 503
+- Running sessions continue to completion
+- Dashboard shows a maintenance banner
+
+When resumed:
+- Poller immediately fetches pending events
+- Dedup table prevents double-dispatch
+- Scheduler resumes from next_run

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -104,6 +104,7 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/webhooks/github", a.handleWebhookGitHub)
 	mux.HandleFunc("/api/v1/admin/settings/webhook", a.handleAdminSettingsWebhook)
 	mux.HandleFunc("/api/v1/system-info", a.handleSystemInfo)
+	mux.HandleFunc("/api/v1/admin/system-state", a.handleSystemState)
 	mux.HandleFunc("/api/v1/auth/tbr-associations", a.handleTBRAssociations)
 	mux.HandleFunc("/api/v1/auth/tbr-associations/", a.handleTBRAssociationByID)
 }
@@ -169,6 +170,12 @@ func (a *API) handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 func (a *API) handleSessions(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPost:
+		// Check system mode before dispatching.
+		if mode, _ := a.settingsStore.GetSystemMode(r.Context()); mode == "paused" {
+			respondError(w, http.StatusServiceUnavailable, "system is paused for maintenance — new sessions are not being accepted")
+			return
+		}
+
 		var req TaskRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
@@ -1846,6 +1853,12 @@ func (a *API) handleAgentDefinitionByID(w http.ResponseWriter, r *http.Request) 
 }
 
 func (a *API) handleAgentDefinitionRun(w http.ResponseWriter, r *http.Request, id string) {
+	// Check system mode before dispatching.
+	if mode, _ := a.settingsStore.GetSystemMode(r.Context()); mode == "paused" {
+		respondError(w, http.StatusServiceUnavailable, "system is paused for maintenance — new sessions are not being accepted")
+		return
+	}
+
 	submitter := r.Header.Get("X-Alcove-User")
 	if submitter == "" {
 		submitter = "anonymous"
@@ -2091,6 +2104,12 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check system mode before dispatching.
+	if mode, _ := a.settingsStore.GetSystemMode(ctx); mode == "paused" {
+		respondJSON(w, http.StatusOK, map[string]any{"matched": 0, "dispatched": 0, "paused": true})
+		return
+	}
+
 	// Query schedules with event triggers.
 	rows, queryErr := a.db.Query(ctx, `
 		SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, owner, debug, trigger_type, event_config
@@ -2193,6 +2212,54 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 		matched, deliveryID)
 
 	respondJSON(w, http.StatusOK, map[string]any{"matched": matched, "dispatched": dispatched})
+}
+
+// --- Admin Settings: System State ---
+
+func (a *API) handleSystemState(w http.ResponseWriter, r *http.Request) {
+	// Admin-only.
+	if r.Header.Get("X-Alcove-Admin") != "true" {
+		respondError(w, http.StatusForbidden, "admin access required")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		mode, _ := a.settingsStore.GetSystemMode(r.Context())
+
+		// Count running sessions.
+		var running int
+		_ = a.db.QueryRow(r.Context(), "SELECT COUNT(*) FROM sessions WHERE outcome = 'running'").Scan(&running)
+
+		respondJSON(w, http.StatusOK, map[string]any{
+			"mode":             mode,
+			"running_sessions": running,
+		})
+
+	case http.MethodPut:
+		var req struct {
+			Mode string `json:"mode"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			respondError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		if req.Mode != "active" && req.Mode != "paused" {
+			respondError(w, http.StatusBadRequest, "mode must be 'active' or 'paused'")
+			return
+		}
+
+		if err := a.settingsStore.SetSystemMode(r.Context(), req.Mode); err != nil {
+			respondError(w, http.StatusInternalServerError, "failed to set system mode")
+			return
+		}
+
+		log.Printf("system mode changed to %s by admin", req.Mode)
+		respondJSON(w, http.StatusOK, map[string]any{"mode": req.Mode})
+
+	default:
+		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
 }
 
 // --- Admin Settings: Webhook ---

--- a/internal/bridge/migrations/023_system_state.sql
+++ b/internal/bridge/migrations/023_system_state.sql
@@ -1,0 +1,10 @@
+-- System state for maintenance mode.
+CREATE TABLE IF NOT EXISTS system_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Default to active mode.
+INSERT INTO system_state (key, value) VALUES ('mode', 'active')
+ON CONFLICT (key) DO NOTHING;

--- a/internal/bridge/poller.go
+++ b/internal/bridge/poller.go
@@ -73,6 +73,13 @@ type pollSchedule struct {
 
 // PollAll queries all polling-mode event schedules, groups by repo, and polls each.
 func (p *GitHubPoller) PollAll(ctx context.Context) {
+	// Check system mode — skip polling when paused.
+	var mode string
+	_ = p.db.QueryRow(ctx, "SELECT value FROM system_state WHERE key = 'mode'").Scan(&mode)
+	if mode == "paused" {
+		return
+	}
+
 	rows, err := p.db.Query(ctx, `
 		SELECT id, name, prompt, repo, provider, timeout, owner, debug, event_config, COALESCE(source_key, '')
 		FROM schedules

--- a/internal/bridge/scheduler.go
+++ b/internal/bridge/scheduler.go
@@ -233,20 +233,22 @@ func contains(vals []int, v int) bool {
 // Scheduler runs recurring tasks based on cron schedules stored in PostgreSQL
 // and polls GitHub Events API for event-triggered schedules.
 type Scheduler struct {
-	db         *pgxpool.Pool
-	dispatcher *Dispatcher
-	cfg        *Config
-	poller     *GitHubPoller
-	stopCh     chan struct{}
-	wg         sync.WaitGroup
+	db            *pgxpool.Pool
+	dispatcher    *Dispatcher
+	cfg           *Config
+	settingsStore *SettingsStore
+	poller        *GitHubPoller
+	stopCh        chan struct{}
+	wg            sync.WaitGroup
 }
 
 // NewScheduler creates a Scheduler with the given dependencies.
-func NewScheduler(db *pgxpool.Pool, dispatcher *Dispatcher, cfg *Config, credStore *CredentialStore, defStore *AgentDefStore) *Scheduler {
+func NewScheduler(db *pgxpool.Pool, dispatcher *Dispatcher, cfg *Config, credStore *CredentialStore, defStore *AgentDefStore, settingsStore *SettingsStore) *Scheduler {
 	return &Scheduler{
-		db:         db,
-		dispatcher: dispatcher,
-		cfg:        cfg,
+		db:            db,
+		dispatcher:    dispatcher,
+		cfg:           cfg,
+		settingsStore: settingsStore,
 		poller: &GitHubPoller{
 			db:         db,
 			dispatcher: dispatcher,
@@ -298,6 +300,11 @@ func (s *Scheduler) Stop() {
 
 // tick queries enabled schedules and dispatches any that are due.
 func (s *Scheduler) tick(ctx context.Context) {
+	// Check system mode — skip dispatch when paused.
+	if mode, _ := s.settingsStore.GetSystemMode(ctx); mode == "paused" {
+		return
+	}
+
 	now := time.Now().UTC()
 
 	rows, err := s.db.Query(ctx, `

--- a/internal/bridge/settings.go
+++ b/internal/bridge/settings.go
@@ -169,6 +169,25 @@ func (s *SettingsStore) SetWebhookSecret(ctx context.Context, secret string) err
 	return err
 }
 
+// GetSystemMode returns the current system mode ("active" or "paused").
+func (s *SettingsStore) GetSystemMode(ctx context.Context) (string, error) {
+	var mode string
+	err := s.db.QueryRow(ctx, "SELECT value FROM system_state WHERE key = 'mode'").Scan(&mode)
+	if err != nil {
+		return "active", nil // default to active if not found
+	}
+	return mode, nil
+}
+
+// SetSystemMode sets the system mode to "active" or "paused".
+func (s *SettingsStore) SetSystemMode(ctx context.Context, mode string) error {
+	_, err := s.db.Exec(ctx, `
+		INSERT INTO system_state (key, value, updated_at) VALUES ('mode', $1, NOW())
+		ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()
+	`, mode)
+	return err
+}
+
 // ResolveEffectiveLLM reads LLM configuration from Config (config file + env vars)
 // and returns the effective config with source tracking.
 func ResolveEffectiveLLM(cfg *Config) *EffectiveSystemLLM {

--- a/internal/bridge/system_state_test.go
+++ b/internal/bridge/system_state_test.go
@@ -1,0 +1,68 @@
+package bridge
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleSystemStateRequiresAdmin(t *testing.T) {
+	a := &API{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/system-state", nil)
+	w := httptest.NewRecorder()
+
+	a.handleSystemState(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestHandleSystemStateMethodNotAllowed(t *testing.T) {
+	a := &API{}
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/system-state", nil)
+	req.Header.Set("X-Alcove-Admin", "true")
+	w := httptest.NewRecorder()
+
+	a.handleSystemState(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleSystemStatePutInvalidMode(t *testing.T) {
+	a := &API{}
+	body := strings.NewReader(`{"mode": "invalid"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/system-state", body)
+	req.Header.Set("X-Alcove-Admin", "true")
+	w := httptest.NewRecorder()
+
+	a.handleSystemState(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["error"] != "mode must be 'active' or 'paused'" {
+		t.Errorf("unexpected error message: %s", resp["error"])
+	}
+}
+
+func TestHandleSystemStatePutInvalidBody(t *testing.T) {
+	a := &API{}
+	body := strings.NewReader(`not json`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/system-state", body)
+	req.Header.Set("X-Alcove-Admin", "true")
+	w := httptest.NewRecorder()
+
+	a.handleSystemState(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2330,3 +2330,25 @@ details[open] > .tx-tool-expand-toggle::before {
     background: rgba(239, 68, 68, 0.15);
     color: #fca5a5;
 }
+
+/* Maintenance banner */
+.maintenance-banner {
+    background: rgba(243, 156, 18, 0.15);
+    border-bottom: 2px solid #f39c12;
+    color: #f39c12;
+    padding: 10px 16px;
+    text-align: center;
+    font-size: 14px;
+    font-weight: 500;
+    display: none;
+}
+.maintenance-banner .btn-sm {
+    margin-left: 12px;
+    padding: 4px 12px;
+    font-size: 12px;
+    background: #f39c12;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -133,6 +133,7 @@
         }).catch(() => {});
         updateAdminUI(); // also call immediately with cached value
         updateRHIdentityUI();
+        startSystemStateCheck();
     }
 
     function updateRHIdentityUI() {
@@ -5628,6 +5629,46 @@
 
     // Make deleteTBRAssociation available globally for onclick handlers
     window.deleteTBRAssociation = deleteTBRAssociation;
+
+    // ---------------------
+    // System State (Maintenance Mode)
+    // ---------------------
+    var systemStateInterval = null;
+
+    function checkSystemState() {
+        api('GET', '/api/v1/admin/system-state')
+            .then(function(resp) { return resp.json(); })
+            .then(function(data) {
+                var banner = document.getElementById('maintenance-banner');
+                if (!banner) {
+                    banner = document.createElement('div');
+                    banner.id = 'maintenance-banner';
+                    banner.className = 'maintenance-banner';
+                    document.body.insertBefore(banner, document.body.firstChild);
+                }
+                if (data.mode === 'paused') {
+                    banner.style.display = 'block';
+                    banner.innerHTML = '<span class="maintenance-text">System paused for maintenance. New sessions will not be dispatched. ' + data.running_sessions + ' session(s) still running.</span>' +
+                        (isAdmin() ? ' <button class="btn btn-sm" onclick="resumeSystem()">Resume</button>' : '');
+                } else {
+                    banner.style.display = 'none';
+                }
+            })
+            .catch(function() {}); // silently fail for non-admins
+    }
+
+    function resumeSystem() {
+        api('PUT', '/api/v1/admin/system-state', {mode: 'active'})
+            .then(function() { checkSystemState(); })
+            .catch(function(err) { alert('Failed to resume: ' + err); });
+    }
+    window.resumeSystem = resumeSystem;
+
+    function startSystemStateCheck() {
+        if (systemStateInterval) clearInterval(systemStateInterval);
+        checkSystemState();
+        systemStateInterval = setInterval(checkSystemState, 30000);
+    }
 
     // ---------------------
     // Init


### PR DESCRIPTION
## Summary

Admin-controlled maintenance mode for safe upgrades. All dispatch paths are gated.

### API
- `GET /api/v1/admin/system-state` — returns `{mode, running_sessions}`
- `PUT /api/v1/admin/system-state` — set `{mode: "paused"}` or `{mode: "active"}`

### What's paused
- Cron scheduler, GitHub poller, manual dispatch, webhook dispatch, agent definition run
- CI Gate retries intentionally NOT paused (should complete)

### What continues
- Running sessions complete normally
- All read APIs work
- Dashboard accessible

### UI
- Yellow maintenance banner when paused with running session count
- Admin "Resume" button

### Changes
- Migration 023: `system_state` table
- `settings.go`: GetSystemMode/SetSystemMode
- `api.go`: system-state handler + pause checks on all dispatch paths
- `scheduler.go`: pause check in tick()
- `poller.go`: pause check in PollAll()
- `app.js`/`style.css`: maintenance banner
- `upgrades.md`: maintenance mode docs
- 4 unit tests for handler validation

## Test plan
- [x] `make build` passes
- [x] All bridge tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)