### PR TITLE
Add ADMIN_RESET_PASSWORD for bootstrap on auth backend switch

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -122,6 +122,17 @@ func main() {
 			}
 			log.Printf("default admin user created — username: admin, password: admin — change this in the dashboard")
 		}
+		// ADMIN_RESET_PASSWORD: force-create or reset the admin user.
+		// Used when switching from rh-identity to postgres backend on a
+		// database that already has SSO-provisioned users (who have no passwords).
+		if resetPw := os.Getenv("ADMIN_RESET_PASSWORD"); resetPw != "" {
+			// Try to delete existing admin, ignore errors (may not exist).
+			_ = pgStore.DeleteUser(context.Background(), "admin")
+			if err := pgStore.CreateUser(context.Background(), "admin", resetPw, true); err != nil {
+				log.Fatalf("resetting admin password: %v", err)
+			}
+			log.Printf("admin user reset with provided password (ADMIN_RESET_PASSWORD)")
+		}
 		store = pgStore
 		if m, ok := store.(auth.UserManager); ok {
 			mgr = m

--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -19,6 +19,8 @@ parameters:
   value: "postgres"
 - name: RH_IDENTITY_ADMINS
   value: ""
+- name: ADMIN_RESET_PASSWORD
+  value: ""
 - name: BRIDGE_LLM_PROVIDER
   value: ""
 - name: BRIDGE_LLM_PROJECT
@@ -128,6 +130,8 @@ objects:
             value: ${AUTH_BACKEND}
           - name: RH_IDENTITY_ADMINS
             value: ${RH_IDENTITY_ADMINS}
+          - name: ADMIN_RESET_PASSWORD
+            value: ${ADMIN_RESET_PASSWORD}
           - name: GATE_IMAGE
             value: ${GATE_IMAGE}
           - name: BRIDGE_URL


### PR DESCRIPTION
## Summary
When switching from rh-identity to postgres auth backend, the database has SSO-provisioned users with no passwords. Bridge skips creating the default admin because the auth_users table isn't empty.

`ADMIN_RESET_PASSWORD` env var forces creation/reset of an admin user on startup. Set it once in the app-interface saas file, deploy, login, then remove it.

## Changes
- `cmd/bridge/main.go`: Check `ADMIN_RESET_PASSWORD` env var, delete+recreate admin user
- `deploy/openshift/template.yaml`: Add parameter (defaults to empty = disabled)

## Usage
```yaml
parameters:
  AUTH_BACKEND: "postgres"
  ADMIN_RESET_PASSWORD: "my-temporary-password"
```
Deploy, login with admin/my-temporary-password, change password, then remove `ADMIN_RESET_PASSWORD` from the config.

## Test plan
- [x] `make build` passes
- [x] All tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)