### PR TITLE
Add deployment hardening and complete upgrade documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,10 @@ LEDGER_DATABASE_URL="postgres://alcove:alcove@localhost:5432/alcove?sslmode=disa
 HAIL_URL="nats://localhost:4222" \
 RUNTIME=docker \
 ./bin/bridge
+
+# Upgrade Bridge (running sessions continue undisturbed)
+make build-images
+podman run -d --replace --name alcove-bridge ...  # same args as dev-up
 ```
 
 ## Code Conventions

--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -167,6 +167,10 @@ objects:
               port: http
             initialDelaySeconds: 3
             periodSeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
           resources:
             requests:
               cpu: 100m
@@ -174,6 +178,7 @@ objects:
             limits:
               cpu: 500m
               memory: 512Mi
+        terminationGracePeriodSeconds: 60
         volumes:
         - name: vertex-ai-credentials
           secret:

--- a/deploy/openshift/template_test.go
+++ b/deploy/openshift/template_test.go
@@ -1,0 +1,111 @@
+package openshift_test
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestTemplateValidYAML verifies the OpenShift template is valid YAML and
+// contains the expected deployment hardening fields (preStop hook,
+// terminationGracePeriodSeconds).
+func TestTemplateValidYAML(t *testing.T) {
+	data, err := os.ReadFile("template.yaml")
+	if err != nil {
+		t.Fatalf("failed to read template.yaml: %v", err)
+	}
+
+	var tmpl map[string]interface{}
+	if err := yaml.Unmarshal(data, &tmpl); err != nil {
+		t.Fatalf("template.yaml is not valid YAML: %v", err)
+	}
+
+	// Verify top-level structure
+	if tmpl["kind"] != "Template" {
+		t.Errorf("expected kind=Template, got %v", tmpl["kind"])
+	}
+
+	objects, ok := tmpl["objects"].([]interface{})
+	if !ok {
+		t.Fatal("expected objects to be a list")
+	}
+
+	// Find the Bridge Deployment
+	var bridgeDep map[string]interface{}
+	for _, obj := range objects {
+		o, ok := obj.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if o["kind"] != "Deployment" {
+			continue
+		}
+		meta, ok := o["metadata"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if meta["name"] == "alcove-bridge" {
+			bridgeDep = o
+			break
+		}
+	}
+	if bridgeDep == nil {
+		t.Fatal("alcove-bridge Deployment not found in template")
+	}
+
+	spec := bridgeDep["spec"].(map[string]interface{})
+	podTemplate := spec["template"].(map[string]interface{})
+	podSpec := podTemplate["spec"].(map[string]interface{})
+
+	// Check terminationGracePeriodSeconds at pod spec level
+	grace, ok := podSpec["terminationGracePeriodSeconds"]
+	if !ok {
+		t.Error("terminationGracePeriodSeconds not found in pod spec")
+	} else if grace != 60 {
+		t.Errorf("expected terminationGracePeriodSeconds=60, got %v", grace)
+	}
+
+	// Find the bridge container
+	containers := podSpec["containers"].([]interface{})
+	var bridgeContainer map[string]interface{}
+	for _, c := range containers {
+		container := c.(map[string]interface{})
+		if container["name"] == "bridge" {
+			bridgeContainer = container
+			break
+		}
+	}
+	if bridgeContainer == nil {
+		t.Fatal("bridge container not found in pod spec")
+	}
+
+	// Check lifecycle.preStop hook
+	lifecycle, ok := bridgeContainer["lifecycle"]
+	if !ok {
+		t.Error("lifecycle not found in bridge container spec")
+	} else {
+		lc := lifecycle.(map[string]interface{})
+		preStop, ok := lc["preStop"]
+		if !ok {
+			t.Error("preStop not found in lifecycle")
+		} else {
+			ps := preStop.(map[string]interface{})
+			exec, ok := ps["exec"]
+			if !ok {
+				t.Error("exec not found in preStop")
+			} else {
+				e := exec.(map[string]interface{})
+				cmd, ok := e["command"]
+				if !ok {
+					t.Error("command not found in preStop exec")
+				} else {
+					cmdList := cmd.([]interface{})
+					if len(cmdList) != 3 || cmdList[0] != "/bin/sh" || cmdList[1] != "-c" || cmdList[2] != "sleep 5" {
+						t.Errorf("unexpected preStop command: %v", cmdList)
+					}
+				}
+			}
+		}
+	}
+}

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -89,3 +89,80 @@ When resumed:
 - Poller immediately fetches pending events
 - Dedup table prevents double-dispatch
 - Scheduler resumes from next_run
+
+## Database Migration Policy
+
+All database migrations MUST be additive to ensure safe rolling updates:
+
+### Allowed
+- `CREATE TABLE`
+- `ALTER TABLE ADD COLUMN` (nullable or with default)
+- `CREATE INDEX`
+- New rows in reference tables
+
+### Not Allowed
+- `ALTER TABLE DROP COLUMN`
+- `ALTER TABLE RENAME COLUMN`
+- `ALTER TABLE ALTER COLUMN SET NOT NULL` (without default)
+- `DROP TABLE`
+- `ALTER TABLE RENAME`
+
+During a rolling update, the old Bridge pod continues serving while the
+new pod runs migrations. Both versions must be able to query the same
+schema simultaneously. The advisory lock in `migrate.go` prevents
+concurrent migration execution.
+
+## Deployment Configuration
+
+### OpenShift/Kubernetes
+
+The Bridge Deployment includes:
+
+- **preStop hook**: 5-second sleep before SIGTERM, allowing the load
+  balancer to drain connections
+- **terminationGracePeriodSeconds: 60**: Bridge has 60 seconds for
+  graceful shutdown (HTTP server drain, NATS drain, final status updates)
+- **Readiness probe**: `/api/v1/health` — new pod only receives traffic
+  after database connectivity is confirmed
+- **Rolling update strategy**: Old pod serves traffic while new pod
+  starts, ensuring zero downtime
+
+### Image Version Management
+
+After upgrade:
+- New sessions use the new `SKIFF_IMAGE` and `GATE_IMAGE`
+- Old sessions continue with their original images until completion
+- No version conflict — sessions are fully isolated containers
+
+## Troubleshooting
+
+### Sessions stuck as "running" after upgrade
+
+The reconciliation loop (every 2 minutes) automatically detects and
+cleans up these sessions. If a session is stuck for more than 5 minutes:
+
+1. Check if the Skiff container still exists:
+   ```bash
+   oc get pods -l task-id=<task-id>
+   ```
+
+2. If the pod is gone, the next reconciliation cycle will clean it up.
+
+3. To force cleanup immediately, restart Bridge — `RecoverHandles()`
+   runs on startup.
+
+### Events not being processed after upgrade
+
+1. Check system mode: `GET /api/v1/admin/system-state`
+2. If paused, resume: `PUT /api/v1/admin/system-state {"mode": "active"}`
+3. Check poller logs: `oc logs deployment/alcove-bridge | grep poller`
+4. Events in GitHub's API are retained for ~90 minutes. As long as
+   Bridge resumes polling within that window, no events are lost.
+
+### CI Gate monitors not resuming
+
+CI Gate monitors are recovered on startup from the `ci_gate_state`
+table. If a monitor isn't running:
+
+1. Check the state: `SELECT * FROM ci_gate_state WHERE status = 'monitoring'`
+2. Restart Bridge to trigger `RecoverMonitors()`


### PR DESCRIPTION
## Summary

Final piece of the safe upgrade story. Completes the three-PR series:
1. PR #162 — Session reconciliation + CI Gate recovery
2. PR #163 — System state API (dispatch pause/resume)
3. **This PR** — K8s deployment hardening + comprehensive upgrade guide

### Deployment template changes
- `preStop` hook: 5-second sleep for load balancer drain before SIGTERM
- `terminationGracePeriodSeconds: 60`: up from default 30

### Documentation
- Database migration policy (additive-only rules)
- Deployment configuration details
- Troubleshooting guide (stuck sessions, stalled events, CI Gate recovery)
- CLAUDE.md quick upgrade command

### Tests
- Template YAML validation test verifying preStop and grace period values

## Test plan
- [x] `make build` passes
- [x] Template test passes
- [x] All bridge tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)