### PR TITLE
Complete orchestration milestone: input injection, approval gates, status API, dashboard

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -222,7 +222,7 @@ func main() {
 	defer syncer.Stop()
 	log.Println("agent repo syncer started")
 
-	api := bridge.NewAPI(dispatcher, dbpool, cfg, scheduler, credStore, toolStore, profileStore, settingsStore, bridgeLLM, defStore, syncer, store)
+	api := bridge.NewAPI(dispatcher, dbpool, cfg, scheduler, credStore, toolStore, profileStore, settingsStore, bridgeLLM, defStore, syncer, store, workflowEngine)
 
 	// Build HTTP server.
 	mux := http.NewServeMux()

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -44,35 +44,37 @@ var templateFS embed.FS
 
 // API holds the HTTP handlers for the Bridge REST API.
 type API struct {
-	dispatcher    *Dispatcher
-	db            *pgxpool.Pool
-	cfg           *Config
-	scheduler     *Scheduler
-	credStore     *CredentialStore
-	toolStore     *ToolStore
-	profileStore  *ProfileStore
-	settingsStore *SettingsStore
-	llm           *BridgeLLM
-	defStore      *AgentDefStore
-	syncer        *AgentRepoSyncer
-	authStore     auth.Authenticator // for TBR associations (rh-identity backend)
+	dispatcher     *Dispatcher
+	db             *pgxpool.Pool
+	cfg            *Config
+	scheduler      *Scheduler
+	credStore      *CredentialStore
+	toolStore      *ToolStore
+	profileStore   *ProfileStore
+	settingsStore  *SettingsStore
+	llm            *BridgeLLM
+	defStore       *AgentDefStore
+	syncer         *AgentRepoSyncer
+	authStore      auth.Authenticator // for TBR associations (rh-identity backend)
+	workflowEngine *WorkflowEngine
 }
 
 // NewAPI creates the API handler set.
-func NewAPI(dispatcher *Dispatcher, db *pgxpool.Pool, cfg *Config, scheduler *Scheduler, credStore *CredentialStore, toolStore *ToolStore, profileStore *ProfileStore, settingsStore *SettingsStore, llm *BridgeLLM, defStore *AgentDefStore, syncer *AgentRepoSyncer, authStore auth.Authenticator) *API {
+func NewAPI(dispatcher *Dispatcher, db *pgxpool.Pool, cfg *Config, scheduler *Scheduler, credStore *CredentialStore, toolStore *ToolStore, profileStore *ProfileStore, settingsStore *SettingsStore, llm *BridgeLLM, defStore *AgentDefStore, syncer *AgentRepoSyncer, authStore auth.Authenticator, workflowEngine *WorkflowEngine) *API {
 	return &API{
-		dispatcher:    dispatcher,
-		db:            db,
-		cfg:           cfg,
-		scheduler:     scheduler,
-		credStore:     credStore,
-		toolStore:     toolStore,
-		profileStore:  profileStore,
-		settingsStore: settingsStore,
-		llm:           llm,
-		defStore:      defStore,
-		syncer:        syncer,
-		authStore:     authStore,
+		dispatcher:     dispatcher,
+		db:             db,
+		cfg:            cfg,
+		scheduler:      scheduler,
+		credStore:      credStore,
+		toolStore:      toolStore,
+		profileStore:   profileStore,
+		settingsStore:  settingsStore,
+		llm:            llm,
+		defStore:       defStore,
+		syncer:         syncer,
+		authStore:      authStore,
+		workflowEngine: workflowEngine,
 	}
 }
 
@@ -109,6 +111,9 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/auth/tbr-associations/", a.handleTBRAssociationByID)
 	mux.HandleFunc("/api/v1/auth/api-tokens", a.handlePersonalAPITokens)
 	mux.HandleFunc("/api/v1/auth/api-tokens/", a.handlePersonalAPITokenByID)
+	mux.HandleFunc("/api/v1/workflows", a.handleWorkflows)
+	mux.HandleFunc("/api/v1/workflow-runs", a.handleWorkflowRuns)
+	mux.HandleFunc("/api/v1/workflow-runs/", a.handleWorkflowRunByID)
 }
 
 // --- Health ---
@@ -2533,6 +2538,127 @@ func (a *API) buildDisabledReposMap(ctx context.Context, username string) map[st
 		}
 	}
 	return disabledRepos
