### PR TITLE
Add CLI profiles for managing multiple Alcove installations

### DIFF
--- a/cmd/alcove/main.go
+++ b/cmd/alcove/main.go
@@ -39,9 +39,9 @@ import (
 // Version is set at build time via -ldflags.
 var Version = "dev"
 
-// CLIConfig holds the user-level CLI configuration.
-type CLIConfig struct {
-	Server   string `yaml:"server"`
+// CLIProfile holds per-profile CLI configuration.
+type CLIProfile struct {
+	Server   string `yaml:"server,omitempty"`
 	Output   string `yaml:"output,omitempty"`    // "json" or "table"
 	Username string `yaml:"username,omitempty"`  // Basic Auth username
 	Password string `yaml:"password,omitempty"`  // Basic Auth password
@@ -54,6 +54,15 @@ type CLIConfig struct {
 		Timeout  string  `yaml:"timeout,omitempty"`  // Default timeout (e.g., "30m")
 		Budget   float64 `yaml:"budget,omitempty"`   // Default budget in USD
 	} `yaml:"defaults,omitempty"`
+}
+
+// CLIConfig holds the user-level CLI configuration, including named profiles.
+type CLIConfig struct {
+	ActiveProfile string                `yaml:"active_profile,omitempty"`
+	Profiles      map[string]CLIProfile `yaml:"profiles,omitempty"`
+
+	// Top-level fields for backward compat (the "default" profile)
+	CLIProfile `yaml:",inline"`
 }
 
 // ProxyConfig holds HTTP proxy configuration.
@@ -77,6 +86,7 @@ func main() {
 	root.PersistentFlags().StringP("password", "p", "", "Password for Basic Auth (overrides ALCOVE_PASSWORD)")
 	root.PersistentFlags().String("proxy-url", "", "HTTP/HTTPS proxy URL (overrides environment)")
 	root.PersistentFlags().String("no-proxy", "", "Comma-separated list of hosts to exclude from proxy (overrides NO_PROXY env var)")
+	root.PersistentFlags().String("profile", "", "Use a named profile from config (overrides active_profile)")
 
 	root.AddCommand(
 		newRunCmd(),
@@ -87,6 +97,7 @@ func main() {
 		newDeleteCmd(),
 		newLoginCmd(),
 		newConfigCmd(),
+		newProfileCmd(),
 		newVersionCmd(),
 	)
 
@@ -94,6 +105,35 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// resolveProfile resolves the active CLIProfile based on --profile flag,
+// ALCOVE_PROFILE env var, active_profile in config, or top-level (inline) fields.
+func resolveProfile(cmd *cobra.Command) (*CLIProfile, error) {
+	cfg, err := loadConfig()
+	if err != nil {
+		return &CLIProfile{}, nil // no config file — empty profile
+	}
+
+	// Determine which profile name to use
+	profileName, _ := cmd.Flags().GetString("profile")
+	if profileName == "" {
+		profileName = os.Getenv("ALCOVE_PROFILE")
+	}
+	if profileName == "" {
+		profileName = cfg.ActiveProfile
+	}
+
+	// Look up the named profile
+	if profileName != "" && cfg.Profiles != nil {
+		if profile, ok := cfg.Profiles[profileName]; ok {
+			return &profile, nil
+		}
+		return nil, fmt.Errorf("profile %q not found in config", profileName)
+	}
+
+	// Fall back to top-level (inline) config
+	return &cfg.CLIProfile, nil
 }
 
 // resolveServer determines the Bridge URL from flag, env, or config file.
@@ -106,10 +146,13 @@ func resolveServer(cmd *cobra.Command) (string, error) {
 	if s := os.Getenv("ALCOVE_SERVER"); s != "" {
 		return strings.TrimRight(s, "/"), nil
 	}
-	// 3. Config file
-	cfg, err := loadConfig()
-	if err == nil && cfg.Server != "" {
-		return strings.TrimRight(cfg.Server, "/"), nil
+	// 3. Active profile from config file
+	profile, err := resolveProfile(cmd)
+	if err != nil {
+		return "", err
+	}
+	if profile.Server != "" {
+		return strings.TrimRight(profile.Server, "/"), nil
 	}
 	return "", fmt.Errorf("no Bridge server configured; use --server, ALCOVE_SERVER, or 'alcove login'")
 }
@@ -131,10 +174,10 @@ func resolveBasicAuth(cmd *cobra.Command) (string, string) {
 		return username, password
 	}
 
-	// 3. Config file
-	if cfg, err := loadConfig(); err == nil {
-		username = cfg.Username
-		password = cfg.Password
+	// 3. Active profile from config file
+	if profile, err := resolveProfile(cmd); err == nil {
+		username = profile.Username
+		password = profile.Password
 	}
 	return username, password
 }
@@ -186,14 +229,14 @@ func resolveProxyConfig(cmd *cobra.Command) (*ProxyConfig, error) {
 		}
 	}
 
-	// 3. Config file
+	// 3. Active profile from config file
 	if config.ProxyURL == "" {
-		if cfg, err := loadConfig(); err == nil && cfg.ProxyURL != "" {
-			if err := validateProxyURL(cfg.ProxyURL); err == nil {
-				config.ProxyURL = cfg.ProxyURL
+		if profile, err := resolveProfile(cmd); err == nil && profile.ProxyURL != "" {
+			if err := validateProxyURL(profile.ProxyURL); err == nil {
+				config.ProxyURL = profile.ProxyURL
 			}
-			if cfg.NoProxy != "" && len(config.NoProxy) == 0 {
-				config.NoProxy = parseNoProxy(cfg.NoProxy)
+			if profile.NoProxy != "" && len(config.NoProxy) == 0 {
+				config.NoProxy = parseNoProxy(profile.NoProxy)
 			}
 		}
 	}
@@ -429,7 +472,7 @@ func isJSONOutput(cmd *cobra.Command) bool {
 	if os.Getenv("ALCOVE_OUTPUT") == "json" {
 		return true
 	}
-	if cfg, err := loadConfig(); err == nil && cfg.Output == "json" {
+	if profile, err := resolveProfile(cmd); err == nil && profile.Output == "json" {
 		return true
 	}
 	return false
@@ -483,22 +526,22 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 	reqBody.Debug, _ = cmd.Flags().GetBool("debug")
 
-	// Fall back to config file defaults
-	if cfg, err := loadConfig(); err == nil {
+	// Fall back to active profile defaults
+	if profile, err := resolveProfile(cmd); err == nil {
 		if reqBody.Repo == "" {
-			reqBody.Repo = cfg.Defaults.Repo
+			reqBody.Repo = profile.Defaults.Repo
 		}
 		if reqBody.Provider == "" {
-			reqBody.Provider = cfg.Defaults.Provider
+			reqBody.Provider = profile.Defaults.Provider
 		}
 		if reqBody.Model == "" {
-			reqBody.Model = cfg.Defaults.Model
+			reqBody.Model = profile.Defaults.Model
 		}
-		if reqBody.Budget == 0 && cfg.Defaults.Budget > 0 {
-			reqBody.Budget = cfg.Defaults.Budget
+		if reqBody.Budget == 0 && profile.Defaults.Budget > 0 {
+			reqBody.Budget = profile.Defaults.Budget
 		}
-		if reqBody.Timeout == 0 && cfg.Defaults.Timeout != "" {
-			if d, err := time.ParseDuration(cfg.Defaults.Timeout); err == nil {
+		if reqBody.Timeout == 0 && profile.Defaults.Timeout != "" {
+			if d, err := time.ParseDuration(profile.Defaults.Timeout); err == nil {
 				reqBody.Timeout = int(d.Seconds())
 			}
 		}
@@ -1070,7 +1113,26 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	if cfg == nil {
 		cfg = &CLIConfig{}
 	}
-	cfg.Server = bridgeURL
+
+	// Determine which profile to save the server URL on
+	loginProfileName, _ := cmd.Flags().GetString("profile")
+	if loginProfileName == "" {
+		loginProfileName = os.Getenv("ALCOVE_PROFILE")
+	}
+	if loginProfileName == "" {
+		loginProfileName = cfg.ActiveProfile
+	}
+
+	if loginProfileName != "" && cfg.Profiles != nil {
+		if profile, ok := cfg.Profiles[loginProfileName]; ok {
+			profile.Server = bridgeURL
+			cfg.Profiles[loginProfileName] = profile
+		} else {
+			cfg.Server = bridgeURL
+		}
+	} else {
+		cfg.Server = bridgeURL
+	}
 	if err := saveConfig(cfg); err != nil {
 		return fmt.Errorf("saving config: %w", err)
 	}
@@ -1128,47 +1190,83 @@ func newConfigCmd() *cobra.Command {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Set a configuration value",
+		Long:  "Set a configuration value. When a named profile is active (via --profile flag, ALCOVE_PROFILE env, or active_profile in config), the value is set on that profile. Otherwise it is set on the top-level config.",
 		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, _ := loadConfig()
-			if cfg == nil {
-				cfg = &CLIConfig{}
-			}
-			key, value := args[0], args[1]
-			switch key {
-			case "server":
-				cfg.Server = value
-			case "output":
-				cfg.Output = value
-			case "username":
-				cfg.Username = value
-			case "password":
-				cfg.Password = value
-			case "proxy_url":
-				cfg.ProxyURL = value
-			case "no_proxy":
-				cfg.NoProxy = value
-			case "defaults.repo":
-				cfg.Defaults.Repo = value
-			case "defaults.provider":
-				cfg.Defaults.Provider = value
-			case "defaults.model":
-				cfg.Defaults.Model = value
-			case "defaults.timeout":
-				cfg.Defaults.Timeout = value
-			case "defaults.budget":
-				if b, err := strconv.ParseFloat(value, 64); err == nil {
-					cfg.Defaults.Budget = b
-				} else {
-					return fmt.Errorf("invalid budget value: %s", value)
-				}
-			default:
-				return fmt.Errorf("unknown config key: %s\nValid keys: server, output, username, password, proxy_url, no_proxy, defaults.repo, defaults.provider, defaults.model, defaults.timeout, defaults.budget", key)
-			}
-			return saveConfig(cfg)
-		},
+		RunE:  runConfigSet,
 	})
 	return cmd
+}
+
+func setProfileField(profile *CLIProfile, key, value string) error {
+	switch key {
+	case "server":
+		profile.Server = value
+	case "output":
+		profile.Output = value
+	case "username":
+		profile.Username = value
+	case "password":
+		profile.Password = value
+	case "proxy_url":
+		profile.ProxyURL = value
+	case "no_proxy":
+		profile.NoProxy = value
+	case "defaults.repo":
+		profile.Defaults.Repo = value
+	case "defaults.provider":
+		profile.Defaults.Provider = value
+	case "defaults.model":
+		profile.Defaults.Model = value
+	case "defaults.timeout":
+		profile.Defaults.Timeout = value
+	case "defaults.budget":
+		if b, err := strconv.ParseFloat(value, 64); err == nil {
+			profile.Defaults.Budget = b
+		} else {
+			return fmt.Errorf("invalid budget value: %s", value)
+		}
+	default:
+		return fmt.Errorf("unknown config key: %s\nValid keys: server, output, username, password, proxy_url, no_proxy, defaults.repo, defaults.provider, defaults.model, defaults.timeout, defaults.budget", key)
+	}
+	return nil
+}
+
+func runConfigSet(cmd *cobra.Command, args []string) error {
+	cfg, _ := loadConfig()
+	if cfg == nil {
+		cfg = &CLIConfig{}
+	}
+	key, value := args[0], args[1]
+
+	// Determine which profile to set the value on
+	profileName, _ := cmd.Flags().GetString("profile")
+	if profileName == "" {
+		profileName = os.Getenv("ALCOVE_PROFILE")
+	}
+	if profileName == "" {
+		profileName = cfg.ActiveProfile
+	}
+
+	if profileName != "" {
+		// Set on named profile
+		if cfg.Profiles == nil {
+			cfg.Profiles = make(map[string]CLIProfile)
+		}
+		profile, ok := cfg.Profiles[profileName]
+		if !ok {
+			return fmt.Errorf("profile %q not found in config; use 'alcove profile add %s' to create it", profileName, profileName)
+		}
+		if err := setProfileField(&profile, key, value); err != nil {
+			return err
+		}
+		cfg.Profiles[profileName] = profile
+	} else {
+		// Set on top-level (inline) config
+		if err := setProfileField(&cfg.CLIProfile, key, value); err != nil {
+			return err
+		}
+	}
+	return saveConfig(cfg)
 }
 
 func runConfigValidate(cmd *cobra.Command, _ []string) error {
@@ -1312,6 +1410,22 @@ func runConfigShow(cmd *cobra.Command, _ []string) error {
 	fmt.Fprintln(os.Stderr, "Effective configuration:")
 	fmt.Fprintln(os.Stderr, "")
 
+	// Active profile
+	profileName, _ := cmd.Flags().GetString("profile")
+	if profileName == "" {
+		profileName = os.Getenv("ALCOVE_PROFILE")
+	}
+	if profileName == "" {
+		if cfg, err := loadConfig(); err == nil {
+			profileName = cfg.ActiveProfile
+		}
+	}
+	if profileName != "" {
+		fmt.Fprintf(os.Stderr, "Profile:      %s\n", profileName)
+	} else {
+		fmt.Fprintf(os.Stderr, "Profile:      <default>\n")
+	}
+
 	// Server resolution
 	server, serverErr := resolveServer(cmd)
 	if serverErr != nil {
@@ -1326,8 +1440,8 @@ func runConfigShow(cmd *cobra.Command, _ []string) error {
 		fmt.Fprintf(os.Stderr, "Output:       %s (from --output flag)\n", f)
 	} else if env := os.Getenv("ALCOVE_OUTPUT"); env != "" {
 		fmt.Fprintf(os.Stderr, "Output:       %s (from ALCOVE_OUTPUT env)\n", env)
-	} else if cfg, err := loadConfig(); err == nil && cfg.Output != "" {
-		fmt.Fprintf(os.Stderr, "Output:       %s (from config file)\n", cfg.Output)
+	} else if profile, err := resolveProfile(cmd); err == nil && profile.Output != "" {
+		fmt.Fprintf(os.Stderr, "Output:       %s (from config file)\n", profile.Output)
 	} else {
 		fmt.Fprintf(os.Stderr, "Output:       %s (default)\n", output)
 	}
@@ -1354,37 +1468,37 @@ func runConfigShow(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	// Defaults
+	// Defaults from active profile
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Default values for 'run' command:")
 
-	if cfg, err := loadConfig(); err == nil {
-		if cfg.Defaults.Repo != "" {
-			fmt.Fprintf(os.Stderr, "  Repository: %s\n", cfg.Defaults.Repo)
+	if profile, err := resolveProfile(cmd); err == nil {
+		if profile.Defaults.Repo != "" {
+			fmt.Fprintf(os.Stderr, "  Repository: %s\n", profile.Defaults.Repo)
 		} else {
 			fmt.Fprintf(os.Stderr, "  Repository: <none>\n")
 		}
 
-		if cfg.Defaults.Provider != "" {
-			fmt.Fprintf(os.Stderr, "  Provider:   %s\n", cfg.Defaults.Provider)
+		if profile.Defaults.Provider != "" {
+			fmt.Fprintf(os.Stderr, "  Provider:   %s\n", profile.Defaults.Provider)
 		} else {
 			fmt.Fprintf(os.Stderr, "  Provider:   <none>\n")
 		}
 
-		if cfg.Defaults.Model != "" {
-			fmt.Fprintf(os.Stderr, "  Model:      %s\n", cfg.Defaults.Model)
+		if profile.Defaults.Model != "" {
+			fmt.Fprintf(os.Stderr, "  Model:      %s\n", profile.Defaults.Model)
 		} else {
 			fmt.Fprintf(os.Stderr, "  Model:      <none>\n")
 		}
 
-		if cfg.Defaults.Timeout != "" {
-			fmt.Fprintf(os.Stderr, "  Timeout:    %s\n", cfg.Defaults.Timeout)
+		if profile.Defaults.Timeout != "" {
+			fmt.Fprintf(os.Stderr, "  Timeout:    %s\n", profile.Defaults.Timeout)
 		} else {
 			fmt.Fprintf(os.Stderr, "  Timeout:    <none>\n")
 		}
 
-		if cfg.Defaults.Budget > 0 {
-			fmt.Fprintf(os.Stderr, "  Budget:     $%.2f\n", cfg.Defaults.Budget)
+		if profile.Defaults.Budget > 0 {
+			fmt.Fprintf(os.Stderr, "  Budget:     $%.2f\n", profile.Defaults.Budget)
 		} else {
 			fmt.Fprintf(os.Stderr, "  Budget:     <none>\n")
 		}
@@ -1397,13 +1511,187 @@ func runConfigShow(cmd *cobra.Command, _ []string) error {
 	fmt.Fprintln(os.Stderr, "Configuration file search order:")
 	for i, path := range getConfigPaths() {
 		if _, err := os.Stat(path); err == nil {
-			fmt.Fprintf(os.Stderr, "  %d. %s ✓\n", i+1, path)
+			fmt.Fprintf(os.Stderr, "  %d. %s (found)\n", i+1, path)
 		} else {
 			fmt.Fprintf(os.Stderr, "  %d. %s\n", i+1, path)
 		}
 	}
 
 	return nil
+}
+
+// ---------- profile ----------
+
+func newProfileCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profile",
+		Short: "Manage named profiles for multiple Alcove installations",
+	}
+	cmd.AddCommand(
+		newProfileListCmd(),
+		newProfileUseCmd(),
+		newProfileAddCmd(),
+		newProfileRemoveCmd(),
+	)
+	return cmd
+}
+
+func newProfileListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all profiles",
+		RunE:  runProfileList,
+	}
+}
+
+func runProfileList(cmd *cobra.Command, _ []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return fmt.Errorf("no config file found; use 'alcove profile add <name> --server <url>' to create a profile")
+	}
+
+	if len(cfg.Profiles) == 0 {
+		fmt.Fprintln(os.Stderr, "No profiles configured. Use 'alcove profile add <name> --server <url>' to create one.")
+		return nil
+	}
+
+	if isJSONOutput(cmd) {
+		result := make([]map[string]interface{}, 0, len(cfg.Profiles))
+		for name, profile := range cfg.Profiles {
+			entry := map[string]interface{}{
+				"name":   name,
+				"server": profile.Server,
+				"active": name == cfg.ActiveProfile,
+			}
+			result = append(result, entry)
+		}
+		return outputJSON(result)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	for name, profile := range cfg.Profiles {
+		marker := " "
+		if name == cfg.ActiveProfile {
+			marker = "*"
+		}
+		fmt.Fprintf(w, "%s %s\t%s\n", marker, name, profile.Server)
+	}
+	return w.Flush()
+}
+
+func newProfileUseCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "use <name>",
+		Short: "Set the active profile",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runProfileUse,
+	}
+}
+
+func runProfileUse(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return fmt.Errorf("no config file found")
+	}
+
+	if cfg.Profiles == nil {
+		return fmt.Errorf("no profiles configured; use 'alcove profile add %s --server <url>' to create one", name)
+	}
+
+	if _, ok := cfg.Profiles[name]; !ok {
+		return fmt.Errorf("profile %q not found in config", name)
+	}
+
+	cfg.ActiveProfile = name
+	return saveConfig(cfg)
+}
+
+func newProfileAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Create a new profile",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runProfileAdd,
+	}
+	cmd.Flags().String("server", "", "Bridge server URL (required)")
+	cmd.Flags().String("username", "", "Username for Basic Auth")
+	cmd.Flags().String("password", "", "Password for Basic Auth")
+	cmd.Flags().String("proxy-url", "", "HTTP/HTTPS proxy URL")
+	cmd.Flags().String("no-proxy", "", "Comma-separated no-proxy hosts")
+	return cmd
+}
+
+func runProfileAdd(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	cfg, _ := loadConfig()
+	if cfg == nil {
+		cfg = &CLIConfig{}
+	}
+
+	if cfg.Profiles == nil {
+		cfg.Profiles = make(map[string]CLIProfile)
+	}
+
+	if _, ok := cfg.Profiles[name]; ok {
+		return fmt.Errorf("profile %q already exists; use 'alcove config set' to modify it", name)
+	}
+
+	profile := CLIProfile{}
+	profile.Server, _ = cmd.Flags().GetString("server")
+	// Use the profile-add-specific flags, not the global ones
+	if u, _ := cmd.Flags().GetString("username"); u != "" {
+		profile.Username = u
+	}
+	if p, _ := cmd.Flags().GetString("password"); p != "" {
+		profile.Password = p
+	}
+	if pu, _ := cmd.Flags().GetString("proxy-url"); pu != "" {
+		profile.ProxyURL = pu
+	}
+	if np, _ := cmd.Flags().GetString("no-proxy"); np != "" {
+		profile.NoProxy = np
+	}
+
+	cfg.Profiles[name] = profile
+	return saveConfig(cfg)
+}
+
+func newProfileRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <name>",
+		Short: "Delete a profile",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runProfileRemove,
+	}
+}
+
+func runProfileRemove(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return fmt.Errorf("no config file found")
+	}
+
+	if cfg.Profiles == nil {
+		return fmt.Errorf("no profiles configured")
+	}
+
+	if _, ok := cfg.Profiles[name]; !ok {
+		return fmt.Errorf("profile %q not found in config", name)
+	}
+
+	delete(cfg.Profiles, name)
+
+	// Clear active_profile if it was the removed profile
+	if cfg.ActiveProfile == name {
+		cfg.ActiveProfile = ""
+	}
+
+	return saveConfig(cfg)
 }
 
 // ---------- version ----------

--- a/cmd/alcove/main_test.go
+++ b/cmd/alcove/main_test.go
@@ -96,6 +96,7 @@ func TestResolveProxyConfig(t *testing.T) {
 		cmd := &cobra.Command{}
 		cmd.PersistentFlags().String("proxy-url", "", "")
 		cmd.PersistentFlags().String("no-proxy", "", "")
+		cmd.PersistentFlags().String("profile", "", "")
 		return cmd
 	}
 
@@ -209,6 +210,10 @@ func TestResolveProxyConfig(t *testing.T) {
 		for _, env := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"} {
 			t.Setenv(env, "")
 		}
+		// Isolate from user config file
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+		t.Setenv("HOME", filepath.Join(tmpDir, "fakehome"))
 
 		cmd := createTestCommand()
 
@@ -399,12 +404,14 @@ func TestSaveAndLoadConfig(t *testing.T) {
 	setupConfigDir(t)
 
 	original := &CLIConfig{
-		Server:   "https://save-test.example.com",
-		Output:   "json",
-		Username: "testuser",
-		Password: "testpass",
-		ProxyURL: "http://proxy:8080",
-		NoProxy:  "localhost,10.0.0.0/8",
+		CLIProfile: CLIProfile{
+			Server:   "https://save-test.example.com",
+			Output:   "json",
+			Username: "testuser",
+			Password: "testpass",
+			ProxyURL: "http://proxy:8080",
+			NoProxy:  "localhost,10.0.0.0/8",
+		},
 	}
 	original.Defaults.Repo = "https://github.com/test/repo.git"
 	original.Defaults.Provider = "google-vertex"
@@ -477,6 +484,7 @@ func TestConfigPriorityFlagsOverrideConfig(t *testing.T) {
 	cmd.PersistentFlags().StringP("password", "p", "", "")
 	cmd.PersistentFlags().String("proxy-url", "", "")
 	cmd.PersistentFlags().String("no-proxy", "", "")
+	cmd.PersistentFlags().String("profile", "", "")
 	cmd.ParseFlags([]string{"--server", "https://flag-server.example.com"})
 
 	// resolveServer should pick up the flag value, not the config file value
@@ -510,6 +518,7 @@ func TestConfigPriorityEnvOverrideConfig(t *testing.T) {
 	cmd.PersistentFlags().StringP("password", "p", "", "")
 	cmd.PersistentFlags().String("proxy-url", "", "")
 	cmd.PersistentFlags().String("no-proxy", "", "")
+	cmd.PersistentFlags().String("profile", "", "")
 
 	// resolveServer should pick up the env var, not the config file value
 	server, err := resolveServer(cmd)
@@ -525,6 +534,8 @@ func TestConfigPriorityEnvOverrideConfig(t *testing.T) {
 
 func TestLoadConfigNoFile(t *testing.T) {
 	setupConfigDir(t)
+	// Also isolate HOME so fallback paths don't find real user config
+	t.Setenv("HOME", filepath.Join(t.TempDir(), "fakehome"))
 
 	// Don't create any config file
 	_, err := loadConfig()
@@ -538,7 +549,7 @@ func TestSaveConfigCreatesDirectory(t *testing.T) {
 	// Point to a subdir that doesn't exist yet (alcove dir not pre-created)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "nested", "dir"))
 
-	cfg := &CLIConfig{Server: "https://test.example.com"}
+	cfg := &CLIConfig{CLIProfile: CLIProfile{Server: "https://test.example.com"}}
 	if err := saveConfig(cfg); err != nil {
 		t.Fatalf("saveConfig error: %v", err)
 	}

--- a/cmd/alcove/profile_test.go
+++ b/cmd/alcove/profile_test.go
@@ -1,0 +1,610 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// setupTestConfig creates a temp config directory and writes the given YAML.
+// It sets XDG_CONFIG_HOME and HOME to temp directories to fully isolate from
+// the user's real config, and returns a cleanup function that restores the
+// original environment.
+func setupTestConfig(t *testing.T, configYAML string) func() {
+	t.Helper()
+	tmpDir := t.TempDir()
+	alcoveDir := filepath.Join(tmpDir, "alcove")
+	if err := os.MkdirAll(alcoveDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(alcoveDir, "config.yaml"), []byte(configYAML), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	origXDG := os.Getenv("XDG_CONFIG_HOME")
+	origHome := os.Getenv("HOME")
+	origProfile := os.Getenv("ALCOVE_PROFILE")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	// Set HOME to a non-existent dir so fallback paths don't find real config
+	os.Setenv("HOME", filepath.Join(tmpDir, "fakehome"))
+	os.Unsetenv("ALCOVE_PROFILE")
+
+	return func() {
+		if origXDG != "" {
+			os.Setenv("XDG_CONFIG_HOME", origXDG)
+		} else {
+			os.Unsetenv("XDG_CONFIG_HOME")
+		}
+		if origHome != "" {
+			os.Setenv("HOME", origHome)
+		} else {
+			os.Unsetenv("HOME")
+		}
+		if origProfile != "" {
+			os.Setenv("ALCOVE_PROFILE", origProfile)
+		} else {
+			os.Unsetenv("ALCOVE_PROFILE")
+		}
+	}
+}
+
+// newTestCmd creates a root cobra command with the persistent flags needed by resolve functions.
+func newTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.PersistentFlags().String("server", "", "")
+	cmd.PersistentFlags().String("output", "", "")
+	cmd.PersistentFlags().StringP("username", "u", "", "")
+	cmd.PersistentFlags().StringP("password", "p", "", "")
+	cmd.PersistentFlags().String("proxy-url", "", "")
+	cmd.PersistentFlags().String("no-proxy", "", "")
+	cmd.PersistentFlags().String("profile", "", "")
+	return cmd
+}
+
+const testConfigMultiProfile = `
+active_profile: staging
+profiles:
+  staging:
+    server: https://staging.example.com
+    username: stage-user
+    password: stage-pass
+    proxy_url: http://proxy.staging:3128
+    output: json
+    defaults:
+      repo: org/staging-repo
+      timeout: 15m
+  production:
+    server: https://prod.example.com
+    username: prod-user
+    password: prod-pass
+    defaults:
+      repo: org/prod-repo
+      budget: 10.0
+server: http://localhost:8080
+username: local-user
+password: local-pass
+output: table
+`
+
+func TestResolveProfile_FlagOverride(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	cmd.ParseFlags([]string{"--profile", "production"})
+
+	profile, err := resolveProfile(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile.Server != "https://prod.example.com" {
+		t.Errorf("expected server https://prod.example.com, got %s", profile.Server)
+	}
+	if profile.Username != "prod-user" {
+		t.Errorf("expected username prod-user, got %s", profile.Username)
+	}
+}
+
+func TestResolveProfile_EnvOverride(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	os.Setenv("ALCOVE_PROFILE", "production")
+	defer os.Unsetenv("ALCOVE_PROFILE")
+
+	cmd := newTestCmd()
+
+	profile, err := resolveProfile(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile.Server != "https://prod.example.com" {
+		t.Errorf("expected server https://prod.example.com, got %s", profile.Server)
+	}
+}
+
+func TestResolveProfile_ActiveProfile(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newTestCmd()
+
+	profile, err := resolveProfile(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// active_profile is "staging" in the test config
+	if profile.Server != "https://staging.example.com" {
+		t.Errorf("expected server https://staging.example.com, got %s", profile.Server)
+	}
+	if profile.Username != "stage-user" {
+		t.Errorf("expected username stage-user, got %s", profile.Username)
+	}
+}
+
+func TestResolveProfile_DefaultFallback(t *testing.T) {
+	configYAML := `
+server: http://localhost:8080
+username: local-user
+password: local-pass
+output: table
+`
+	cleanup := setupTestConfig(t, configYAML)
+	defer cleanup()
+
+	cmd := newTestCmd()
+
+	profile, err := resolveProfile(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile.Server != "http://localhost:8080" {
+		t.Errorf("expected server http://localhost:8080, got %s", profile.Server)
+	}
+	if profile.Username != "local-user" {
+		t.Errorf("expected username local-user, got %s", profile.Username)
+	}
+	if profile.Output != "table" {
+		t.Errorf("expected output table, got %s", profile.Output)
+	}
+}
+
+func TestResolveProfile_NotFound(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	cmd.ParseFlags([]string{"--profile", "nonexistent"})
+
+	_, err := resolveProfile(cmd)
+	if err == nil {
+		t.Fatal("expected error for nonexistent profile, got nil")
+	}
+	expected := `profile "nonexistent" not found in config`
+	if err.Error() != expected {
+		t.Errorf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+func TestResolveProfile_NoConfigFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	origXDG := os.Getenv("XDG_CONFIG_HOME")
+	origHome := os.Getenv("HOME")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	// Set HOME to a non-existent dir so fallback paths don't find real config
+	os.Setenv("HOME", filepath.Join(tmpDir, "fakehome"))
+	defer func() {
+		if origXDG != "" {
+			os.Setenv("XDG_CONFIG_HOME", origXDG)
+		} else {
+			os.Unsetenv("XDG_CONFIG_HOME")
+		}
+		if origHome != "" {
+			os.Setenv("HOME", origHome)
+		} else {
+			os.Unsetenv("HOME")
+		}
+	}()
+
+	cmd := newTestCmd()
+
+	profile, err := resolveProfile(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should return empty profile when no config
+	if profile.Server != "" {
+		t.Errorf("expected empty server, got %s", profile.Server)
+	}
+}
+
+func TestResolveProfile_FlagOverridesEnv(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	os.Setenv("ALCOVE_PROFILE", "staging")
+	defer os.Unsetenv("ALCOVE_PROFILE")
+
+	cmd := newTestCmd()
+	cmd.ParseFlags([]string{"--profile", "production"})
+
+	profile, err := resolveProfile(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// --profile flag should win over ALCOVE_PROFILE env
+	if profile.Server != "https://prod.example.com" {
+		t.Errorf("expected production server, got %s", profile.Server)
+	}
+}
+
+func TestResolveServer_UsesProfile(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	// Ensure no env vars interfere
+	origServer := os.Getenv("ALCOVE_SERVER")
+	os.Unsetenv("ALCOVE_SERVER")
+	defer func() {
+		if origServer != "" {
+			os.Setenv("ALCOVE_SERVER", origServer)
+		}
+	}()
+
+	cmd := newTestCmd()
+	cmd.ParseFlags([]string{"--profile", "production"})
+
+	server, err := resolveServer(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if server != "https://prod.example.com" {
+		t.Errorf("expected https://prod.example.com, got %s", server)
+	}
+}
+
+func TestResolveBasicAuth_UsesProfile(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	origUser := os.Getenv("ALCOVE_USERNAME")
+	origPass := os.Getenv("ALCOVE_PASSWORD")
+	os.Unsetenv("ALCOVE_USERNAME")
+	os.Unsetenv("ALCOVE_PASSWORD")
+	defer func() {
+		if origUser != "" {
+			os.Setenv("ALCOVE_USERNAME", origUser)
+		}
+		if origPass != "" {
+			os.Setenv("ALCOVE_PASSWORD", origPass)
+		}
+	}()
+
+	cmd := newTestCmd()
+	cmd.ParseFlags([]string{"--profile", "production"})
+
+	username, password := resolveBasicAuth(cmd)
+	if username != "prod-user" {
+		t.Errorf("expected username prod-user, got %s", username)
+	}
+	if password != "prod-pass" {
+		t.Errorf("expected password prod-pass, got %s", password)
+	}
+}
+
+func TestProfileList_Empty(t *testing.T) {
+	configYAML := `
+server: http://localhost:8080
+`
+	cleanup := setupTestConfig(t, configYAML)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	err := runProfileList(cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProfileList_WithProfiles(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	// Just verify it doesn't error; output goes to stdout/stderr
+	err := runProfileList(cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProfileUse_Success(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	err := runProfileUse(cmd, []string{"production"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the active_profile was saved
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if cfg.ActiveProfile != "production" {
+		t.Errorf("expected active_profile production, got %s", cfg.ActiveProfile)
+	}
+}
+
+func TestProfileUse_NotFound(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	err := runProfileUse(cmd, []string{"nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent profile, got nil")
+	}
+}
+
+func TestProfileAdd_Success(t *testing.T) {
+	configYAML := `
+server: http://localhost:8080
+`
+	cleanup := setupTestConfig(t, configYAML)
+	defer cleanup()
+
+	cmd := newProfileAddCmd()
+	// Set local flags on the profile add command
+	cmd.Flags().Set("server", "https://new.example.com")
+	cmd.Flags().Set("username", "newuser")
+
+	err := runProfileAdd(cmd, []string{"newprofile"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the profile was created
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	profile, ok := cfg.Profiles["newprofile"]
+	if !ok {
+		t.Fatal("expected profile newprofile to exist")
+	}
+	if profile.Server != "https://new.example.com" {
+		t.Errorf("expected server https://new.example.com, got %s", profile.Server)
+	}
+	if profile.Username != "newuser" {
+		t.Errorf("expected username newuser, got %s", profile.Username)
+	}
+}
+
+func TestProfileAdd_AlreadyExists(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newProfileAddCmd()
+	err := runProfileAdd(cmd, []string{"staging"})
+	if err == nil {
+		t.Fatal("expected error for existing profile, got nil")
+	}
+}
+
+func TestProfileRemove_Success(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	err := runProfileRemove(cmd, []string{"production"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if _, ok := cfg.Profiles["production"]; ok {
+		t.Error("expected production profile to be removed")
+	}
+}
+
+func TestProfileRemove_ClearsActive(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	// staging is the active profile
+	err := runProfileRemove(cmd, []string{"staging"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if cfg.ActiveProfile != "" {
+		t.Errorf("expected active_profile to be cleared, got %s", cfg.ActiveProfile)
+	}
+}
+
+func TestProfileRemove_NotFound(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	err := runProfileRemove(cmd, []string{"nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent profile, got nil")
+	}
+}
+
+func TestConfigSet_OnActiveProfile(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	// active_profile is "staging", so config set should modify staging
+	err := runConfigSet(cmd, []string{"server", "https://new-staging.example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	profile := cfg.Profiles["staging"]
+	if profile.Server != "https://new-staging.example.com" {
+		t.Errorf("expected server https://new-staging.example.com, got %s", profile.Server)
+	}
+}
+
+func TestConfigSet_OnSpecificProfile(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	cmd.ParseFlags([]string{"--profile", "production"})
+
+	err := runConfigSet(cmd, []string{"username", "new-prod-user"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	profile := cfg.Profiles["production"]
+	if profile.Username != "new-prod-user" {
+		t.Errorf("expected username new-prod-user, got %s", profile.Username)
+	}
+}
+
+func TestConfigSet_OnTopLevel(t *testing.T) {
+	configYAML := `
+server: http://localhost:8080
+`
+	cleanup := setupTestConfig(t, configYAML)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	err := runConfigSet(cmd, []string{"server", "http://localhost:9090"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if cfg.Server != "http://localhost:9090" {
+		t.Errorf("expected server http://localhost:9090, got %s", cfg.Server)
+	}
+}
+
+func TestBackwardCompat_FlatConfig(t *testing.T) {
+	// Verify that a config file with no profiles works exactly like before
+	configYAML := `
+server: http://localhost:8080
+username: admin
+password: secret
+output: json
+defaults:
+  repo: myorg/myrepo
+  timeout: 30m
+  budget: 5.0
+`
+	cleanup := setupTestConfig(t, configYAML)
+	defer cleanup()
+
+	origServer := os.Getenv("ALCOVE_SERVER")
+	os.Unsetenv("ALCOVE_SERVER")
+	defer func() {
+		if origServer != "" {
+			os.Setenv("ALCOVE_SERVER", origServer)
+		}
+	}()
+
+	origUser := os.Getenv("ALCOVE_USERNAME")
+	origPass := os.Getenv("ALCOVE_PASSWORD")
+	os.Unsetenv("ALCOVE_USERNAME")
+	os.Unsetenv("ALCOVE_PASSWORD")
+	defer func() {
+		if origUser != "" {
+			os.Setenv("ALCOVE_USERNAME", origUser)
+		}
+		if origPass != "" {
+			os.Setenv("ALCOVE_PASSWORD", origPass)
+		}
+	}()
+
+	cmd := newTestCmd()
+
+	server, err := resolveServer(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if server != "http://localhost:8080" {
+		t.Errorf("expected http://localhost:8080, got %s", server)
+	}
+
+	username, password := resolveBasicAuth(cmd)
+	if username != "admin" {
+		t.Errorf("expected username admin, got %s", username)
+	}
+	if password != "secret" {
+		t.Errorf("expected password secret, got %s", password)
+	}
+
+	profile, err := resolveProfile(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile.Defaults.Repo != "myorg/myrepo" {
+		t.Errorf("expected repo myorg/myrepo, got %s", profile.Defaults.Repo)
+	}
+	if profile.Defaults.Budget != 5.0 {
+		t.Errorf("expected budget 5.0, got %f", profile.Defaults.Budget)
+	}
+}
+
+func TestResolveProfile_ProfileDefaults(t *testing.T) {
+	cleanup := setupTestConfig(t, testConfigMultiProfile)
+	defer cleanup()
+
+	cmd := newTestCmd()
+	// active_profile is "staging" which has defaults
+	profile, err := resolveProfile(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile.Defaults.Repo != "org/staging-repo" {
+		t.Errorf("expected repo org/staging-repo, got %s", profile.Defaults.Repo)
+	}
+	if profile.Defaults.Timeout != "15m" {
+		t.Errorf("expected timeout 15m, got %s", profile.Defaults.Timeout)
+	}
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -53,6 +53,7 @@ alcove --help
 |------|-------------|
 | `--server <url>` | Bridge server URL (overrides env and config file) |
 | `--output <format>` | Output format: `json` or `table` (default: `table`) |
+| `--profile <name>` | Use a named profile from config (overrides `ALCOVE_PROFILE` and `active_profile`) |
 | `--proxy-url <url>` | HTTP/HTTPS proxy URL (overrides environment) |
 | `--no-proxy <hosts>` | Comma-separated list of hosts to exclude from proxy (overrides `NO_PROXY` env var) |
 | `-u, --username <user>` | Username for Basic Auth (overrides `ALCOVE_USERNAME`) |
@@ -97,6 +98,7 @@ The Alcove CLI respects several environment variables for configuration:
 |----------|-------------|
 | `ALCOVE_SERVER` | Bridge server URL |
 | `ALCOVE_OUTPUT` | Output format: `json` or `table` |
+| `ALCOVE_PROFILE` | Named profile to use (overrides `active_profile` in config) |
 | `ALCOVE_USERNAME` | Username for Basic Auth |
 | `ALCOVE_PASSWORD` | Password for Basic Auth |
 | `HTTP_PROXY` | HTTP proxy URL for API requests |
@@ -244,11 +246,52 @@ defaults:
   budget: 5.00
 ```
 
+### Named Profiles
+
+You can configure multiple Alcove installations as named profiles. This is
+useful when you work with different environments (staging, production, local
+dev).
+
+```yaml
+# Which profile is active by default
+active_profile: hcmai
+
+# Named profiles
+profiles:
+  crc:
+    server: https://internal.console.stage.redhat.com/app/alcove
+    username: "13409664|alcove-dev"
+    password: "apat_abc123..."
+    proxy_url: http://squid.corp.redhat.com:3128
+  hcmai:
+    server: https://alcove-bridge-pulp-stage.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com
+    username: admin
+    password: "apat_def456..."
+  local:
+    server: http://localhost:8080
+    username: admin
+    password: admin
+
+# Top-level fields still work for backward compat (treated as "default" profile)
+server: http://localhost:8080
+output: table
+defaults:
+  timeout: 30m
+```
+
+Profile resolution order:
+1. `--profile` flag (highest priority)
+2. `ALCOVE_PROFILE` environment variable
+3. `active_profile` setting in config file
+4. Top-level (inline) fields as the default profile
+
+Existing config files without profiles continue to work unchanged.
+
 ### Priority Order (highest to lowest)
 
 1. CLI flags (e.g., `--server`, `--repo`)
 2. Environment variables (e.g., `ALCOVE_SERVER`, `ALCOVE_OUTPUT`)
-3. Config file (`~/.config/alcove/config.yaml`)
+3. Active profile from config file (`~/.config/alcove/config.yaml`)
 4. Built-in defaults
 
 ### Managing Configuration
@@ -257,11 +300,14 @@ defaults:
 # Show current configuration
 alcove config show
 
-# Set individual values
+# Set individual values (operates on active profile)
 alcove config set server https://alcove.example.com
 alcove config set defaults.repo https://github.com/myorg/myrepo.git
 alcove config set defaults.timeout 30m
 alcove config set defaults.budget 5.00
+
+# Set values on a specific profile
+alcove --profile crc config set username admin
 
 # Validate configuration
 alcove config validate
@@ -702,6 +748,135 @@ credentials: cannot read /home/user/.config/alcove/credentials: no such file
 Issues:
   - credentials: cannot read /home/user/.config/alcove/credentials: no such file
 Error: configuration has 1 issue(s)
+```
+
+---
+
+## alcove profile list
+
+List all named profiles from the config file.
+
+```
+alcove profile list
+```
+
+### Flags
+
+No command-specific flags. Supports global `--output json`.
+
+### Description
+
+Displays all configured profiles with their server URLs. The active profile is
+marked with an asterisk (`*`).
+
+### Examples
+
+```bash
+# List all profiles
+alcove profile list
+```
+
+Sample output:
+
+```
+  crc     https://internal.console.stage.redhat.com/app/alcove
+* hcmai   https://alcove-bridge-pulp-stage.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com
+  local   http://localhost:8080
+```
+
+---
+
+## alcove profile use
+
+Set the active profile.
+
+```
+alcove profile use <name>
+```
+
+### Flags
+
+No command-specific flags.
+
+### Description
+
+Sets `active_profile` in the config file. All subsequent commands will use this
+profile's settings (server, credentials, proxy, defaults) unless overridden by
+flags, environment variables, or `--profile`.
+
+### Examples
+
+```bash
+# Switch to the CRC profile
+alcove profile use crc
+
+# Switch to local development
+alcove profile use local
+```
+
+---
+
+## alcove profile add
+
+Create a new named profile.
+
+```
+alcove profile add <name> [flags]
+```
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--server` | string | Bridge server URL |
+| `--username` | string | Username for Basic Auth |
+| `--password` | string | Password for Basic Auth |
+| `--proxy-url` | string | HTTP/HTTPS proxy URL |
+| `--no-proxy` | string | Comma-separated no-proxy hosts |
+
+### Description
+
+Creates a new named profile in the config file. The profile name must not
+already exist. Use `alcove config set` to modify an existing profile, or
+`alcove profile remove` and re-add to replace one.
+
+### Examples
+
+```bash
+# Add a profile with just a server URL
+alcove profile add staging --server https://staging.example.com
+
+# Add a profile with credentials
+alcove profile add production --server https://prod.example.com --username admin --password secret
+
+# Add a profile with proxy
+alcove profile add corp --server https://internal.example.com --proxy-url http://proxy:3128
+```
+
+---
+
+## alcove profile remove
+
+Delete a named profile.
+
+```
+alcove profile remove <name>
+```
+
+### Flags
+
+No command-specific flags.
+
+### Description
+
+Removes a named profile from the config file. If the removed profile was the
+active profile, `active_profile` is cleared.
+
+### Examples
+
+```bash
+# Remove a profile
+alcove profile remove staging
 ```
 
 ---


### PR DESCRIPTION
## Summary

Named profiles let users configure and switch between multiple Alcove installations from one CLI.

### Config format
```yaml
active_profile: hcmai
profiles:
  crc:
    server: https://internal.console.stage.redhat.com/app/alcove
    username: "13409664|alcove-dev"
    password: "apat_abc123..."
    proxy_url: http://squid.corp.redhat.com:3128
  hcmai:
    server: https://alcove-bridge-pulp-stage.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com
    username: admin
    password: "apat_def456..."
```

### New commands
- `alcove profile list` — list profiles with active marker
- `alcove profile use <name>` — switch active profile
- `alcove profile add <name> --server URL` — create profile
- `alcove profile remove <name>` — delete profile

### Global flag
- `--profile <name>` — use a specific profile for one command

### Resolution order
1. `--profile` flag
2. `ALCOVE_PROFILE` env var
3. `active_profile` in config
4. Top-level (inline) config fields

### Backward compatible
Existing flat configs without profiles continue working.

### Tests
21 new tests covering profile resolution, commands, backward compatibility.

## Test plan
- [x] `go build` passes
- [x] All 21 profile tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)