### PR TITLE
Add Claude Pro/Max OAuth example to alcove.yaml.example

### DIFF
--- a/alcove.yaml.example
+++ b/alcove.yaml.example
@@ -29,7 +29,13 @@ runtime: podman
 #   api_key: sk-ant-...
 #   model: claude-sonnet-4-20250514
 
-# Option B: Google Vertex AI (Service Account)
+# Option B: Claude Pro/Max (OAuth)
+# system_llm:
+#   provider: claude-oauth
+#   oauth_token: <token from 'claude setup-token'>
+#   model: claude-sonnet-4-20250514
+
+# Option C: Google Vertex AI (Service Account)
 # system_llm:
 #   provider: google-vertex
 #   service_account_json: |


### PR DESCRIPTION
## Summary

- Add Claude Pro/Max (`claude-oauth`) as Option B in the example config file
- PR #111 added this provider but the example config was not updated

## Test plan

- [ ] Verify example config renders correctly
- [ ] Verify no YAML syntax issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)