+}
+
+// --- Workflows ---
+
+func (a *API) handleWorkflows(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	owner := r.Header.Get("X-Alcove-User")
+	if owner == "" {
+		owner = "anonymous"
+	}
+
+	workflows, err := a.workflowEngine.workflowStore.ListWorkflows(r.Context(), owner)
+	if err != nil {
+		log.Printf("error listing workflows: %v", err)
+		respondError(w, http.StatusInternalServerError, "failed to list workflows")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]any{
+		"workflows": workflows,
+		"count":     len(workflows),
+	})
+}
+
+func (a *API) handleWorkflowRuns(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	owner := r.Header.Get("X-Alcove-User")
+	if owner == "" {
+		owner = "anonymous"
+	}
+
+	status := r.URL.Query().Get("status")
+
+	runs, err := a.workflowEngine.ListWorkflowRuns(r.Context(), status, owner)
+	if err != nil {
+		log.Printf("error listing workflow runs: %v", err)
+		respondError(w, http.StatusInternalServerError, "failed to list workflow runs")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]any{
+		"workflow_runs": runs,
+		"count":         len(runs),
+	})
+}
+
+func (a *API) handleWorkflowRunByID(w http.ResponseWriter, r *http.Request) {
+	// Parse: /api/v1/workflow-runs/{id} or /api/v1/workflow-runs/{id}/approve/{step_id} or /api/v1/workflow-runs/{id}/reject/{step_id}
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/workflow-runs/")
+	parts := strings.SplitN(path, "/", 3)
+	runID := parts[0]
+
+	if runID == "" {
+		respondError(w, http.StatusBadRequest, "workflow run id required")
+		return
+	}
+
+	// Handle approve/reject actions
+	if len(parts) >= 3 {
+		action := parts[1]
+		stepID := parts[2]
+
+		if r.Method != http.MethodPost {
+			respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+
+		switch action {
+		case "approve":
+			if err := a.workflowEngine.ApproveStep(r.Context(), runID, stepID); err != nil {
+				log.Printf("error approving step %s in run %s: %v", stepID, runID, err)
+				respondError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			respondJSON(w, http.StatusOK, map[string]string{
+				"status":  "approved",
+				"run_id":  runID,
+				"step_id": stepID,
+			})
+		case "reject":
+			if err := a.workflowEngine.RejectStep(r.Context(), runID, stepID); err != nil {
+				log.Printf("error rejecting step %s in run %s: %v", stepID, runID, err)
+				respondError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			respondJSON(w, http.StatusOK, map[string]string{
+				"status":  "rejected",
+				"run_id":  runID,
+				"step_id": stepID,
+			})
+		default:
+			respondError(w, http.StatusNotFound, "unknown action: "+action)
+		}
+		return
+	}
+
+	// GET /api/v1/workflow-runs/{id} — get run detail with all steps
+	if r.Method != http.MethodGet {
+		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	run, steps, err := a.workflowEngine.GetWorkflowRunDetail(r.Context(), runID)
+	if err != nil {
+		log.Printf("error getting workflow run %s: %v", runID, err)
+		respondError(w, http.StatusNotFound, "workflow run not found")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]any{
+		"workflow_run": run,
+		"steps":        steps,
+	})
 }
 
 // --- Helpers ---

--- a/internal/bridge/workflow_engine.go
+++ b/internal/bridge/workflow_engine.go
@@ -28,6 +28,9 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// templateRegex matches template references like {{steps.X.outputs.Y}}.
+var templateRegex = regexp.MustCompile(`\{\{[^}]+\}\}`)
+
 // WorkflowEngine manages workflow execution: DAG evaluation, step dispatch, and completion tracking.
 type WorkflowEngine struct {
 	db            *pgxpool.Pool
@@ -166,7 +169,10 @@ func (we *WorkflowEngine) dispatchStep(ctx context.Context, run *WorkflowRun, st
 		if err := we.updateStepStatus(ctx, run.ID, step.ID, "awaiting_approval", nil, nil); err != nil {
 			return fmt.Errorf("marking step as awaiting approval: %w", err)
 		}
-		// TODO: Implement approval mechanism
+		// Update workflow run status to awaiting_approval
+		if err := we.updateWorkflowRunStatus(ctx, run.ID, "awaiting_approval", nil, nil); err != nil {
+			return fmt.Errorf("marking workflow run as awaiting approval: %w", err)
+		}
 		return nil
 	}
 
@@ -470,15 +476,24 @@ func (we *WorkflowEngine) injectStepInputs(ctx context.Context, runID string, st
 		processedInputs[key] = processedValue
 	}
 
-	// Convert inputs to environment variables or modify prompt
-	// For now, append inputs as JSON to the prompt
+	// Build a "Workflow Context" section and prepend it to the prompt
 	if len(processedInputs) > 0 {
-		inputsJSON, err := json.Marshal(processedInputs)
-		if err != nil {
-			return fmt.Errorf("marshaling inputs: %w", err)
+		var contextLines []string
+		contextLines = append(contextLines, "Workflow Context (from previous steps):")
+		for key, value := range processedInputs {
+			if str, ok := value.(string); ok {
+				contextLines = append(contextLines, fmt.Sprintf("  %s: %s", key, str))
+			} else {
+				valueJSON, err := json.Marshal(value)
+				if err != nil {
+					contextLines = append(contextLines, fmt.Sprintf("  %s: %v", key, value))
+				} else {
+					contextLines = append(contextLines, fmt.Sprintf("  %s: %s", key, string(valueJSON)))
+				}
+			}
 		}
-
-		taskReq.Prompt = taskReq.Prompt + "\n\nWorkflow Step Inputs:\n" + string(inputsJSON)
+		workflowContext := strings.Join(contextLines, "\n")
+		taskReq.Prompt = workflowContext + "\n\n" + taskReq.Prompt
 	}
 
 	return nil
@@ -520,6 +535,28 @@ func (we *WorkflowEngine) expandTemplate(template string, stepOutputs map[string
 	}
 
 	return result, nil
+}
+
+// resolveInputs resolves template references in step inputs using outputs from previous steps.
+// Template references like {{steps.X.outputs.Y}} are replaced with actual values from stepOutputs.
+func resolveInputs(inputs map[string]string, stepOutputs map[string]map[string]string) map[string]string {
+	resolved := make(map[string]string)
+	for key, value := range inputs {
+		// Replace {{steps.X.outputs.Y}} with actual values
+		resolved[key] = templateRegex.ReplaceAllStringFunc(value, func(match string) string {
+			// Parse steps.X.outputs.Y
+			parts := strings.Split(strings.Trim(match, "{}"), ".")
+			if len(parts) == 4 && parts[0] == "steps" && parts[2] == "outputs" {
+				if outputs, ok := stepOutputs[parts[1]]; ok {
+					if val, ok := outputs[parts[3]]; ok {
+						return val
+					}
+				}
+			}
+			return match // leave unresolved templates as-is
+		})
+	}
+	return resolved
 }
 
 // readStepOutputs reads outputs from a completed session.
@@ -625,6 +662,210 @@ func (we *WorkflowEngine) resumeWorkflowRun(ctx context.Context, run *WorkflowRu
 	}
 
 	return nil
+}
+
+// ApproveStep approves a pending approval gate step and dispatches it.
+func (we *WorkflowEngine) ApproveStep(ctx context.Context, runID, stepID string) error {
+	// Verify the step is in awaiting_approval status
+	status, err := we.getStepStatus(ctx, runID, stepID)
+	if err != nil {
+		return fmt.Errorf("getting step status: %w", err)
+	}
+	if status != "awaiting_approval" {
+		return fmt.Errorf("step %s is not awaiting approval (current status: %s)", stepID, status)
+	}
+
+	// Get the workflow run
+	run, err := we.GetWorkflowRun(ctx, runID)
+	if err != nil {
+		return fmt.Errorf("getting workflow run: %w", err)
+	}
+
+	// Get the workflow definition
+	workflow, err := we.getWorkflowByID(ctx, run.WorkflowID)
+	if err != nil {
+		return fmt.Errorf("getting workflow definition: %w", err)
+	}
+
+	// Get the step definition
+	stepDef := workflow.GetStepByID(stepID)
+	if stepDef == nil {
+		return fmt.Errorf("step %s not found in workflow definition", stepID)
+	}
+
+	// Update workflow run status back to running
+	if err := we.updateWorkflowRunStatus(ctx, runID, "running", nil, nil); err != nil {
+		return fmt.Errorf("updating workflow run status: %w", err)
+	}
+
+	// Reset step status to pending so dispatchStep can proceed
+	if err := we.updateStepStatus(ctx, runID, stepID, "pending", nil, nil); err != nil {
+		return fmt.Errorf("resetting step status: %w", err)
+	}
+
+	// Create a temporary copy of the step without the approval requirement
+	approvedStep := *stepDef
+	approvedStep.Approval = ""
+
+	// Dispatch the step
+	if err := we.dispatchStep(ctx, run, &approvedStep, workflow); err != nil {
+		return fmt.Errorf("dispatching approved step: %w", err)
+	}
+
+	log.Printf("step %s approved and dispatched for workflow run %s", stepID, runID)
+	return nil
+}
+
+// RejectStep rejects a pending approval gate step and marks the workflow as failed.
+func (we *WorkflowEngine) RejectStep(ctx context.Context, runID, stepID string) error {
+	// Verify the step is in awaiting_approval status
+	status, err := we.getStepStatus(ctx, runID, stepID)
+	if err != nil {
+		return fmt.Errorf("getting step status: %w", err)
+	}
+	if status != "awaiting_approval" {
+		return fmt.Errorf("step %s is not awaiting approval (current status: %s)", stepID, status)
+	}
+
+	// Mark the step as failed
+	now := time.Now().UTC()
+	if err := we.updateStepStatus(ctx, runID, stepID, "failed", &now, nil); err != nil {
+		return fmt.Errorf("marking step as failed: %w", err)
+	}
+
+	// Mark the workflow run as failed
+	if err := we.updateWorkflowRunStatus(ctx, runID, "failed", nil, &now); err != nil {
+		return fmt.Errorf("marking workflow run as failed: %w", err)
+	}
+
+	log.Printf("step %s rejected for workflow run %s", stepID, runID)
+	return nil
+}
+
+// GetWorkflowRun retrieves a workflow run by ID.
+func (we *WorkflowEngine) GetWorkflowRun(ctx context.Context, runID string) (*WorkflowRun, error) {
+	row := we.db.QueryRow(ctx, `
+		SELECT id, workflow_id, status, trigger_type, trigger_ref, current_step, step_outputs, started_at, finished_at, owner, created_at
+		FROM workflow_runs
+		WHERE id = $1
+	`, runID)
+
+	var run WorkflowRun
+	var stepOutputsJSON []byte
+	var currentStep *string
+	var triggerType, triggerRef *string
+
+	if err := row.Scan(
+		&run.ID, &run.WorkflowID, &run.Status, &triggerType, &triggerRef,
+		&currentStep, &stepOutputsJSON, &run.StartedAt, &run.FinishedAt, &run.Owner, &run.CreatedAt,
+	); err != nil {
+		return nil, fmt.Errorf("getting workflow run %s: %w", runID, err)
+	}
+
+	if currentStep != nil {
+		run.CurrentStep = *currentStep
+	}
+	if triggerType != nil {
+		run.TriggerType = *triggerType
+	}
+	if triggerRef != nil {
+		run.TriggerRef = *triggerRef
+	}
+	if stepOutputsJSON != nil {
+		if err := json.Unmarshal(stepOutputsJSON, &run.StepOutputs); err != nil {
+			run.StepOutputs = make(map[string]interface{})
+		}
+	} else {
+		run.StepOutputs = make(map[string]interface{})
+	}
+
+	return &run, nil
+}
+
+// ListWorkflowRuns lists workflow runs, optionally filtered by status and owner.
+func (we *WorkflowEngine) ListWorkflowRuns(ctx context.Context, status, owner string) ([]WorkflowRun, error) {
+	query := `
+		SELECT id, workflow_id, status, trigger_type, trigger_ref, current_step, step_outputs, started_at, finished_at, owner, created_at
+		FROM workflow_runs
+		WHERE 1=1
+	`
+	args := []interface{}{}
+	argN := 1
+
+	if owner != "" {
+		query += fmt.Sprintf(" AND owner = $%d", argN)
+		args = append(args, owner)
+		argN++
+	}
+	if status != "" {
+		query += fmt.Sprintf(" AND status = $%d", argN)
+		args = append(args, status)
+		argN++
+	}
+
+	query += " ORDER BY created_at DESC LIMIT 100"
+
+	rows, err := we.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing workflow runs: %w", err)
+	}
+	defer rows.Close()
+
+	var runs []WorkflowRun
+	for rows.Next() {
+		var run WorkflowRun
+		var stepOutputsJSON []byte
+		var currentStep, triggerType, triggerRef *string
+
+		if err := rows.Scan(
+			&run.ID, &run.WorkflowID, &run.Status, &triggerType, &triggerRef,
+			&currentStep, &stepOutputsJSON, &run.StartedAt, &run.FinishedAt, &run.Owner, &run.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scanning workflow run: %w", err)
+		}
+
+		if currentStep != nil {
+			run.CurrentStep = *currentStep
+		}
+		if triggerType != nil {
+			run.TriggerType = *triggerType
+		}
+		if triggerRef != nil {
+			run.TriggerRef = *triggerRef
+		}
+		if stepOutputsJSON != nil {
+			if err := json.Unmarshal(stepOutputsJSON, &run.StepOutputs); err != nil {
+				run.StepOutputs = make(map[string]interface{})
+			}
+		} else {
+			run.StepOutputs = make(map[string]interface{})
+		}
+
+		runs = append(runs, run)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating workflow runs: %w", err)
+	}
+
+	if runs == nil {
+		runs = []WorkflowRun{}
+	}
+	return runs, nil
+}
+
+// GetWorkflowRunDetail retrieves a workflow run with all its steps.
+func (we *WorkflowEngine) GetWorkflowRunDetail(ctx context.Context, runID string) (*WorkflowRun, []WorkflowRunStep, error) {
+	run, err := we.GetWorkflowRun(ctx, runID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	steps, err := we.getWorkflowRunSteps(ctx, runID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting workflow run steps: %w", err)
+	}
+
+	return run, steps, nil
 }
 
 // Database helper methods

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2410,6 +2410,117 @@ details[open] > .tx-tool-expand-toggle::before {
     cursor: pointer;
 }
 
+/* === Workflow Steps === */
+.workflow-run-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 16px;
+    margin-bottom: 12px;
+    cursor: pointer;
+    transition: border-color var(--transition), background var(--transition);
+}
+
+.workflow-run-card:hover {
+    border-color: var(--text-muted);
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.workflow-run-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.workflow-run-name {
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--text);
+}
+
+.workflow-run-meta {
+    display: flex;
+    gap: 16px;
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.workflow-step-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin-bottom: 8px;
+}
+
+.workflow-step-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.workflow-step-dot-pending {
+    background: var(--text-muted);
+    opacity: 0.5;
+}
+
+.workflow-step-dot-running {
+    background: var(--status-running);
+    animation: pulse-dot 1.5s ease-in-out infinite;
+}
+
+.workflow-step-dot-completed {
+    background: var(--status-completed);
+}
+
+.workflow-step-dot-failed {
+    background: var(--status-error);
+}
+
+.workflow-step-dot-skipped {
+    background: var(--text-muted);
+    opacity: 0.3;
+}
+
+.workflow-step-dot-awaiting_approval {
+    background: var(--status-cancelled);
+    animation: pulse-dot 1.5s ease-in-out infinite;
+}
+
+.workflow-step-info {
+    flex: 1;
+}
+
+.workflow-step-name {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--text);
+}
+
+.workflow-step-agent {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+}
+
+.workflow-step-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.workflow-step-connector {
+    width: 2px;
+    height: 12px;
+    background: var(--border);
+    margin-left: 21px;
+}
+
 /* === Footer === */
 .alcove-footer {
     text-align: center;

--- a/web/index.html
+++ b/web/index.html
@@ -57,6 +57,7 @@
                 <a href="#task/new" class="nav-tab" data-tab="task/new">New Session</a>
                 <a href="#sessions" class="nav-tab" data-tab="sessions">Sessions</a>
                 <a href="#schedules" class="nav-tab" data-tab="schedules">Schedules</a>
+                <a href="#workflows" class="nav-tab" data-tab="workflows">Workflows</a>
                 <a href="#credentials" class="nav-tab" data-tab="credentials">Credentials</a>
                 <a href="#security" class="nav-tab" data-tab="security">Security</a>
                 <a href="#repos" class="nav-tab" data-tab="repos">Repos</a>
@@ -503,6 +504,37 @@
                         </div>
                     </div>
                 </div>
+            </div>
+
+            <!-- Workflows -->
+            <div id="page-workflows" class="page" hidden>
+                <div class="page-header">
+                    <h2>Workflows</h2>
+                    <div class="filters">
+                        <select id="workflow-filter-status" class="input input-small" aria-label="Filter by status">
+                            <option value="">All Statuses</option>
+                            <option value="pending">Pending</option>
+                            <option value="running">Running</option>
+                            <option value="completed">Completed</option>
+                            <option value="failed">Failed</option>
+                            <option value="awaiting_approval">Awaiting Approval</option>
+                        </select>
+                    </div>
+                </div>
+                <div id="workflow-runs-list"></div>
+                <div id="workflow-runs-empty" class="empty-state" hidden><p>No workflow runs found.</p></div>
+                <div id="workflow-runs-loading" class="loading-state" hidden><div class="spinner"></div><p>Loading workflow runs...</p></div>
+            </div>
+
+            <!-- Workflow Run Detail -->
+            <div id="page-workflow-detail" class="page" hidden>
+                <div class="page-header">
+                    <button id="back-to-workflows" class="btn btn-small btn-outline">Back to Workflows</button>
+                    <h2 id="workflow-detail-title">Workflow Run</h2>
+                </div>
+                <div class="session-meta-grid" id="workflow-meta"></div>
+                <h3 style="color:#fff;margin-bottom:12px;">Steps</h3>
+                <div id="workflow-steps-list"></div>
             </div>
 
             <!-- Tools (admin, accessible from Security page) -->

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1199,12 +1199,13 @@
         stopSSE();
 
         const route = getRoute();
-        const pages = ['sessions', 'task-new', 'schedules', 'repos', 'credentials', 'security', 'tools', 'session-detail', 'users', 'account'];
+        const pages = ['sessions', 'task-new', 'schedules', 'repos', 'credentials', 'security', 'tools', 'session-detail', 'users', 'account', 'workflows', 'workflow-detail'];
         pages.forEach((p) => hide($('#page-' + p)));
 
         // Update active nav tab
         var navRoute = route.startsWith('session/') ? 'sessions' : route;
         if (navRoute === 'tools' || navRoute === 'tools-admin') navRoute = 'security';
+        if (route.startsWith('workflow-run/')) navRoute = 'workflows';
         $$('.nav-tab').forEach((tab) => {
             tab.classList.toggle('active', tab.dataset.tab === navRoute);
         });
@@ -1244,6 +1245,13 @@
             const id = route.replace('session/', '');
             show($('#page-session-detail'));
             loadSessionDetail(id);
+        } else if (route === 'workflows') {
+            show($('#page-workflows'));
+            loadWorkflowRuns();
+        } else if (route.startsWith('workflow-run/')) {
+            var wfRunId = route.replace('workflow-run/', '');
+            show($('#page-workflow-detail'));
+            loadWorkflowRunDetail(wfRunId);
         } else if (route === 'users') {
             if (!isAdmin()) { navigate('sessions'); return; }
             show($('#page-users'));
@@ -5877,6 +5885,187 @@
         checkSystemState();
         systemStateInterval = setInterval(checkSystemState, 30000);
     }
+
+    // ---------------------
+    // Workflows
+    // ---------------------
+
+    async function loadWorkflowRuns() {
+        var list = $('#workflow-runs-list');
+        var empty = $('#workflow-runs-empty');
+        var loading = $('#workflow-runs-loading');
+
+        list.innerHTML = '';
+        hide(empty);
+        show(loading);
+
+        try {
+            var statusFilter = $('#workflow-filter-status') ? $('#workflow-filter-status').value : '';
+            var url = '/api/v1/workflow-runs';
+            if (statusFilter) url += '?status=' + encodeURIComponent(statusFilter);
+
+            var resp = await api('GET', url);
+            var data = await resp.json();
+            hide(loading);
+
+            if (!data.workflow_runs || data.workflow_runs.length === 0) {
+                show(empty);
+                return;
+            }
+
+            data.workflow_runs.forEach(function (run) {
+                var card = document.createElement('div');
+                card.className = 'workflow-run-card';
+                card.onclick = function () { navigate('workflow-run/' + run.id); };
+
+                var statusClass = 'badge-' + (run.status === 'awaiting_approval' ? 'cancelled' : run.status === 'failed' ? 'error' : run.status);
+                var startTime = run.started_at ? new Date(run.started_at).toLocaleString() : 'Not started';
+
+                card.innerHTML =
+                    '<div class="workflow-run-header">' +
+                        '<span class="workflow-run-name">Run ' + escapeHtml(run.id.substring(0, 8)) + '</span>' +
+                        '<span class="badge ' + statusClass + '">' + escapeHtml(run.status) + '</span>' +
+                    '</div>' +
+                    '<div class="workflow-run-meta">' +
+                        '<span>Started: ' + escapeHtml(startTime) + '</span>' +
+                        (run.trigger_type ? '<span>Trigger: ' + escapeHtml(run.trigger_type) + '</span>' : '') +
+                        (run.current_step ? '<span>Current: ' + escapeHtml(run.current_step) + '</span>' : '') +
+                    '</div>';
+
+                list.appendChild(card);
+            });
+        } catch (err) {
+            hide(loading);
+            if (err.message !== 'unauthorized') {
+                list.innerHTML = '<div class="error-message">Failed to load workflow runs.</div>';
+            }
+        }
+    }
+
+    // Attach filter change handler
+    (function() {
+        var filterEl = $('#workflow-filter-status');
+        if (filterEl) {
+            filterEl.addEventListener('change', function () {
+                loadWorkflowRuns();
+            });
+        }
+    })();
+
+    async function loadWorkflowRunDetail(runId) {
+        var meta = $('#workflow-meta');
+        var stepsList = $('#workflow-steps-list');
+        var title = $('#workflow-detail-title');
+
+        meta.innerHTML = '';
+        stepsList.innerHTML = '';
+        title.textContent = 'Workflow Run';
+
+        try {
+            var resp = await api('GET', '/api/v1/workflow-runs/' + runId);
+            var data = await resp.json();
+
+            var run = data.workflow_run;
+            var steps = data.steps || [];
+
+            title.textContent = 'Workflow Run ' + run.id.substring(0, 8);
+
+            // Build meta cards
+            var statusClass = 'badge-' + (run.status === 'awaiting_approval' ? 'cancelled' : run.status === 'failed' ? 'error' : run.status);
+            meta.innerHTML =
+                '<div class="meta-card"><div class="meta-label">Status</div><div class="meta-value"><span class="badge ' + statusClass + '">' + escapeHtml(run.status) + '</span></div></div>' +
+                '<div class="meta-card"><div class="meta-label">Started</div><div class="meta-value">' + (run.started_at ? new Date(run.started_at).toLocaleString() : 'Not started') + '</div></div>' +
+                '<div class="meta-card"><div class="meta-label">Finished</div><div class="meta-value">' + (run.finished_at ? new Date(run.finished_at).toLocaleString() : '-') + '</div></div>' +
+                '<div class="meta-card"><div class="meta-label">Trigger</div><div class="meta-value">' + escapeHtml(run.trigger_type || 'manual') + '</div></div>';
+
+            // Build steps list with connectors
+            steps.forEach(function (step, idx) {
+                if (idx > 0) {
+                    var connector = document.createElement('div');
+                    connector.className = 'workflow-step-connector';
+                    stepsList.appendChild(connector);
+                }
+
+                var item = document.createElement('div');
+                item.className = 'workflow-step-item';
+
+                var dotClass = 'workflow-step-dot workflow-step-dot-' + step.status;
+                var statusBadgeClass = 'badge-' + (step.status === 'awaiting_approval' ? 'cancelled' : step.status === 'failed' ? 'error' : step.status);
+
+                var actionsHtml = '';
+                if (step.status === 'awaiting_approval') {
+                    actionsHtml =
+                        '<div class="workflow-step-actions">' +
+                            '<button class="btn btn-small btn-primary" onclick="window._approveStep(\'' + escapeHtml(runId) + '\',\'' + escapeHtml(step.step_id) + '\')">Approve</button>' +
+                            '<button class="btn btn-small btn-outline" style="color:var(--status-error);border-color:var(--status-error);" onclick="window._rejectStep(\'' + escapeHtml(runId) + '\',\'' + escapeHtml(step.step_id) + '\')">Reject</button>' +
+                        '</div>';
+                }
+
+                var sessionLink = '';
+                if (step.session_id) {
+                    sessionLink = ' <a href="#session/' + escapeHtml(step.session_id) + '" class="trigger-link" onclick="event.stopPropagation()">View Session</a>';
+                }
+
+                item.innerHTML =
+                    '<div class="' + dotClass + '"></div>' +
+                    '<div class="workflow-step-info">' +
+                        '<div class="workflow-step-name">' + escapeHtml(step.step_id) + '</div>' +
+                        '<div class="workflow-step-agent">' +
+                            '<span class="badge ' + statusBadgeClass + '">' + escapeHtml(step.status) + '</span>' +
+                            sessionLink +
+                        '</div>' +
+                    '</div>' +
+                    actionsHtml;
+
+                stepsList.appendChild(item);
+            });
+
+        } catch (err) {
+            if (err.message !== 'unauthorized') {
+                stepsList.innerHTML = '<div class="error-message">Failed to load workflow run detail.</div>';
+            }
+        }
+    }
+
+    // Back button for workflow detail
+    (function() {
+        var backBtn = $('#back-to-workflows');
+        if (backBtn) {
+            backBtn.addEventListener('click', function () {
+                navigate('workflows');
+            });
+        }
+    })();
+
+    // Expose approve/reject functions to window for inline onclick handlers
+    window._approveStep = async function (runId, stepId) {
+        try {
+            var resp = await api('POST', '/api/v1/workflow-runs/' + runId + '/approve/' + stepId);
+            if (resp.ok) {
+                loadWorkflowRunDetail(runId);
+            } else {
+                var data = await resp.json();
+                alert('Failed to approve step: ' + (data.error || 'Unknown error'));
+            }
+        } catch (err) {
+            alert('Failed to approve step: ' + err.message);
+        }
+    };
+
+    window._rejectStep = async function (runId, stepId) {
+        if (!confirm('Are you sure you want to reject this step? The workflow will be marked as failed.')) return;
+        try {
+            var resp = await api('POST', '/api/v1/workflow-runs/' + runId + '/reject/' + stepId);
+            if (resp.ok) {
+                loadWorkflowRunDetail(runId);
+            } else {
+                var data = await resp.json();
+                alert('Failed to reject step: ' + (data.error || 'Unknown error'));
+            }
+        } catch (err) {
+            alert('Failed to reject step: ' + err.message);
+        }
+    };
 
     // ---------------------
     // Version Footer


### PR DESCRIPTION
## Summary

Implements the remaining 4 milestone issues for Agent Orchestration in one PR:

- **#182** (5/12) Input injection: resolve `{{steps.X.outputs.Y}}` templates, prepend as workflow context to prompt
- **#185** (8/12) Approval gates: `awaiting_approval` step status, `POST .../approve/{step}` and `.../reject/{step}` API endpoints
- **#186** (9/12) Workflow status API: `GET /api/v1/workflows`, `GET /api/v1/workflow-runs`, `GET /api/v1/workflow-runs/{id}` with step details
- **#187** (10/12) Dashboard workflows page: run list with status filter, run detail with step visualization, inline approve/reject buttons

## Test plan
- [x] `make build` passes
- [x] All tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)