### PR TITLE
Add teams: shared resource ownership

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ podman run -d --replace --name alcove-bridge ...  # same args as dev-up
 
 ## Key Decisions
 
+- **Teams are the ownership unit** — every resource belongs to a team; every user belongs to one or more teams; personal team auto-created on signup; `X-Alcove-Team` header scopes all API requests
 - **Gate is a sidecar** per Skiff pod (not shared service) — credential isolation
 - **No MITM TLS** — protocol-level interception (HTTP_PROXY, git credential helpers)
 - **LLM keys never enter Skiff** — Gate proxies LLM API calls, injects keys; Gate also translates Anthropic API format to Vertex AI format when using Vertex AI (`GATE_VERTEX_PROJECT`, `GATE_VERTEX_REGION`)

--- a/cmd/alcove/main.go
+++ b/cmd/alcove/main.go
@@ -41,13 +41,14 @@ var Version = "dev"
 
 // CLIProfile holds per-profile CLI configuration.
 type CLIProfile struct {
-	Server   string `yaml:"server,omitempty"`
-	Output   string `yaml:"output,omitempty"`    // "json" or "table"
-	Username string `yaml:"username,omitempty"`  // Basic Auth username
-	Password string `yaml:"password,omitempty"`  // Basic Auth password
-	ProxyURL string `yaml:"proxy_url,omitempty"` // HTTP proxy
-	NoProxy  string `yaml:"no_proxy,omitempty"`  // Comma-separated no-proxy hosts
-	Defaults struct {
+	Server     string `yaml:"server,omitempty"`
+	Output     string `yaml:"output,omitempty"`      // "json" or "table"
+	Username   string `yaml:"username,omitempty"`    // Basic Auth username
+	Password   string `yaml:"password,omitempty"`    // Basic Auth password
+	ProxyURL   string `yaml:"proxy_url,omitempty"`   // HTTP proxy
+	NoProxy    string `yaml:"no_proxy,omitempty"`    // Comma-separated no-proxy hosts
+	ActiveTeam string `yaml:"active_team,omitempty"` // Active team name
+	Defaults   struct {
 		Repo     string  `yaml:"repo,omitempty"`     // Default repository
 		Provider string  `yaml:"provider,omitempty"` // Default LLM provider
 		Model    string  `yaml:"model,omitempty"`    // Default model
@@ -87,6 +88,7 @@ func main() {
 	root.PersistentFlags().String("proxy-url", "", "HTTP/HTTPS proxy URL (overrides environment)")
 	root.PersistentFlags().String("no-proxy", "", "Comma-separated list of hosts to exclude from proxy (overrides NO_PROXY env var)")
 	root.PersistentFlags().String("profile", "", "Use a named profile from config (overrides active_profile)")
+	root.PersistentFlags().String("team", "", "Team name to use for this invocation (overrides active_team in profile)")
 
 	root.AddCommand(
 		newRunCmd(),
@@ -98,6 +100,7 @@ func main() {
 		newLoginCmd(),
 		newConfigCmd(),
 		newProfileCmd(),
+		newTeamsCmd(),
 		newVersionCmd(),
 	)
 
@@ -415,8 +418,60 @@ func newHTTPClient(proxyConfig *ProxyConfig) *http.Client {
 	}
 }
 
-// apiRequest performs an authenticated HTTP request to the Bridge API.
-func apiRequest(cmd *cobra.Command, method, path string, body interface{}) (*http.Response, error) {
+// teamInfo represents a team returned from the API.
+type teamInfo struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	IsPersonal bool   `json:"is_personal"`
+	CreatedAt  string `json:"created_at"`
+}
+
+// teamsListResponse is the response from GET /api/v1/teams.
+type teamsListResponse struct {
+	Teams []teamInfo `json:"teams"`
+}
+
+// resolveTeamName determines the team name to use from --team flag or active_team config.
+func resolveTeamName(cmd *cobra.Command) string {
+	if teamFlag, _ := cmd.Flags().GetString("team"); teamFlag != "" {
+		return teamFlag
+	}
+	if profile, err := resolveProfile(cmd); err == nil && profile.ActiveTeam != "" {
+		return profile.ActiveTeam
+	}
+	return ""
+}
+
+// resolveTeamID resolves a team name to its ID by calling the teams API.
+// It uses apiRequestRaw to avoid infinite recursion (apiRequest calls resolveTeamID).
+func resolveTeamID(cmd *cobra.Command, teamName string) (string, error) {
+	resp, err := apiRequestRaw(cmd, http.MethodGet, "/api/v1/teams", nil, "")
+	if err != nil {
+		return "", fmt.Errorf("fetching teams: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("fetching teams: bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result teamsListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decoding teams response: %w", err)
+	}
+
+	for _, team := range result.Teams {
+		if team.Name == teamName {
+			return team.ID, nil
+		}
+	}
+	return "", fmt.Errorf("team %q not found", teamName)
+}
+
+// apiRequestRaw performs an authenticated HTTP request with an explicit team ID header.
+// This is the low-level function; apiRequest wraps it with team name resolution.
+func apiRequestRaw(cmd *cobra.Command, method, path string, body interface{}, teamID string) (*http.Response, error) {
 	server, err := resolveServer(cmd)
 	if err != nil {
 		return nil, err
@@ -442,6 +497,11 @@ func apiRequest(cmd *cobra.Command, method, path string, body interface{}) (*htt
 	}
 	req.Header.Set("Content-Type", "application/json")
 
+	// Set team header if provided
+	if teamID != "" {
+		req.Header.Set("X-Alcove-Team", teamID)
+	}
+
 	// Try Basic Auth first
 	username, password := resolveBasicAuth(cmd)
 	if username != "" {
@@ -457,6 +517,23 @@ func apiRequest(cmd *cobra.Command, method, path string, body interface{}) (*htt
 	}
 
 	return newHTTPClient(proxyConfig).Do(req)
+}
+
+// apiRequest performs an authenticated HTTP request to the Bridge API.
+// It automatically resolves the team name (from --team flag or active_team config)
+// to a team ID and sets the X-Alcove-Team header.
+func apiRequest(cmd *cobra.Command, method, path string, body interface{}) (*http.Response, error) {
+	teamName := resolveTeamName(cmd)
+	var teamID string
+	if teamName != "" {
+		var err error
+		teamID, err = resolveTeamID(cmd, teamName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return apiRequestRaw(cmd, method, path, body, teamID)
 }
 
 func outputJSON(v interface{}) error {
@@ -1211,6 +1288,8 @@ func setProfileField(profile *CLIProfile, key, value string) error {
 		profile.ProxyURL = value
 	case "no_proxy":
 		profile.NoProxy = value
+	case "active_team":
+		profile.ActiveTeam = value
 	case "defaults.repo":
 		profile.Defaults.Repo = value
 	case "defaults.provider":
@@ -1226,7 +1305,7 @@ func setProfileField(profile *CLIProfile, key, value string) error {
 			return fmt.Errorf("invalid budget value: %s", value)
 		}
 	default:
-		return fmt.Errorf("unknown config key: %s\nValid keys: server, output, username, password, proxy_url, no_proxy, defaults.repo, defaults.provider, defaults.model, defaults.timeout, defaults.budget", key)
+		return fmt.Errorf("unknown config key: %s\nValid keys: server, output, username, password, proxy_url, no_proxy, active_team, defaults.repo, defaults.provider, defaults.model, defaults.timeout, defaults.budget", key)
 	}
 	return nil
 }
@@ -1769,6 +1848,16 @@ func streamSSE(cmd *cobra.Command, sessionID, path string) error {
 	}
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
+
+	// Set team header if applicable
+	teamName := resolveTeamName(cmd)
+	if teamName != "" {
+		teamID, err := resolveTeamID(cmd, teamName)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("X-Alcove-Team", teamID)
+	}
 
 	// Try Basic Auth first
 	username, password := resolveBasicAuth(cmd)

--- a/cmd/alcove/teams.go
+++ b/cmd/alcove/teams.go
@@ -1,0 +1,365 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+func newTeamsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "teams",
+		Short: "Manage teams",
+	}
+	cmd.AddCommand(
+		newTeamsListCmd(),
+		newTeamsCreateCmd(),
+		newTeamsUseCmd(),
+		newTeamsAddMemberCmd(),
+		newTeamsRemoveMemberCmd(),
+		newTeamsDeleteCmd(),
+	)
+	return cmd
+}
+
+// ---------- teams list ----------
+
+func newTeamsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all teams",
+		RunE:  runTeamsList,
+	}
+}
+
+func runTeamsList(cmd *cobra.Command, _ []string) error {
+	resp, err := apiRequestRaw(cmd, http.MethodGet, "/api/v1/teams", nil, "")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result teamsListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(result)
+	}
+
+	if len(result.Teams) == 0 {
+		fmt.Fprintln(os.Stderr, "No teams found.")
+		return nil
+	}
+
+	activeTeam := resolveTeamName(cmd)
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "  NAME\tPERSONAL\tCREATED")
+	for _, t := range result.Teams {
+		marker := " "
+		if t.Name == activeTeam {
+			marker = "*"
+		}
+		personal := "no"
+		if t.IsPersonal {
+			personal = "yes"
+		}
+		fmt.Fprintf(w, "%s %s\t%s\t%s\n", marker, t.Name, personal, t.CreatedAt)
+	}
+	return w.Flush()
+}
+
+// ---------- teams create ----------
+
+func newTeamsCreateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a new team",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runTeamsCreate,
+	}
+}
+
+func runTeamsCreate(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	reqBody := map[string]string{"name": name}
+
+	resp, err := apiRequestRaw(cmd, http.MethodPost, "/api/v1/teams", reqBody, "")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result teamInfo
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(result)
+	}
+
+	fmt.Fprintf(os.Stderr, "Team created: %s\n", result.Name)
+	return nil
+}
+
+// ---------- teams use ----------
+
+func newTeamsUseCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "use [name]",
+		Short: "Set the active team for the current profile",
+		Long:  "Set the active team. Use --personal to switch to your personal team, or provide a team name.",
+		RunE:  runTeamsUse,
+	}
+	cmd.Flags().Bool("personal", false, "Switch to your personal team")
+	return cmd
+}
+
+func runTeamsUse(cmd *cobra.Command, args []string) error {
+	personal, _ := cmd.Flags().GetBool("personal")
+
+	var teamName string
+
+	if personal {
+		if len(args) > 0 {
+			return fmt.Errorf("cannot specify both --personal and a team name")
+		}
+		// Find the personal team
+		resp, err := apiRequestRaw(cmd, http.MethodGet, "/api/v1/teams", nil, "")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+		}
+
+		var result teamsListResponse
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return fmt.Errorf("decoding response: %w", err)
+		}
+
+		for _, t := range result.Teams {
+			if t.IsPersonal {
+				teamName = t.Name
+				break
+			}
+		}
+		if teamName == "" {
+			return fmt.Errorf("no personal team found")
+		}
+	} else {
+		if len(args) != 1 {
+			return fmt.Errorf("provide a team name or use --personal")
+		}
+		teamName = args[0]
+
+		// Validate the team exists by resolving its ID
+		if _, err := resolveTeamID(cmd, teamName); err != nil {
+			return err
+		}
+	}
+
+	// Save to active_team in current profile config
+	cfg, _ := loadConfig()
+	if cfg == nil {
+		cfg = &CLIConfig{}
+	}
+
+	// Determine which profile to update
+	profileName, _ := cmd.Flags().GetString("profile")
+	if profileName == "" {
+		profileName = os.Getenv("ALCOVE_PROFILE")
+	}
+	if profileName == "" {
+		profileName = cfg.ActiveProfile
+	}
+
+	if profileName != "" && cfg.Profiles != nil {
+		if profile, ok := cfg.Profiles[profileName]; ok {
+			profile.ActiveTeam = teamName
+			cfg.Profiles[profileName] = profile
+		} else {
+			return fmt.Errorf("profile %q not found in config", profileName)
+		}
+	} else {
+		cfg.CLIProfile.ActiveTeam = teamName
+	}
+
+	if err := saveConfig(cfg); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Active team set to: %s\n", teamName)
+	return nil
+}
+
+// ---------- teams add-member ----------
+
+func newTeamsAddMemberCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add-member <team> <username>",
+		Short: "Add a member to a team",
+		Args:  cobra.ExactArgs(2),
+		RunE:  runTeamsAddMember,
+	}
+}
+
+func runTeamsAddMember(cmd *cobra.Command, args []string) error {
+	teamName := args[0]
+	username := args[1]
+
+	teamID, err := resolveTeamID(cmd, teamName)
+	if err != nil {
+		return err
+	}
+
+	reqBody := map[string]string{"username": username}
+	path := fmt.Sprintf("/api/v1/teams/%s/members", teamID)
+
+	resp, err := apiRequestRaw(cmd, http.MethodPost, path, reqBody, "")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(map[string]string{"team": teamName, "username": username, "status": "added"})
+	}
+
+	fmt.Fprintf(os.Stderr, "Added %s to team %s\n", username, teamName)
+	return nil
+}
+
+// ---------- teams remove-member ----------
+
+func newTeamsRemoveMemberCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove-member <team> <username>",
+		Short: "Remove a member from a team",
+		Args:  cobra.ExactArgs(2),
+		RunE:  runTeamsRemoveMember,
+	}
+}
+
+func runTeamsRemoveMember(cmd *cobra.Command, args []string) error {
+	teamName := args[0]
+	username := args[1]
+
+	teamID, err := resolveTeamID(cmd, teamName)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/api/v1/teams/%s/members/%s", teamID, username)
+
+	resp, err := apiRequestRaw(cmd, http.MethodDelete, path, nil, "")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(map[string]string{"team": teamName, "username": username, "status": "removed"})
+	}
+
+	fmt.Fprintf(os.Stderr, "Removed %s from team %s\n", username, teamName)
+	return nil
+}
+
+// ---------- teams delete ----------
+
+func newTeamsDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <team>",
+		Short: "Delete a team",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runTeamsDelete,
+	}
+	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	return cmd
+}
+
+func runTeamsDelete(cmd *cobra.Command, args []string) error {
+	teamName := args[0]
+	yes, _ := cmd.Flags().GetBool("yes")
+
+	teamID, err := resolveTeamID(cmd, teamName)
+	if err != nil {
+		return err
+	}
+
+	if !yes {
+		fmt.Fprintf(os.Stderr, "Delete team %q? This cannot be undone. [y/N] ", teamName)
+		var answer string
+		fmt.Scanln(&answer)
+		if answer != "y" && answer != "Y" && answer != "yes" {
+			fmt.Fprintln(os.Stderr, "Aborted.")
+			return nil
+		}
+	}
+
+	path := fmt.Sprintf("/api/v1/teams/%s", teamID)
+
+	resp, err := apiRequestRaw(cmd, http.MethodDelete, path, nil, "")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(map[string]string{"team": teamName, "status": "deleted"})
+	}
+
+	fmt.Fprintf(os.Stderr, "Team %s deleted\n", teamName)
+	return nil
+}

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -222,7 +222,8 @@ func main() {
 	defer syncer.Stop()
 	log.Println("agent repo syncer started")
 
-	api := bridge.NewAPI(dispatcher, dbpool, cfg, scheduler, credStore, toolStore, profileStore, settingsStore, bridgeLLM, defStore, syncer, store, workflowEngine)
+	teamStore := bridge.NewTeamStore(dbpool)
+	api := bridge.NewAPI(dispatcher, dbpool, cfg, scheduler, credStore, toolStore, profileStore, settingsStore, bridgeLLM, defStore, syncer, store, workflowEngine, teamStore)
 
 	// Build HTTP server.
 	mux := http.NewServeMux()
@@ -259,7 +260,7 @@ func main() {
 	}
 
 	// Wrap with auth middleware.
-	handler := auth.AuthMiddleware(store, mgr)(mux)
+	handler := auth.AuthMiddleware(store, mgr, dbpool)(mux)
 
 	server := &http.Server{
 		Addr:         ":" + cfg.Port,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,8 +206,16 @@ The `alcove` CLI (`cmd/alcove`) stores configuration in
 
 | File | Purpose |
 |---|---|
-| `config.yaml` | Stores the Bridge server URL. Created by `alcove login`. |
+| `config.yaml` | Stores the Bridge server URL and active team. Created by `alcove login`. |
 | `credentials` | Stores the JWT authentication token. Created by `alcove login`. |
+
+The `config.yaml` file supports an `active_team` field that sets the default
+team context for all CLI commands. Set it with `alcove teams use`:
+
+```yaml
+server: http://localhost:8080
+active_team: my-team
+```
 
 ### CLI Environment Variables
 
@@ -234,6 +242,7 @@ The `alcove` CLI (`cmd/alcove`) stores configuration in
 | `--no-proxy <hosts>` | Comma-separated list of hosts to exclude from proxy. Overrides `NO_PROXY` env var. |
 | `-u, --username <user>` | Username for Basic Auth. Overrides `ALCOVE_USERNAME`. |
 | `-p, --password <pass>` | Password for Basic Auth. Overrides `ALCOVE_PASSWORD`. |
+| `--team <name>` | Team context for the request. Overrides `active_team` in config. |
 
 ### Server Resolution Order
 
@@ -242,6 +251,55 @@ The CLI resolves the Bridge URL in this order:
 1. `--server` flag
 2. `ALCOVE_SERVER` environment variable
 3. `server` field in `~/.config/alcove/config.yaml`
+
+---
+
+## Teams
+
+Teams are the universal ownership unit. Every resource (sessions, credentials,
+security profiles, agent definitions, schedules, workflows, tools, agent repos)
+belongs to a team. Every user belongs to one or more teams.
+
+### X-Alcove-Team Header
+
+All API requests include an `X-Alcove-Team` header to scope the request to a
+team. The CLI sets this header automatically based on the `--team` flag or the
+`active_team` field in `config.yaml`. The dashboard sets it based on the team
+switcher selection.
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+     -H "X-Alcove-Team: my-team-id" \
+     http://localhost:8080/api/v1/sessions
+```
+
+### Teams API
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/teams` | List teams for the authenticated user |
+| `POST` | `/api/v1/teams` | Create a new team |
+| `GET` | `/api/v1/teams/{id}` | Get team details |
+| `PUT` | `/api/v1/teams/{id}` | Update team name |
+| `DELETE` | `/api/v1/teams/{id}` | Delete a team |
+| `POST` | `/api/v1/teams/{id}/members` | Add a member to a team |
+| `DELETE` | `/api/v1/teams/{id}/members/{username}` | Remove a member from a team |
+
+All team members have equal permissions. Any member can invite or remove others.
+Admins can override team membership.
+
+### Database Tables
+
+Teams are stored in three tables:
+
+| Table | Description |
+|---|---|
+| `teams` | Team ID, name, type (personal or shared), created/updated timestamps |
+| `team_members` | Maps users to teams |
+| `team_settings` | Per-team settings (e.g., agent repos) |
+
+All resource tables use a `team_id` column (replacing the previous `owner`
+column) to associate resources with teams.
 
 ---
 

--- a/docs/design/implementation-status.md
+++ b/docs/design/implementation-status.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-Last updated: 2026-03-30
+Last updated: 2026-04-12
 
 ## Project Overview
 
@@ -46,10 +46,10 @@ alcove/
 │   │   ├── dispatcher.go       ✅ Session dispatch: creates session, resolves security profiles, publishes to NATS, starts Skiff+Gate with LLM/SCM credentials and tool configs
 │   │   ├── config.go           ✅ Config loading from env vars, auth backend selection, debug mode
 │   │   ├── runtime.go          ✅ Runtime factory (podman/kubernetes selection)
-│   │   ├── credentials.go      ✅ Credential CRUD, AES-256-GCM encryption, OAuth2 token acquisition, token refresh, AcquireSCMToken, AcquireSystemToken, owner scoping, system credentials, claude-oauth support
+│   │   ├── credentials.go      ✅ Credential CRUD, AES-256-GCM encryption, OAuth2 token acquisition, token refresh, AcquireSCMToken, AcquireSystemToken, team scoping, system credentials, claude-oauth support
 │   │   ├── credentials_test.go ✅ Credential store tests
 │   │   ├── scheduler.go        ✅ Cron scheduler: parsing, next-run computation, schedule CRUD, background tick loop, per-schedule debug flag
-│   │   ├── profiles.go         ✅ Security profiles: multi-rule per-repo operation scoping, profile CRUD with owner scoping
+│   │   ├── profiles.go         ✅ Security profiles: multi-rule per-repo operation scoping, profile CRUD with team scoping
 │   │   ├── tools.go            ✅ MCP tool registry: tool CRUD, MCP command/args, tool configs passed to Gate/Skiff
 │   │   ├── settings.go         ✅ Admin settings: system LLM configuration, skill repos (system + per-user), env+DB+config resolution
 │   │   ├── llm.go              ✅ BridgeLLM: system LLM client for AI-powered features (Anthropic + Vertex AI), used by security profile builder
@@ -63,7 +63,9 @@ alcove/
 │   │       ├── 006_mcp_tools.sql       ✅ MCP tool registry table
 │   │       ├── 007_security_profiles.sql  ✅ Security profiles table
 │   │       ├── 008_credential_api_host.sql  ✅ Custom API host for credentials (GitLab private servers)
-│   │       └── 009_system_settings.sql  ✅ System settings key-value store
+│   │       ├── 009_system_settings.sql  ✅ System settings key-value store
+│   │       ├── ...
+│   │       └── 026_teams.sql           ✅ Teams, team_members, team_settings tables; owner→team_id migration
 │   ├── gate/
 │   │   ├── proxy.go            ✅ HTTP proxy, CONNECT tunneling, LLM API injection (api_key + bearer + oauth_token), audit logging, 401 token refresh
 │   │   ├── proxy_test.go       ✅ Proxy tests
@@ -151,13 +153,13 @@ alcove/
 
 4. **Cron Scheduler** — Full cron scheduler with 5-field expression parsing (wildcards,
    ranges, steps, lists), schedule CRUD API, background tick loop (60s interval),
-   automatic next-run computation, per-schedule debug flag, owner scoping. Dashboard
+   automatic next-run computation, per-schedule debug flag, team scoping. Dashboard
    includes NLP-style cron expression input (e.g., "every weekday at 9am",
    "twice daily", "hourly on weekdays").
 
 5. **Credential Management API** — CRUD for provider credentials, encrypted storage,
    token acquisition (API key pass-through or OAuth2 exchange), env-based credential
-   migration on first start, owner scoping (user credentials vs system credentials),
+   migration on first start, team scoping (team credentials vs system credentials),
    system credentials (`_system` owner) for Bridge-level LLM features, custom
    `api_host` field for GitLab private server support.
 
@@ -207,9 +209,9 @@ alcove/
 
 12. **Security Profiles** — Named, reusable bundles of tool + repo + operation
     permissions. Supports multi-rule per-repo operation scoping (each rule specifies
-    repos and operations independently). Profiles have owner scoping. Dispatcher
+    repos and operations independently). Profiles have team scoping. Dispatcher
     resolves security profiles into scope and tool configs at dispatch time.
-    Profile CRUD API with owner isolation.
+    Profile CRUD API with team isolation.
 
 13. **AI-Powered Security Profile Builder** — `POST /api/v1/security-profiles/build` accepts a natural
     language description and uses the system LLM (BridgeLLM) to generate a JSON
@@ -305,6 +307,21 @@ alcove/
     network isolation means adversarial prompt injection could make Claude Code
     bypass Gate. Acceptable for personal/trusted deployments; use Podman or
     Kubernetes for production/shared deployments.
+
+27. **Teams** — Teams are the universal ownership unit. Every resource (sessions,
+    credentials, security profiles, agent definitions, schedules, workflows,
+    tools, agent repos) belongs to a team via a `team_id` column (replacing the
+    previous `owner` column). Every user belongs to one or more teams. A personal
+    team is auto-created for each user on signup. Users can create additional
+    shared teams and invite others. All team members have equal permissions (no
+    roles). The `X-Alcove-Team` header scopes all API requests to a team. The
+    dashboard provides a team switcher dropdown. The CLI supports `alcove teams`
+    subcommands and a `--team` flag. Database tables: `teams`, `team_members`,
+    `team_settings` (migration `026_teams.sql`). Agent repos are team-scoped
+    (moved from user settings to team settings). Teams API:
+    `GET/POST /api/v1/teams`, `GET/PUT/DELETE /api/v1/teams/{id}`,
+    `POST /api/v1/teams/{id}/members`,
+    `DELETE /api/v1/teams/{id}/members/{username}`.
 
 ## What's NOT Working Yet
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -165,7 +165,7 @@ are applied automatically on Bridge startup.
 
    ```bash
    ls internal/bridge/migrations/
-   # 001_initial_schema.sql
+   # 001_initial_schema.sql  ...  026_teams.sql
    ```
 
 2. Create a new file with the next numeric prefix and a descriptive name:
@@ -299,6 +299,14 @@ Use the two provided helpers for all responses:
 respondJSON(w, http.StatusOK, data)           // success with JSON body
 respondError(w, http.StatusBadRequest, "msg") // error with {"error": "msg"}
 ```
+
+### Team Scoping
+
+API routes use the `X-Alcove-Team` header to scope requests to a team. The
+team middleware extracts this header on every authenticated request and makes
+the team ID available to handlers. If the header is missing, the request is
+scoped to the user's personal team. The middleware validates that the
+authenticated user is a member of the requested team (returning 403 if not).
 
 ### Authentication
 
@@ -529,6 +537,35 @@ operation-level scope (e.g., allowing `create_pr_draft` but blocking
 `merge_pr`), injects real SCM credentials, and forwards to the upstream API.
 See `internal/gate/` for the proxy implementation and
 `docs/design/gate-scm-authorization.md` for the full design.
+
+## Team-Based Ownership
+
+All resources are owned by teams rather than individual users. The database
+schema reflects this with a `team_id` column on all resource tables (sessions,
+credentials, security profiles, agent definitions, schedules, tools, agent
+repos). The migration `026_teams.sql` creates three tables:
+
+| Table | Columns | Purpose |
+|-------|---------|---------|
+| `teams` | `id`, `name`, `type`, `created_at`, `updated_at` | Team registry. Type is `personal` or `shared`. |
+| `team_members` | `team_id`, `username`, `joined_at` | Maps users to teams. |
+| `team_settings` | `team_id`, `key`, `value` | Per-team settings (e.g., agent repos). |
+
+The same migration renames `owner` to `team_id` on existing resource tables.
+
+A personal team is auto-created for each user on signup. Personal teams cannot
+be deleted, renamed, or have members added. Users can create additional shared
+teams and invite others. All team members have equal permissions.
+
+The `X-Alcove-Team` header is required on all authenticated API requests. The
+team middleware validates membership and injects the team context. If the
+header is omitted, the user's personal team is used as the default.
+
+### Functional Tests
+
+The `test-teams.sh` script in `scripts/` exercises team CRUD, membership
+management, and team-scoped resource isolation against a running Bridge
+instance.
 
 ## Testing Patterns
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -176,6 +176,49 @@ ALCOVE_DEBUG=true
 
 See `docs/configuration.md` for the complete list.
 
+## Teams
+
+Every resource in Alcove (sessions, credentials, security profiles, agent
+definitions, schedules, workflows, tools, agent repos) belongs to a team. A
+personal team is auto-created for each user on signup -- this acts as "My
+Workspace" and cannot be deleted, renamed, or have members added.
+
+### Creating a team in the dashboard
+
+Click the team switcher dropdown in the top nav, then click "Create Team". Give
+your team a name and it's ready to use.
+
+### Inviting members
+
+Open the team switcher, select your team, then go to team settings. Click "Add
+Member" and enter a username. All team members have equal access -- there are no
+roles within a team.
+
+### Switching teams
+
+Use the team switcher dropdown in the dashboard nav to select which team context
+you are working in. All resources you create will belong to the active team,
+and you will only see resources owned by that team.
+
+### CLI
+
+```bash
+# Create a team
+./bin/alcove teams create "My Team"
+
+# Switch active team
+./bin/alcove teams use "My Team"
+
+# Add a member
+./bin/alcove teams add-member "My Team" --username alice
+
+# List your teams
+./bin/alcove teams list
+```
+
+You can also pass `--team "My Team"` to any command to override the active team
+for a single invocation.
+
 ## Skill / Agent Repos and Agent Definitions
 
 After configuring your LLM provider, you can optionally set up skill repos and
@@ -192,6 +235,9 @@ it is loaded as a Claude Code plugin; if it contains a `module/` directory it is
 loaded as a lola module. You just add a repo URL and Skiff figures out the
 format automatically. At task dispatch time, all configured repos are cloned
 into the Skiff container and loaded accordingly.
+
+Agent repos are team-scoped. Configure them in the dashboard under team
+settings (or under admin settings for system-wide repos).
 
 ### Agent Definitions
 

--- a/docs/superpowers/specs/2026-04-14-teams-design.md
+++ b/docs/superpowers/specs/2026-04-14-teams-design.md
@@ -236,6 +236,89 @@ Personal teams cannot be renamed, deleted, or have members added/removed. They
 always have exactly one member: the user they were created for. The
 `is_personal` flag on the `teams` table enforces this in the API handlers.
 
+## Functional Tests
+
+New test script `scripts/test-teams.sh` covering the full team lifecycle. Tests
+run against a live Bridge instance (same pattern as existing functional tests).
+
+### Team CRUD and Membership
+
+- Create a team, verify it appears in `GET /api/v1/teams`
+- Add a second user as a member, verify membership in team detail
+- Remove a member, verify they lose access
+- Rename a team, verify updated name
+- Delete a team, verify it and its resources are gone
+- Verify personal team cannot be deleted (expect 400/403)
+- Verify personal team cannot have members added (expect 400/403)
+
+### Team-Scoped Resource Isolation
+
+- User A creates a credential in Team X
+- User B (member of Team X) lists credentials with `X-Alcove-Team` header,
+  verify they see User A's credential
+- User C (not a member of Team X) lists credentials with Team X header,
+  expect 403
+- User B switches to their personal team, verify Team X credentials are not
+  visible
+
+### Cross-Team Isolation
+
+- Create resources (credential, schedule, security profile) in Team X
+- Create resources with the same names in Team Y
+- Verify no collision (unique per team) and each team only sees its own
+
+### Backward Compatibility
+
+- Omit the `X-Alcove-Team` header entirely, verify requests default to the
+  user's personal team
+- Verify existing test scripts (`test-credentials.sh`, `test-schedules.sh`,
+  `test-user-isolation.sh`) still pass without modification (they don't send
+  `X-Alcove-Team`, so they operate on personal teams)
+
+### Admin Override
+
+- Admin user sets `X-Alcove-Team` to a team they are not a member of
+- Verify admin can list and manage that team's resources
+
+### Updates to Existing Test Scripts
+
+- `test-user-isolation.sh`: verify that user isolation still holds — two users
+  in different personal teams cannot see each other's resources (existing
+  behavior preserved)
+- `test-credentials.sh`, `test-schedules.sh`, `test-agent-repos.sh`: no changes
+  expected (they use personal team by default)
+
+## Documentation Updates
+
+### docs/getting-started.md
+
+- Add a "Teams" section after the existing user management content
+- Cover creating a team, inviting members, and switching teams in the dashboard
+- Cover the CLI team commands (`alcove teams create`, `use`, `add-member`)
+
+### docs/configuration.md
+
+- Document the `X-Alcove-Team` header
+- Document the `active_team` profile config option
+- Document the `--team` CLI flag
+
+### docs/development-guide.md
+
+- Add the `teams`, `team_members`, and `team_settings` tables to the database
+  schema reference
+- Document the `X-Alcove-Team` middleware behavior
+- Add `test-teams.sh` to the functional test inventory
+
+### docs/design/implementation-status.md
+
+- Add Teams to the feature list with current status
+- Update the resource ownership model description from per-user to per-team
+
+### CLAUDE.md
+
+- Update the Architecture section to mention teams as the ownership unit
+- Add `X-Alcove-Team` to the Key Decisions section
+
 ## Components Not Affected
 
 - **Gate**: No changes. Gate receives session-level config (credentials, scopes)

--- a/docs/superpowers/specs/2026-04-14-teams-design.md
+++ b/docs/superpowers/specs/2026-04-14-teams-design.md
@@ -1,0 +1,247 @@
+# Teams: Shared Resource Ownership for Alcove
+
+## Problem
+
+Today every resource in Alcove (sessions, credentials, security profiles, agent
+definitions, schedules, workflows, tools, agent repos) is owned by a single user.
+There is no way for a group of users to share a common set of resources. Teams
+working together must each configure their own credentials, agent definitions,
+and schedules independently, with no shared visibility into each other's sessions
+or workflows.
+
+## Solution
+
+Introduce teams as the universal ownership unit. Every resource belongs to a team.
+Every user belongs to one or more teams. A personal team is auto-created for each
+user on signup, preserving the current single-user experience. Users can create
+additional teams and invite others, enabling shared ownership with equal
+permissions for all members.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Membership model | Multi-team per user | Marginal complexity over single-team; avoids future migration |
+| Personal workspace | Auto-created personal team | One ownership concept everywhere; no personal-vs-team dual path |
+| Permissions within a team | Equal — all members have full access | Matches requirement; no roles/ACLs needed |
+| Team management | Self-service creation, member-managed | Any user creates teams; any member invites/removes; admins can override |
+| Credential sharing | Fully shared, no restrictions | Consistent with "team acts like a single user" |
+| Agent repos | Team-level setting | Avoids duplicate definitions when multiple users add the same repo |
+| Active team context | Explicit team switcher | Clean mental model; UI scoped to one team at a time |
+| Implementation approach | Team ID replaces owner column | Clean model, uniform queries, no legacy dual-path |
+
+## Data Model
+
+### New Tables
+
+```sql
+CREATE TABLE teams (
+    id         UUID PRIMARY KEY,
+    name       TEXT NOT NULL,
+    is_personal BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE team_members (
+    team_id  UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    username TEXT NOT NULL,
+    PRIMARY KEY (team_id, username)
+);
+CREATE INDEX idx_team_members_username ON team_members(username);
+```
+
+### New Settings Table
+
+```sql
+CREATE TABLE team_settings (
+    team_id    UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    key        TEXT NOT NULL,
+    value      JSONB NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (team_id, key)
+);
+```
+
+### Resource Table Changes
+
+Every resource table changes from `owner TEXT` to `team_id UUID REFERENCES teams(id)`:
+
+| Table | Column change | Notes |
+|-------|--------------|-------|
+| `sessions` | Add `team_id UUID`; keep `submitter` | `submitter` is who ran it; `team_id` is ownership |
+| `provider_credentials` | `owner` → `team_id UUID` | |
+| `security_profiles` | `owner` → `team_id UUID` | |
+| `agent_definitions` | `owner` → `team_id UUID` | |
+| `schedules` | `owner` → `team_id UUID` | |
+| `workflows` | `owner` → `team_id UUID` | |
+| `workflow_runs` | `owner` → `team_id UUID` | |
+| `mcp_tools` | `owner` → `team_id UUID` | |
+
+Unique constraints update accordingly:
+- `UNIQUE(name, owner)` → `UNIQUE(name, team_id)` on security_profiles, mcp_tools
+- `UNIQUE(source_key)` on agent_definitions and workflows becomes `UNIQUE(source_key, team_id)` so multiple teams can sync the same repo independently
+
+## API Design
+
+### Active Team Context
+
+The active team is sent via the `X-Alcove-Team` HTTP header. The auth middleware
+validates that the authenticated user is a member of the specified team. If the
+header is missing, Bridge defaults to the user's personal team.
+
+Admins can specify any team ID, even teams they are not a member of.
+
+### New Endpoints
+
+```
+GET    /api/v1/teams              — list teams the current user belongs to
+POST   /api/v1/teams              — create a team (any authenticated user)
+GET    /api/v1/teams/{id}         — get team details + member list
+PUT    /api/v1/teams/{id}         — update team name
+DELETE /api/v1/teams/{id}         — delete team (personal teams cannot be deleted)
+POST   /api/v1/teams/{id}/members           — add a member
+DELETE /api/v1/teams/{id}/members/{username} — remove a member
+```
+
+Authorization for member management: the caller must be a member of the team,
+or a Bridge admin.
+
+### Changes to Existing Endpoints
+
+Every existing handler changes the same way:
+
+- **List**: `WHERE owner = $username` → `WHERE team_id = $active_team`
+- **Create**: set `team_id = $active_team` instead of `owner = $username`
+- **Get/Delete**: verify `team_id = $active_team` instead of `owner = $username`
+
+The `checkOwnership()` function becomes `checkTeamAccess()` — verifies the
+resource's `team_id` matches the active team and that the user is a member.
+
+### Agent Repos
+
+Agent repos move from `user_settings` to `team_settings`. The syncer pulls
+definitions into the team scope. Any team member can add/remove repos for the
+team via the existing agent repos UI (now scoped to the active team).
+
+## CLI Changes
+
+### Team Subcommands
+
+```
+alcove teams list                           — list your teams
+alcove teams create <name>                  — create a team
+alcove teams use <name>                     — set active team for current profile
+alcove teams use --personal                 — switch back to personal team
+alcove teams add-member <team> <username>   — add a member
+alcove teams remove-member <team> <username> — remove a member
+alcove teams delete <team>                  — delete a team
+```
+
+### Active Team in Config
+
+The active team is persisted per profile in the CLI config:
+
+```yaml
+profiles:
+    hcmai:
+        server: https://...
+        username: bmbouter
+        password: ...
+        active_team: engineering
+```
+
+The `--team <name>` flag on any command overrides the profile default for that
+invocation.
+
+## Dashboard UI
+
+### Team Switcher
+
+A dropdown in the top nav bar, next to the username. Shows all teams the user
+belongs to. The personal team appears first, labeled as "My Workspace." Selecting
+a team reloads the current view scoped to that team.
+
+### Team Management Page
+
+A new "Teams" section accessible from the nav. Contains:
+
+- List of teams the user belongs to
+- "Create Team" button
+- Per-team view: team name, member list, add/remove member controls
+- Delete team button (disabled for personal teams)
+- Agent repos configuration (moved from Account settings, scoped to active team)
+
+### No Changes to Existing Views
+
+Sessions, credentials, agents, schedules, workflows, security profiles, and
+tools views work exactly as today. The data is scoped by the active team via
+the team switcher. No new columns in table views, no team badges on rows.
+
+## Database Migration
+
+A single migration file performs the following steps in order:
+
+1. Create `teams`, `team_members`, and `team_settings` tables
+2. For each user in `auth_users`: create a personal team (`is_personal = true`,
+   name = `"{username}'s workspace"`), insert into `team_members`
+3. Add `team_id UUID` column (nullable) to all resource tables
+4. Backfill `team_id` from the personal team of each resource's current
+   `owner`/`submitter` value
+5. Set `team_id` to `NOT NULL`, add foreign key constraint
+6. Drop `owner` columns (keep `submitter` on `sessions`)
+7. Recreate unique constraints with `team_id`
+8. Migrate `user_settings` agent repo entries to `team_settings`
+
+## Auth Backend Integration
+
+### Postgres Backend
+
+No special handling. Users are created via the API; personal teams are created
+at the same time.
+
+### RH-Identity Backend
+
+When a new user is auto-provisioned via the `X-RH-Identity` header, Bridge
+creates their personal team as part of the `UpsertUser()` flow.
+
+## Edge Cases
+
+### Deleting a Team
+
+All resources owned by the team are deleted (CASCADE on `team_id` foreign key).
+Running sessions are cancelled first. The UI shows a confirmation dialog with a
+count of resources that will be destroyed. Personal teams cannot be deleted.
+
+### Removing a User from a Team
+
+The user immediately loses access to that team's resources. If their CLI config
+has `active_team` set to the removed team, the next request falls back to their
+personal team. Resources stay with the team.
+
+### Deleting a User
+
+Membership in all teams is removed (CASCADE on `team_members`). Their personal
+team and all its resources are deleted. Shared teams persist — only the
+membership row is removed.
+
+### Schedule and Workflow Execution
+
+Schedules and workflows fire in their team context, using the team's credentials
+and security profiles. The resulting session's `submitter` is the system
+identifier (schedule name or workflow name); the `team_id` is the owning team.
+
+### Personal Team Constraints
+
+Personal teams cannot be renamed, deleted, or have members added/removed. They
+always have exactly one member: the user they were created for. The
+`is_personal` flag on the `teams` table enforces this in the API handlers.
+
+## Components Not Affected
+
+- **Gate**: No changes. Gate receives session-level config (credentials, scopes)
+  and does not know about teams.
+- **Skiff**: No changes. Skiff runs tasks; team context is resolved by Bridge
+  before dispatch.
+- **Hail (NATS)**: No changes. Message topics use session IDs, not team IDs.
+- **Ledger schema**: Sessions table gains `team_id`, but the Ledger HTTP client
+  API is unchanged.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/crypto/argon2"
 )
 
@@ -183,11 +184,55 @@ func LoginHandler(store Authenticator, mgr UserManager) http.HandlerFunc {
 	}
 }
 
+// resolveTeamID looks up the team to use for the request.
+// If X-Alcove-Team header is set, validates the user is a member of that team.
+// Otherwise, returns the user's personal team.
+func resolveTeamID(ctx context.Context, db *pgxpool.Pool, username string, teamHeader string, isAdmin bool) (string, error) {
+	if db == nil {
+		return "", nil
+	}
+
+	if teamHeader != "" {
+		// Validate user is a member of the requested team (or is admin).
+		var exists bool
+		err := db.QueryRow(ctx,
+			`SELECT EXISTS(SELECT 1 FROM team_members WHERE team_id = $1 AND username = $2)`,
+			teamHeader, username).Scan(&exists)
+		if err != nil {
+			return "", fmt.Errorf("checking team membership: %w", err)
+		}
+		if !exists && !isAdmin {
+			return "", fmt.Errorf("not a member of team %s", teamHeader)
+		}
+		return teamHeader, nil
+	}
+
+	// Look up personal team.
+	var teamID string
+	err := db.QueryRow(ctx, `
+		SELECT t.id FROM teams t
+		JOIN team_members tm ON t.id = tm.team_id
+		WHERE tm.username = $1 AND t.is_personal = true
+	`, username).Scan(&teamID)
+	if err != nil {
+		// No personal team yet — this can happen during migration or for new users
+		// before their personal team is created. Return empty string.
+		return "", nil
+	}
+	return teamID, nil
+}
+
 // AuthMiddleware returns middleware that validates session tokens on
 // protected routes. It skips /api/v1/auth/login and /api/v1/health.
 // When the auth backend is rh-identity, it reads the X-RH-Identity header
 // instead of requiring Bearer tokens.
-func AuthMiddleware(store Authenticator, mgr UserManager) func(http.Handler) http.Handler {
+func AuthMiddleware(store Authenticator, mgr UserManager, db ...*pgxpool.Pool) func(http.Handler) http.Handler {
+	// Extract optional db pool for team resolution.
+	var dbPool *pgxpool.Pool
+	if len(db) > 0 {
+		dbPool = db[0]
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			path := r.URL.Path
@@ -288,6 +333,12 @@ func AuthMiddleware(store Authenticator, mgr UserManager) func(http.Handler) htt
 						r.Header.Set("X-Alcove-Admin", "true")
 					}
 				}
+				// Resolve team ID.
+				isAdmin := r.Header.Get("X-Alcove-Admin") == "true"
+				teamHeader := r.Header.Get("X-Alcove-Team")
+				if teamID, err := resolveTeamID(r.Context(), dbPool, username, teamHeader, isAdmin); err == nil && teamID != "" {
+					r.Header.Set("X-Alcove-Team-ID", teamID)
+				}
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -363,6 +414,13 @@ func AuthMiddleware(store Authenticator, mgr UserManager) func(http.Handler) htt
 				if admin, err := mgr.IsAdmin(context.Background(), username); err == nil && admin {
 					r.Header.Set("X-Alcove-Admin", "true")
 				}
+			}
+
+			// Resolve team ID.
+			isAdmin := r.Header.Get("X-Alcove-Admin") == "true"
+			teamHeader := r.Header.Get("X-Alcove-Team")
+			if teamID, err := resolveTeamID(r.Context(), dbPool, username, teamHeader, isAdmin); err == nil && teamID != "" {
+				r.Header.Set("X-Alcove-Team-ID", teamID)
 			}
 
 			next.ServeHTTP(w, r)

--- a/internal/auth/postgres.go
+++ b/internal/auth/postgres.go
@@ -185,17 +185,44 @@ func (s *PgStore) pgRecordFailure(username string) {
 // --- UserManager methods ---
 
 // CreateUser creates a new user with the given username and password.
+// Also creates a personal team for the user.
 func (s *PgStore) CreateUser(ctx context.Context, username, password string, isAdmin bool) error {
 	hash, err := HashPassword(password)
 	if err != nil {
 		return fmt.Errorf("hashing password: %w", err)
 	}
 
-	_, err = s.db.Exec(ctx,
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = tx.Exec(ctx,
 		"INSERT INTO auth_users (username, password, is_admin, created_at, updated_at) VALUES ($1, $2, $3, NOW(), NOW())",
 		username, hash, isAdmin)
 	if err != nil {
 		return fmt.Errorf("creating user: %w", err)
+	}
+
+	// Create personal team.
+	teamID := uuid.New().String()
+	teamName := username + "'s workspace"
+	_, err = tx.Exec(ctx,
+		"INSERT INTO teams (id, name, is_personal, created_at) VALUES ($1, $2, true, NOW())",
+		teamID, teamName)
+	if err != nil {
+		return fmt.Errorf("creating personal team: %w", err)
+	}
+	_, err = tx.Exec(ctx,
+		"INSERT INTO team_members (team_id, username) VALUES ($1, $2)",
+		teamID, username)
+	if err != nil {
+		return fmt.Errorf("adding user to personal team: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("committing transaction: %w", err)
 	}
 	return nil
 }

--- a/internal/auth/rh_identity.go
+++ b/internal/auth/rh_identity.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -188,13 +189,39 @@ func (s *RHIdentityStore) UpsertUser(ctx context.Context, id *RHIdentity) (strin
 		return username, nil
 	}
 
-	// User doesn't exist at all — insert.
-	_, err = s.db.Exec(ctx,
+	// User doesn't exist at all — insert user and create personal team.
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return "", fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = tx.Exec(ctx,
 		`INSERT INTO auth_users (username, password, external_id, display_name, auth_source, is_admin, created_at, updated_at)
 		 VALUES ($1, NULL, $2, $3, 'rh-identity', false, NOW(), NOW())`,
 		assoc.Email, assoc.RhatUUID, displayName)
 	if err != nil {
 		return "", fmt.Errorf("creating user: %w", err)
+	}
+
+	// Create personal team for the new user.
+	teamID := uuid.New().String()
+	teamName := assoc.Email + "'s workspace"
+	_, err = tx.Exec(ctx,
+		"INSERT INTO teams (id, name, is_personal, created_at) VALUES ($1, $2, true, NOW())",
+		teamID, teamName)
+	if err != nil {
+		return "", fmt.Errorf("creating personal team: %w", err)
+	}
+	_, err = tx.Exec(ctx,
+		"INSERT INTO team_members (team_id, username) VALUES ($1, $2)",
+		teamID, assoc.Email)
+	if err != nil {
+		return "", fmt.Errorf("adding user to personal team: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return "", fmt.Errorf("committing transaction: %w", err)
 	}
 
 	return assoc.Email, nil

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -57,10 +57,11 @@ type API struct {
 	syncer         *AgentRepoSyncer
 	authStore      auth.Authenticator // for TBR associations (rh-identity backend)
 	workflowEngine *WorkflowEngine
+	teamStore      *TeamStore
 }
 
 // NewAPI creates the API handler set.
-func NewAPI(dispatcher *Dispatcher, db *pgxpool.Pool, cfg *Config, scheduler *Scheduler, credStore *CredentialStore, toolStore *ToolStore, profileStore *ProfileStore, settingsStore *SettingsStore, llm *BridgeLLM, defStore *AgentDefStore, syncer *AgentRepoSyncer, authStore auth.Authenticator, workflowEngine *WorkflowEngine) *API {
+func NewAPI(dispatcher *Dispatcher, db *pgxpool.Pool, cfg *Config, scheduler *Scheduler, credStore *CredentialStore, toolStore *ToolStore, profileStore *ProfileStore, settingsStore *SettingsStore, llm *BridgeLLM, defStore *AgentDefStore, syncer *AgentRepoSyncer, authStore auth.Authenticator, workflowEngine *WorkflowEngine, teamStore *TeamStore) *API {
 	return &API{
 		dispatcher:     dispatcher,
 		db:             db,
@@ -75,6 +76,7 @@ func NewAPI(dispatcher *Dispatcher, db *pgxpool.Pool, cfg *Config, scheduler *Sc
 		syncer:         syncer,
 		authStore:      authStore,
 		workflowEngine: workflowEngine,
+		teamStore:      teamStore,
 	}
 }
 
@@ -114,6 +116,8 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/workflows", a.handleWorkflows)
 	mux.HandleFunc("/api/v1/workflow-runs", a.handleWorkflowRuns)
 	mux.HandleFunc("/api/v1/workflow-runs/", a.handleWorkflowRunByID)
+	mux.HandleFunc("/api/v1/teams", a.handleTeams)
+	mux.HandleFunc("/api/v1/teams/", a.handleTeam)
 }
 
 // --- Health ---
@@ -201,7 +205,8 @@ func (a *API) handleSessions(w http.ResponseWriter, r *http.Request) {
 
 		req.TriggerType = "manual"
 
-		session, err := a.dispatcher.DispatchTask(r.Context(), req, submitter)
+		teamID := getActiveTeamID(r)
+		session, err := a.dispatcher.DispatchTask(r.Context(), req, submitter, teamID)
 		if err != nil {
 			log.Printf("error: dispatch failed: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to dispatch session: "+err.Error())
@@ -215,7 +220,7 @@ func (a *API) handleSessions(w http.ResponseWriter, r *http.Request) {
 		repo := query.Get("repo")
 		since := query.Get("since")
 		until := query.Get("until")
-		user := r.Header.Get("X-Alcove-User")
+		teamID := getActiveTeamID(r)
 
 		pageStr := query.Get("page")
 		perPageStr := query.Get("per_page")
@@ -229,7 +234,7 @@ func (a *API) handleSessions(w http.ResponseWriter, r *http.Request) {
 			perPage = pp
 		}
 
-		sessions, total, err := a.listSessions(r.Context(), status, repo, since, until, user, page, perPage)
+		sessions, total, err := a.listSessions(r.Context(), status, repo, since, until, teamID, page, perPage)
 		if err != nil {
 			log.Printf("error: listing sessions: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to list sessions")
@@ -263,15 +268,13 @@ func (a *API) handleSessionByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user := r.Header.Get("X-Alcove-User")
-
 	if len(parts) == 2 {
 		switch parts[1] {
 		case "transcript":
 			if r.Method == http.MethodPost {
 				a.handleAppendTranscript(w, r, sessionID)
 			} else {
-				a.handleTranscript(w, r, sessionID, user)
+				a.handleTranscript(w, r, sessionID)
 			}
 			return
 		case "status":
@@ -286,7 +289,7 @@ func (a *API) handleSessionByID(w http.ResponseWriter, r *http.Request) {
 			case http.MethodPost:
 				a.handleAppendProxyLog(w, r, sessionID)
 			case http.MethodGet:
-				a.handleGetProxyLog(w, r, sessionID, user)
+				a.handleGetProxyLog(w, r, sessionID)
 			default:
 				respondError(w, http.StatusMethodNotAllowed, "method not allowed")
 			}
@@ -296,21 +299,21 @@ func (a *API) handleSessionByID(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodGet:
-		a.handleGetSession(w, r, sessionID, user)
+		a.handleGetSession(w, r, sessionID)
 	case http.MethodDelete:
 		// Check if this is a delete request (vs cancel)
 		if r.URL.Query().Get("action") == "delete" {
-			a.handleDeleteSession(w, r, sessionID, user)
+			a.handleDeleteSession(w, r, sessionID)
 		} else {
-			a.handleCancelSession(w, r, sessionID, user)
+			a.handleCancelSession(w, r, sessionID)
 		}
 	default:
 		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
 	}
 }
 
-func (a *API) handleGetSession(w http.ResponseWriter, r *http.Request, sessionID string, user string) {
-	if err := a.checkOwnership(r.Context(), sessionID, user); err != nil {
+func (a *API) handleGetSession(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if err := a.checkTeamAccess(r.Context(), sessionID, r); err != nil {
 		respondError(w, http.StatusForbidden, "access denied")
 		return
 	}
@@ -345,8 +348,8 @@ func (a *API) handleGetSession(w http.ResponseWriter, r *http.Request, sessionID
 	respondJSON(w, http.StatusOK, detail)
 }
 
-func (a *API) handleCancelSession(w http.ResponseWriter, r *http.Request, sessionID string, user string) {
-	if err := a.checkOwnership(r.Context(), sessionID, user); err != nil {
+func (a *API) handleCancelSession(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if err := a.checkTeamAccess(r.Context(), sessionID, r); err != nil {
 		respondError(w, http.StatusForbidden, "access denied")
 		return
 	}
@@ -362,8 +365,8 @@ func (a *API) handleCancelSession(w http.ResponseWriter, r *http.Request, sessio
 	})
 }
 
-func (a *API) handleDeleteSession(w http.ResponseWriter, r *http.Request, sessionID string, user string) {
-	if err := a.checkOwnership(r.Context(), sessionID, user); err != nil {
+func (a *API) handleDeleteSession(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if err := a.checkTeamAccess(r.Context(), sessionID, r); err != nil {
 		respondError(w, http.StatusForbidden, "access denied")
 		return
 	}
@@ -408,8 +411,8 @@ func (a *API) handleDeleteSession(w http.ResponseWriter, r *http.Request, sessio
 }
 
 func (a *API) handleBulkDeleteSessions(w http.ResponseWriter, r *http.Request) {
-	user := r.Header.Get("X-Alcove-User")
-	if user == "" {
+	teamID := getActiveTeamID(r)
+	if teamID == "" {
 		respondError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
@@ -426,8 +429,8 @@ func (a *API) handleBulkDeleteSessions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build WHERE clause for deletion criteria
-	whereClause := " WHERE submitter = $1"
-	args := []any{user}
+	whereClause := " WHERE team_id = $1"
+	args := []any{teamID}
 	argN := 2
 
 	// Only allow deleting terminal state sessions
@@ -502,13 +505,13 @@ func (a *API) handleBulkDeleteSessions(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (a *API) handleTranscript(w http.ResponseWriter, r *http.Request, sessionID string, user string) {
+func (a *API) handleTranscript(w http.ResponseWriter, r *http.Request, sessionID string) {
 	if r.Method != http.MethodGet {
 		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 
-	if err := a.checkOwnership(r.Context(), sessionID, user); err != nil {
+	if err := a.checkTeamAccess(r.Context(), sessionID, r); err != nil {
 		respondError(w, http.StatusForbidden, "access denied")
 		return
 	}
@@ -771,8 +774,8 @@ func (a *API) handleAppendProxyLog(w http.ResponseWriter, r *http.Request, sessi
 	respondJSON(w, http.StatusOK, map[string]int{"appended": len(req.Entries)})
 }
 
-func (a *API) handleGetProxyLog(w http.ResponseWriter, r *http.Request, sessionID string, user string) {
-	if err := a.checkOwnership(r.Context(), sessionID, user); err != nil {
+func (a *API) handleGetProxyLog(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if err := a.checkTeamAccess(r.Context(), sessionID, r); err != nil {
 		respondError(w, http.StatusForbidden, "access denied")
 		return
 	}
@@ -867,14 +870,14 @@ func parseEventContext(prompt string) string {
 	return "Manual"
 }
 
-func (a *API) listSessions(ctx context.Context, status, repo, since, until, submitter string, page, perPage int) ([]internal.Session, int, error) {
+func (a *API) listSessions(ctx context.Context, status, repo, since, until, teamID string, page, perPage int) ([]internal.Session, int, error) {
 	whereClause := " WHERE 1=1"
 	args := []any{}
 	argN := 1
 
-	if submitter != "" {
-		whereClause += fmt.Sprintf(" AND s.submitter = $%d", argN)
-		args = append(args, submitter)
+	if teamID != "" {
+		whereClause += fmt.Sprintf(" AND s.team_id = $%d", argN)
+		args = append(args, teamID)
 		argN++
 	}
 	if status != "" {
@@ -1068,11 +1071,11 @@ func (a *API) getSession(ctx context.Context, id string) (*internal.Session, err
 // --- Schedules ---
 
 func (a *API) handleSchedules(w http.ResponseWriter, r *http.Request) {
-	user := r.Header.Get("X-Alcove-User")
+	teamID := getActiveTeamID(r)
 
 	switch r.Method {
 	case http.MethodGet:
-		schedules, err := a.scheduler.ListSchedules(r.Context(), user)
+		schedules, err := a.scheduler.ListSchedules(r.Context(), teamID)
 		if err != nil {
 			log.Printf("error: listing schedules: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to list schedules")
@@ -1080,10 +1083,10 @@ func (a *API) handleSchedules(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Annotate schedules with repo_disabled by joining through agent definitions.
-		disabledRepos := a.buildDisabledReposMap(r.Context(), user)
+		disabledRepos := a.buildDisabledReposMap(r.Context(), teamID)
 		if len(disabledRepos) > 0 {
 			// Build source_key -> source_repo map from agent definitions.
-			defs, defErr := a.defStore.ListAgentDefinitions(r.Context(), user)
+			defs, defErr := a.defStore.ListAgentDefinitions(r.Context(), teamID)
 			if defErr == nil {
 				sourceKeyToRepo := make(map[string]string)
 				for _, d := range defs {
@@ -1111,7 +1114,7 @@ func (a *API) handleSchedules(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 			return
 		}
-		if err := a.scheduler.CreateSchedule(r.Context(), &sched, user); err != nil {
+		if err := a.scheduler.CreateSchedule(r.Context(), &sched, teamID); err != nil {
 			log.Printf("error: creating schedule: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to create schedule: "+err.Error())
 			return
@@ -1133,7 +1136,7 @@ func (a *API) handleScheduleByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user := r.Header.Get("X-Alcove-User")
+	teamID := getActiveTeamID(r)
 
 	if len(parts) == 2 {
 		switch parts[1] {
@@ -1149,7 +1152,7 @@ func (a *API) handleScheduleByID(w http.ResponseWriter, r *http.Request) {
 				respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 				return
 			}
-			if err := a.scheduler.EnableSchedule(r.Context(), id, req.Enabled, user); err != nil {
+			if err := a.scheduler.EnableSchedule(r.Context(), id, req.Enabled, teamID); err != nil {
 				log.Printf("error: enabling/disabling schedule %s: %v", id, err)
 				respondError(w, http.StatusInternalServerError, "failed to update schedule: "+err.Error())
 				return
@@ -1161,7 +1164,7 @@ func (a *API) handleScheduleByID(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodGet:
-		sched, err := a.scheduler.GetSchedule(r.Context(), id, user)
+		sched, err := a.scheduler.GetSchedule(r.Context(), id, teamID)
 		if err != nil {
 			respondError(w, http.StatusNotFound, "schedule not found")
 			return
@@ -1174,14 +1177,14 @@ func (a *API) handleScheduleByID(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		sched.ID = id
-		if err := a.scheduler.UpdateSchedule(r.Context(), &sched, user); err != nil {
+		if err := a.scheduler.UpdateSchedule(r.Context(), &sched, teamID); err != nil {
 			log.Printf("error: updating schedule %s: %v", id, err)
 			respondError(w, http.StatusInternalServerError, "failed to update schedule: "+err.Error())
 			return
 		}
 		respondJSON(w, http.StatusOK, sched)
 	case http.MethodDelete:
-		if err := a.scheduler.DeleteSchedule(r.Context(), id, user); err != nil {
+		if err := a.scheduler.DeleteSchedule(r.Context(), id, teamID); err != nil {
 			log.Printf("error: deleting schedule %s: %v", id, err)
 			respondError(w, http.StatusInternalServerError, "failed to delete schedule: "+err.Error())
 			return
@@ -1195,11 +1198,11 @@ func (a *API) handleScheduleByID(w http.ResponseWriter, r *http.Request) {
 // --- Credentials ---
 
 func (a *API) handleCredentials(w http.ResponseWriter, r *http.Request) {
-	user := r.Header.Get("X-Alcove-User")
+	teamID := getActiveTeamID(r)
 
 	switch r.Method {
 	case http.MethodGet:
-		creds, err := a.credStore.ListCredentials(r.Context(), user)
+		creds, err := a.credStore.ListCredentials(r.Context(), teamID)
 		if err != nil {
 			log.Printf("error: listing credentials: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to list credentials")
@@ -1227,10 +1230,10 @@ func (a *API) handleCredentials(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusBadRequest, "name, provider, auth_type, and credential are required")
 			return
 		}
-		// Enforce one LLM credential per user.
+		// Enforce one LLM credential per team.
 		scmProviders := map[string]bool{"github": true, "gitlab": true, "jira": true}
 		if !scmProviders[req.Provider] {
-			existing, _ := a.credStore.ListCredentials(r.Context(), user)
+			existing, _ := a.credStore.ListCredentials(r.Context(), teamID)
 			for _, c := range existing {
 				if !scmProviders[c.Provider] {
 					respondJSON(w, http.StatusConflict, map[string]any{
@@ -1251,7 +1254,7 @@ func (a *API) handleCredentials(w http.ResponseWriter, r *http.Request) {
 			Region:    req.Region,
 			APIHost:   req.APIHost,
 		}
-		if err := a.credStore.CreateCredential(r.Context(), &cred, []byte(req.Credential), user); err != nil {
+		if err := a.credStore.CreateCredential(r.Context(), &cred, []byte(req.Credential), teamID); err != nil {
 			log.Printf("error: creating credential: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to create credential: "+err.Error())
 			return
@@ -1269,18 +1272,18 @@ func (a *API) handleCredentialByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user := r.Header.Get("X-Alcove-User")
+	teamID := getActiveTeamID(r)
 
 	switch r.Method {
 	case http.MethodGet:
-		cred, err := a.credStore.GetCredential(r.Context(), id, user)
+		cred, err := a.credStore.GetCredential(r.Context(), id, teamID)
 		if err != nil {
 			respondError(w, http.StatusNotFound, "credential not found")
 			return
 		}
 		respondJSON(w, http.StatusOK, cred)
 	case http.MethodDelete:
-		if err := a.credStore.DeleteCredential(r.Context(), id, user); err != nil {
+		if err := a.credStore.DeleteCredential(r.Context(), id, teamID); err != nil {
 			log.Printf("error: deleting credential %s: %v", id, err)
 			respondError(w, http.StatusNotFound, "credential not found")
 			return
@@ -1320,7 +1323,33 @@ func (a *API) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, http.StatusOK, result)
 }
 
-// checkOwnership verifies the requesting user owns the session.
+// getActiveTeamID returns the active team ID from the X-Alcove-Team-ID header.
+func getActiveTeamID(r *http.Request) string {
+	return r.Header.Get("X-Alcove-Team-ID")
+}
+
+// checkTeamAccess verifies the session belongs to the active team.
+func (a *API) checkTeamAccess(ctx context.Context, sessionID string, r *http.Request) error {
+	teamID := getActiveTeamID(r)
+	if teamID == "" {
+		return fmt.Errorf("no team context")
+	}
+	var sessionTeamID string
+	err := a.db.QueryRow(ctx, `SELECT team_id FROM sessions WHERE id = $1`, sessionID).Scan(&sessionTeamID)
+	if err != nil {
+		return fmt.Errorf("session not found")
+	}
+	if sessionTeamID != teamID {
+		// Also allow admins.
+		if r.Header.Get("X-Alcove-Admin") == "true" {
+			return nil
+		}
+		return fmt.Errorf("access denied")
+	}
+	return nil
+}
+
+// checkOwnership verifies the requesting user owns the session (legacy, delegates to team access).
 func (a *API) checkOwnership(ctx context.Context, sessionID, user string) error {
 	if user == "" {
 		return fmt.Errorf("no user context")
@@ -1339,11 +1368,11 @@ func (a *API) checkOwnership(ctx context.Context, sessionID, user string) error 
 // --- Tools ---
 
 func (a *API) handleTools(w http.ResponseWriter, r *http.Request) {
-	user := r.Header.Get("X-Alcove-User")
+	teamID := getActiveTeamID(r)
 
 	switch r.Method {
 	case http.MethodGet:
-		tools, err := a.toolStore.ListTools(r.Context(), user)
+		tools, err := a.toolStore.ListTools(r.Context(), teamID)
 		if err != nil {
 			log.Printf("error: listing tools: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to list tools")
@@ -1363,7 +1392,7 @@ func (a *API) handleTools(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusBadRequest, "name and display_name are required")
 			return
 		}
-		if err := a.toolStore.CreateTool(r.Context(), &tool, user); err != nil {
+		if err := a.toolStore.CreateTool(r.Context(), &tool, teamID); err != nil {
 			log.Printf("error: creating tool: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to create tool: "+err.Error())
 			return
@@ -1381,11 +1410,11 @@ func (a *API) handleToolByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user := r.Header.Get("X-Alcove-User")
+	teamID := getActiveTeamID(r)
 
 	switch r.Method {
 	case http.MethodGet:
-		tool, err := a.toolStore.GetTool(r.Context(), name, user)
+		tool, err := a.toolStore.GetTool(r.Context(), name, teamID)
 		if err != nil {
 			respondError(w, http.StatusNotFound, "tool not found")
 			return
@@ -1398,7 +1427,7 @@ func (a *API) handleToolByID(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		tool.Name = name
-		if err := a.toolStore.UpdateTool(r.Context(), &tool, user); err != nil {
+		if err := a.toolStore.UpdateTool(r.Context(), &tool, teamID); err != nil {
 			log.Printf("error: updating tool %s: %v", name, err)
 			if strings.Contains(err.Error(), "builtin") {
 				respondError(w, http.StatusForbidden, "builtin tools cannot be modified")
@@ -1410,7 +1439,7 @@ func (a *API) handleToolByID(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, tool)
 	case http.MethodDelete:
 		// Check if it's a builtin tool first.
-		existing, err := a.toolStore.GetTool(r.Context(), name, user)
+		existing, err := a.toolStore.GetTool(r.Context(), name, teamID)
 		if err != nil {
 			respondError(w, http.StatusNotFound, "tool not found")
 			return
@@ -1419,7 +1448,7 @@ func (a *API) handleToolByID(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusForbidden, "builtin tools cannot be deleted")
 			return
 		}
-		if err := a.toolStore.DeleteTool(r.Context(), name, user); err != nil {
+		if err := a.toolStore.DeleteTool(r.Context(), name, teamID); err != nil {
 			log.Printf("error: deleting tool %s: %v", name, err)
 			respondError(w, http.StatusNotFound, "tool not found")
 			return
@@ -1452,8 +1481,8 @@ func (a *API) handleSecurityProfileBuild(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Get available tools for the prompt context.
-	user := r.Header.Get("X-Alcove-User")
-	tools, _ := a.toolStore.ListTools(r.Context(), user)
+	teamID := getActiveTeamID(r)
+	tools, _ := a.toolStore.ListTools(r.Context(), teamID)
 
 	toolsDesc := ""
 	for _, t := range tools {
@@ -1534,11 +1563,11 @@ Respond with ONLY a JSON object (no markdown, no explanation):
 // --- Security Profiles ---
 
 func (a *API) handleSecurityProfiles(w http.ResponseWriter, r *http.Request) {
-	user := r.Header.Get("X-Alcove-User")
+	teamID := getActiveTeamID(r)
 
 	switch r.Method {
 	case http.MethodGet:
-		profiles, err := a.profileStore.ListProfiles(r.Context(), user)
+		profiles, err := a.profileStore.ListProfiles(r.Context(), teamID)
 		if err != nil {
 			log.Printf("error: listing profiles: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to list profiles")
@@ -1562,7 +1591,7 @@ func (a *API) handleSecurityProfiles(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusBadRequest, "tools is required")
 			return
 		}
-		if err := a.profileStore.CreateProfile(r.Context(), &profile, user); err != nil {
+		if err := a.profileStore.CreateProfile(r.Context(), &profile, teamID); err != nil {
 			log.Printf("error: creating profile: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to create profile: "+err.Error())
 			return
@@ -1580,11 +1609,11 @@ func (a *API) handleSecurityProfileByID(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	user := r.Header.Get("X-Alcove-User")
+	teamID := getActiveTeamID(r)
 
 	switch r.Method {
 	case http.MethodGet:
-		profile, err := a.profileStore.GetProfile(r.Context(), name, user)
+		profile, err := a.profileStore.GetProfile(r.Context(), name, teamID)
 		if err != nil {
 			respondError(w, http.StatusNotFound, "profile not found")
 			return
@@ -1597,14 +1626,14 @@ func (a *API) handleSecurityProfileByID(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		profile.Name = name
-		if err := a.profileStore.UpdateProfile(r.Context(), &profile, user); err != nil {
+		if err := a.profileStore.UpdateProfile(r.Context(), &profile, teamID); err != nil {
 			log.Printf("error: updating profile %s: %v", name, err)
 			respondError(w, http.StatusNotFound, "profile not found or cannot be updated")
 			return
 		}
 		respondJSON(w, http.StatusOK, profile)
 	case http.MethodDelete:
-		if err := a.profileStore.DeleteProfile(r.Context(), name, user); err != nil {
+		if err := a.profileStore.DeleteProfile(r.Context(), name, teamID); err != nil {
 			log.Printf("error: deleting profile %s: %v", name, err)
 			respondError(w, http.StatusNotFound, "profile not found")
 			return
@@ -1710,15 +1739,47 @@ func (a *API) handleUserSettingsSkillRepos(w http.ResponseWriter, r *http.Reques
 // --- Agent Repos Settings ---
 
 func (a *API) handleUserSettingsAgentRepos(w http.ResponseWriter, r *http.Request) {
-	username := r.Header.Get("X-Alcove-User")
-	if username == "" {
-		respondError(w, http.StatusUnauthorized, "authentication required")
+	teamID := getActiveTeamID(r)
+	if teamID == "" {
+		// Fallback to user_settings for backward compatibility.
+		username := r.Header.Get("X-Alcove-User")
+		if username == "" {
+			respondError(w, http.StatusUnauthorized, "authentication required")
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			repos, err := a.settingsStore.GetUserAgentRepos(r.Context(), username)
+			if err != nil {
+				repos = []SkillRepo{}
+			}
+			respondJSON(w, http.StatusOK, map[string]any{"repos": repos})
+		case http.MethodPut:
+			var req struct {
+				Repos []SkillRepo `json:"repos"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+				return
+			}
+			if req.Repos == nil {
+				req.Repos = []SkillRepo{}
+			}
+			if err := a.settingsStore.SetUserAgentRepos(r.Context(), username, req.Repos); err != nil {
+				respondError(w, http.StatusInternalServerError, "failed to save agent repos")
+				return
+			}
+			go a.syncer.SyncAll(context.Background())
+			respondJSON(w, http.StatusOK, map[string]any{"repos": req.Repos})
+		default:
+			respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
 		return
 	}
 
 	switch r.Method {
 	case http.MethodGet:
-		repos, err := a.settingsStore.GetUserAgentRepos(r.Context(), username)
+		repos, err := a.teamStore.GetTeamAgentRepos(r.Context(), teamID)
 		if err != nil {
 			repos = []SkillRepo{}
 		}
@@ -1734,7 +1795,7 @@ func (a *API) handleUserSettingsAgentRepos(w http.ResponseWriter, r *http.Reques
 		if req.Repos == nil {
 			req.Repos = []SkillRepo{}
 		}
-		if err := a.settingsStore.SetUserAgentRepos(r.Context(), username, req.Repos); err != nil {
+		if err := a.teamStore.SetTeamAgentRepos(r.Context(), teamID, req.Repos); err != nil {
 			respondError(w, http.StatusInternalServerError, "failed to save agent repos")
 			return
 		}
@@ -1780,16 +1841,16 @@ func (a *API) handleAgentDefinitions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user := r.Header.Get("X-Alcove-User")
-	defs, err := a.defStore.ListAgentDefinitions(r.Context(), user)
+	teamID := getActiveTeamID(r)
+	defs, err := a.defStore.ListAgentDefinitions(r.Context(), teamID)
 	if err != nil {
 		log.Printf("error: listing agent definitions: %v", err)
 		respondError(w, http.StatusInternalServerError, "failed to list agent definitions")
 		return
 	}
 
-	// Fetch user's agent repos to check disabled status.
-	disabledRepos := a.buildDisabledReposMap(r.Context(), user)
+	// Fetch team's agent repos to check disabled status.
+	disabledRepos := a.buildDisabledReposMap(r.Context(), teamID)
 
 	// Annotate each agent definition with repo_disabled.
 	for i := range defs {
@@ -1849,8 +1910,8 @@ func (a *API) handleAgentDefinitionByID(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	user := r.Header.Get("X-Alcove-User")
-	def, err := a.defStore.GetAgentDefinition(r.Context(), id, user)
+	teamID := getActiveTeamID(r)
+	def, err := a.defStore.GetAgentDefinition(r.Context(), id, teamID)
 	if err != nil {
 		respondError(w, http.StatusNotFound, "agent definition not found")
 		return
@@ -1871,7 +1932,8 @@ func (a *API) handleAgentDefinitionRun(w http.ResponseWriter, r *http.Request, i
 		submitter = "anonymous"
 	}
 
-	def, err := a.defStore.GetAgentDefinition(r.Context(), id, submitter)
+	teamID := getActiveTeamID(r)
+	def, err := a.defStore.GetAgentDefinition(r.Context(), id, teamID)
 	if err != nil {
 		respondError(w, http.StatusNotFound, "agent definition not found")
 		return
@@ -1885,7 +1947,7 @@ func (a *API) handleAgentDefinitionRun(w http.ResponseWriter, r *http.Request, i
 	req := def.ToTaskRequest()
 	req.TaskName = def.Name
 	req.TriggerType = "manual"
-	session, err := a.dispatcher.DispatchTask(r.Context(), req, submitter)
+	session, err := a.dispatcher.DispatchTask(r.Context(), req, submitter, teamID)
 	if err != nil {
 		log.Printf("error: dispatching agent definition %s: %v", id, err)
 		respondError(w, http.StatusInternalServerError, "failed to dispatch session: "+err.Error())
@@ -2119,7 +2181,7 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 
 	// Query schedules with event triggers.
 	rows, queryErr := a.db.Query(ctx, `
-		SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, owner, debug, trigger_type, event_config
+		SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, team_id, debug, trigger_type, event_config
 		FROM schedules
 		WHERE enabled = true
 		  AND COALESCE(trigger_type, 'cron') IN ('event', 'cron-and-event')
@@ -2146,7 +2208,7 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 			ScopePreset string
 			Timeout     int
 			Enabled     bool
-			Owner       string
+			TeamID      string
 			Debug       bool
 			TriggerType string
 			EventConfig []byte
@@ -2155,7 +2217,7 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 		if err := rows.Scan(
 			&sched.ID, &sched.Name, &sched.Cron, &sched.Prompt,
 			&sched.Repo, &sched.Provider, &sched.ScopePreset, &sched.Timeout,
-			&sched.Enabled, &sched.Owner, &sched.Debug, &sched.TriggerType, &sched.EventConfig,
+			&sched.Enabled, &sched.TeamID, &sched.Debug, &sched.TriggerType, &sched.EventConfig,
 		); err != nil {
 			log.Printf("webhook: error scanning schedule: %v", err)
 			continue
@@ -2189,7 +2251,7 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 			taskReq.TriggerRef = fmt.Sprintf("%s#%s", repo, prNumber)
 		}
 
-		session, err := a.dispatcher.DispatchTask(ctx, taskReq, sched.Owner)
+		session, err := a.dispatcher.DispatchTask(ctx, taskReq, "webhook", sched.TeamID)
 		if err != nil {
 			log.Printf("webhook: error dispatching schedule %s (%s): %v", sched.Name, sched.ID, err)
 			continue
@@ -2526,18 +2588,21 @@ func (a *API) handlePersonalAPITokenByID(w http.ResponseWriter, r *http.Request)
 }
 
 // buildDisabledReposMap returns a set of repo URLs that are disabled for the given user.
-func (a *API) buildDisabledReposMap(ctx context.Context, username string) map[string]bool {
-	agentRepos, err := a.settingsStore.GetUserAgentRepos(ctx, username)
-	if err != nil {
-		return nil
-	}
-	disabledRepos := make(map[string]bool)
-	for _, repo := range agentRepos {
-		if !repo.IsEnabled() {
-			disabledRepos[repo.URL] = true
+func (a *API) buildDisabledReposMap(ctx context.Context, teamID string) map[string]bool {
+	// Try team settings first, fall back to user_settings for backward compat.
+	if teamID != "" && a.teamStore != nil {
+		agentRepos, err := a.teamStore.GetTeamAgentRepos(ctx, teamID)
+		if err == nil {
+			disabledRepos := make(map[string]bool)
+			for _, repo := range agentRepos {
+				if !repo.IsEnabled() {
+					disabledRepos[repo.URL] = true
+				}
+			}
+			return disabledRepos
 		}
 	}
-	return disabledRepos
+	return nil
 }
 
 // --- Workflows ---
@@ -2548,12 +2613,9 @@ func (a *API) handleWorkflows(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	owner := r.Header.Get("X-Alcove-User")
-	if owner == "" {
-		owner = "anonymous"
-	}
+	teamID := getActiveTeamID(r)
 
-	workflows, err := a.workflowEngine.workflowStore.ListWorkflows(r.Context(), owner)
+	workflows, err := a.workflowEngine.workflowStore.ListWorkflows(r.Context(), teamID)
 	if err != nil {
 		log.Printf("error listing workflows: %v", err)
 		respondError(w, http.StatusInternalServerError, "failed to list workflows")
@@ -2572,14 +2634,11 @@ func (a *API) handleWorkflowRuns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	owner := r.Header.Get("X-Alcove-User")
-	if owner == "" {
-		owner = "anonymous"
-	}
+	teamID := getActiveTeamID(r)
 
 	status := r.URL.Query().Get("status")
 
-	runs, err := a.workflowEngine.ListWorkflowRuns(r.Context(), status, owner)
+	runs, err := a.workflowEngine.ListWorkflowRuns(r.Context(), status, teamID)
 	if err != nil {
 		log.Printf("error listing workflow runs: %v", err)
 		respondError(w, http.StatusInternalServerError, "failed to list workflow runs")

--- a/internal/bridge/cigate.go
+++ b/internal/bridge/cigate.go
@@ -371,8 +371,12 @@ func (m *CIGateMonitor) handleCIFailure(ctx context.Context, sessionID, repo str
 	taskReq.TriggerType = "event"
 	taskReq.TriggerRef = fmt.Sprintf("%s#%d", repo, prNumber)
 
+	// Resolve team_id from the original session.
+	var ciTeamID string
+	_ = m.db.QueryRow(ctx, `SELECT team_id FROM sessions WHERE id = $1`, sessionID).Scan(&ciTeamID)
+
 	// Dispatch retry task.
-	newSession, err := m.dispatcher.DispatchTask(ctx, taskReq, owner)
+	newSession, err := m.dispatcher.DispatchTask(ctx, taskReq, owner, ciTeamID)
 	if err != nil {
 		log.Printf("cigate: error dispatching retry for PR %s#%d: %v", repo, prNumber, err)
 		m.updateStatus(ctx, sessionID, "error")

--- a/internal/bridge/credentials.go
+++ b/internal/bridge/credentials.go
@@ -42,7 +42,7 @@ type Credential struct {
 	APIHost   string    `json:"api_host,omitempty"` // custom API host (e.g., self-hosted GitLab)
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
-	Owner     string    `json:"owner,omitempty"`
+	TeamID    string    `json:"team_id,omitempty"`
 }
 
 // CredentialStore manages encrypted credential storage in PostgreSQL.
@@ -117,23 +117,28 @@ func NewCredentialStore(db *pgxpool.Pool, masterKey string) *CredentialStore {
 }
 
 // CreateCredential stores a new credential with encrypted material.
-func (cs *CredentialStore) CreateCredential(ctx context.Context, cred *Credential, rawCredential []byte, owner string) error {
+func (cs *CredentialStore) CreateCredential(ctx context.Context, cred *Credential, rawCredential []byte, teamID string) error {
 	cred.ID = uuid.New().String()
 	now := time.Now().UTC()
 	cred.CreatedAt = now
 	cred.UpdatedAt = now
-	cred.Owner = owner
+	cred.TeamID = teamID
 
 	encrypted, err := encrypt(cs.key, rawCredential)
 	if err != nil {
 		return fmt.Errorf("encrypting credential: %w", err)
 	}
 
+	var teamIDVal *string
+	if teamID != "" {
+		teamIDVal = &teamID
+	}
+
 	_, err = cs.db.Exec(ctx,
-		`INSERT INTO provider_credentials (id, name, provider, auth_type, credential, project_id, region, api_host, created_at, updated_at, owner)
+		`INSERT INTO provider_credentials (id, name, provider, auth_type, credential, project_id, region, api_host, created_at, updated_at, team_id)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
 		cred.ID, cred.Name, cred.Provider, cred.AuthType, encrypted,
-		cred.ProjectID, cred.Region, cred.APIHost, cred.CreatedAt, cred.UpdatedAt, owner)
+		cred.ProjectID, cred.Region, cred.APIHost, cred.CreatedAt, cred.UpdatedAt, teamIDVal)
 	if err != nil {
 		return fmt.Errorf("inserting credential: %w", err)
 	}
@@ -142,22 +147,17 @@ func (cs *CredentialStore) CreateCredential(ctx context.Context, cred *Credentia
 }
 
 // ListCredentials returns credentials without their encrypted material.
-// If owner is non-empty, only credentials belonging to that owner are returned.
-func (cs *CredentialStore) ListCredentials(ctx context.Context, owner string) ([]Credential, error) {
-	query := `SELECT id, name, provider, auth_type, project_id, region, api_host, created_at, updated_at, owner
+// If teamID is non-empty, only credentials belonging to that team are returned.
+func (cs *CredentialStore) ListCredentials(ctx context.Context, teamID string) ([]Credential, error) {
+	query := `SELECT id, name, provider, auth_type, project_id, region, api_host, created_at, updated_at, COALESCE(team_id::text, '')
 		FROM provider_credentials`
 	args := []any{}
-	if owner != "" {
-		query += ` WHERE owner = $1`
-		args = append(args, owner)
-	}
-	// Always exclude system credentials from user lists.
-	if owner != "_system" {
-		if len(args) > 0 {
-			query += ` AND owner != '_system'`
-		} else {
-			query += ` WHERE owner != '_system'`
-		}
+	if teamID != "" {
+		query += ` WHERE team_id = $1`
+		args = append(args, teamID)
+	} else {
+		// Exclude system credentials (NULL team_id) from general lists.
+		query += ` WHERE team_id IS NOT NULL`
 	}
 	query += ` ORDER BY created_at DESC`
 
@@ -171,7 +171,7 @@ func (cs *CredentialStore) ListCredentials(ctx context.Context, owner string) ([
 	for rows.Next() {
 		var c Credential
 		if err := rows.Scan(&c.ID, &c.Name, &c.Provider, &c.AuthType,
-			&c.ProjectID, &c.Region, &c.APIHost, &c.CreatedAt, &c.UpdatedAt, &c.Owner); err != nil {
+			&c.ProjectID, &c.Region, &c.APIHost, &c.CreatedAt, &c.UpdatedAt, &c.TeamID); err != nil {
 			return nil, fmt.Errorf("scanning credential: %w", err)
 		}
 		creds = append(creds, c)
@@ -185,19 +185,19 @@ func (cs *CredentialStore) ListCredentials(ctx context.Context, owner string) ([
 }
 
 // GetCredential returns a single credential by ID without its encrypted material.
-// If owner is non-empty, only returns the credential if it belongs to that owner.
-func (cs *CredentialStore) GetCredential(ctx context.Context, id, owner string) (*Credential, error) {
-	query := `SELECT id, name, provider, auth_type, project_id, region, api_host, created_at, updated_at, owner
+// If teamID is non-empty, only returns the credential if it belongs to that team.
+func (cs *CredentialStore) GetCredential(ctx context.Context, id, teamID string) (*Credential, error) {
+	query := `SELECT id, name, provider, auth_type, project_id, region, api_host, created_at, updated_at, COALESCE(team_id::text, '')
 		FROM provider_credentials WHERE id = $1`
 	args := []any{id}
-	if owner != "" {
-		query += ` AND owner = $2`
-		args = append(args, owner)
+	if teamID != "" {
+		query += ` AND team_id = $2`
+		args = append(args, teamID)
 	}
 
 	var c Credential
 	err := cs.db.QueryRow(ctx, query, args...).Scan(&c.ID, &c.Name, &c.Provider, &c.AuthType,
-		&c.ProjectID, &c.Region, &c.APIHost, &c.CreatedAt, &c.UpdatedAt, &c.Owner)
+		&c.ProjectID, &c.Region, &c.APIHost, &c.CreatedAt, &c.UpdatedAt, &c.TeamID)
 	if err != nil {
 		return nil, fmt.Errorf("credential not found: %w", err)
 	}
@@ -205,13 +205,13 @@ func (cs *CredentialStore) GetCredential(ctx context.Context, id, owner string) 
 }
 
 // DeleteCredential removes a credential by ID. Returns an error if not found.
-// If owner is non-empty, only deletes the credential if it belongs to that owner.
-func (cs *CredentialStore) DeleteCredential(ctx context.Context, id, owner string) error {
+// If teamID is non-empty, only deletes the credential if it belongs to that team.
+func (cs *CredentialStore) DeleteCredential(ctx context.Context, id, teamID string) error {
 	query := `DELETE FROM provider_credentials WHERE id = $1`
 	args := []any{id}
-	if owner != "" {
-		query += ` AND owner = $2`
-		args = append(args, owner)
+	if teamID != "" {
+		query += ` AND team_id = $2`
+		args = append(args, teamID)
 	}
 
 	result, err := cs.db.Exec(ctx, query, args...)
@@ -231,7 +231,7 @@ func (cs *CredentialStore) AcquireToken(ctx context.Context, providerName string
 	var authType, provider string
 	var encrypted []byte
 	err := cs.db.QueryRow(ctx,
-		`SELECT auth_type, provider, credential FROM provider_credentials WHERE (provider = $1 OR name = $1) AND owner != '_system' ORDER BY created_at DESC LIMIT 1`, providerName,
+		`SELECT auth_type, provider, credential FROM provider_credentials WHERE (provider = $1 OR name = $1) AND team_id IS NOT NULL ORDER BY created_at DESC LIMIT 1`, providerName,
 	).Scan(&authType, &provider, &encrypted)
 	if err != nil {
 		return nil, fmt.Errorf("credential for provider %q not found: %w", providerName, err)
@@ -288,7 +288,7 @@ func (cs *CredentialStore) AcquireSystemToken(ctx context.Context, providerName 
 	var encrypted []byte
 	err := cs.db.QueryRow(ctx,
 		`SELECT auth_type, provider, credential FROM provider_credentials
-		 WHERE (provider = $1 OR name = $1) AND owner = '_system'
+		 WHERE (provider = $1 OR name = $1) AND team_id IS NULL
 		 ORDER BY created_at DESC LIMIT 1`,
 		providerName).Scan(&authType, &provider, &encrypted)
 	if err != nil {
@@ -342,7 +342,7 @@ func (cs *CredentialStore) AcquireSystemToken(ctx context.Context, providerName 
 // This is used to clean up existing system credentials before saving new ones.
 func (cs *CredentialStore) DeleteSystemCredentialByName(ctx context.Context, name string) error {
 	_, err := cs.db.Exec(ctx,
-		`DELETE FROM provider_credentials WHERE name = $1 AND owner = '_system'`, name)
+		`DELETE FROM provider_credentials WHERE name = $1 AND team_id IS NULL`, name)
 	return err
 }
 
@@ -383,14 +383,14 @@ func (cs *CredentialStore) AcquireSCMTokenWithHost(ctx context.Context, service 
 
 // AcquireSCMTokenForOwner looks up an SCM credential for a specific owner and returns
 // the token and API host. Falls back to AcquireSCMTokenWithHost if no owner-specific credential exists.
-func (cs *CredentialStore) AcquireSCMTokenForOwner(ctx context.Context, service, owner string) (token string, apiHost string, err error) {
+func (cs *CredentialStore) AcquireSCMTokenForOwner(ctx context.Context, service, teamID string) (token string, apiHost string, err error) {
 	var encrypted []byte
 	var host string
 	err = cs.db.QueryRow(ctx,
 		`SELECT credential, COALESCE(api_host, '') FROM provider_credentials
-		WHERE (provider = $1 OR name = $1) AND owner = $2
+		WHERE (provider = $1 OR name = $1) AND team_id = $2
 		ORDER BY created_at DESC LIMIT 1`,
-		service, owner).Scan(&encrypted, &host)
+		service, teamID).Scan(&encrypted, &host)
 	if err != nil {
 		// Fall back to any available credential for this service.
 		return cs.AcquireSCMTokenWithHost(ctx, service)
@@ -420,13 +420,13 @@ func (cs *CredentialStore) AcquireTokenBySessionID(ctx context.Context, sessionI
 func (cs *CredentialStore) FirstAvailableProvider(ctx context.Context) (*Credential, error) {
 	var c Credential
 	err := cs.db.QueryRow(ctx,
-		`SELECT id, name, provider, auth_type, project_id, region, api_host, created_at, updated_at, owner
+		`SELECT id, name, provider, auth_type, project_id, region, api_host, created_at, updated_at, COALESCE(team_id::text, '')
 		FROM provider_credentials
-		WHERE owner != '_system'
+		WHERE team_id IS NOT NULL
 		AND provider NOT IN ('github', 'gitlab', 'jira')
 		ORDER BY created_at ASC LIMIT 1`,
 	).Scan(&c.ID, &c.Name, &c.Provider, &c.AuthType,
-		&c.ProjectID, &c.Region, &c.APIHost, &c.CreatedAt, &c.UpdatedAt, &c.Owner)
+		&c.ProjectID, &c.Region, &c.APIHost, &c.CreatedAt, &c.UpdatedAt, &c.TeamID)
 	if err != nil {
 		return nil, fmt.Errorf("no LLM credentials available: %w", err)
 	}
@@ -438,13 +438,13 @@ func (cs *CredentialStore) FirstAvailableProvider(ctx context.Context) (*Credent
 func (cs *CredentialStore) LookupProviderCredential(ctx context.Context, providerName string) (*Credential, error) {
 	var c Credential
 	err := cs.db.QueryRow(ctx,
-		`SELECT id, name, provider, auth_type, project_id, region, api_host, created_at, updated_at, owner
+		`SELECT id, name, provider, auth_type, project_id, region, api_host, created_at, updated_at, COALESCE(team_id::text, '')
 		FROM provider_credentials
-		WHERE (provider = $1 OR name = $1) AND owner != '_system'
+		WHERE (provider = $1 OR name = $1) AND team_id IS NOT NULL
 		ORDER BY created_at DESC LIMIT 1`,
 		providerName,
 	).Scan(&c.ID, &c.Name, &c.Provider, &c.AuthType,
-		&c.ProjectID, &c.Region, &c.APIHost, &c.CreatedAt, &c.UpdatedAt, &c.Owner)
+		&c.ProjectID, &c.Region, &c.APIHost, &c.CreatedAt, &c.UpdatedAt, &c.TeamID)
 	if err != nil {
 		return nil, fmt.Errorf("credential for provider %q not found: %w", providerName, err)
 	}
@@ -455,9 +455,9 @@ func (cs *CredentialStore) LookupProviderCredential(ctx context.Context, provide
 // mapped to internal.Provider structs. Excludes system and SCM credentials.
 func (cs *CredentialStore) ListDistinctProviders(ctx context.Context) ([]Credential, error) {
 	rows, err := cs.db.Query(ctx,
-		`SELECT DISTINCT ON (provider) id, name, provider, auth_type, project_id, region, api_host, created_at, updated_at, owner
+		`SELECT DISTINCT ON (provider) id, name, provider, auth_type, project_id, region, api_host, created_at, updated_at, COALESCE(team_id::text, '')
 		FROM provider_credentials
-		WHERE owner != '_system'
+		WHERE team_id IS NOT NULL
 		AND provider NOT IN ('github', 'gitlab', 'jira')
 		ORDER BY provider, created_at DESC`)
 	if err != nil {
@@ -469,7 +469,7 @@ func (cs *CredentialStore) ListDistinctProviders(ctx context.Context) ([]Credent
 	for rows.Next() {
 		var c Credential
 		if err := rows.Scan(&c.ID, &c.Name, &c.Provider, &c.AuthType,
-			&c.ProjectID, &c.Region, &c.APIHost, &c.CreatedAt, &c.UpdatedAt, &c.Owner); err != nil {
+			&c.ProjectID, &c.Region, &c.APIHost, &c.CreatedAt, &c.UpdatedAt, &c.TeamID); err != nil {
 			return nil, fmt.Errorf("scanning credential: %w", err)
 		}
 		creds = append(creds, c)

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -113,8 +113,9 @@ type StatusUpdate struct {
 }
 
 // DispatchTask creates a session record, publishes to Hail, and starts a
-// Skiff pod via the Runtime.
-func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitter string) (*internal.Session, error) {
+// Skiff pod via the Runtime. The optional teamID parameter associates the
+// session with a team; if empty, the session has no team association.
+func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitter string, teamID ...string) (*internal.Session, error) {
 	sessionID := uuid.New().String()
 	taskID := uuid.New().String()
 
@@ -204,6 +205,12 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		}
 	}
 
+	// Extract team ID from variadic parameter.
+	var activeTeamID string
+	if len(teamID) > 0 {
+		activeTeamID = teamID[0]
+	}
+
 	now := time.Now().UTC()
 	session := &internal.Session{
 		ID:          sessionID,
@@ -218,6 +225,7 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		TaskName:    req.TaskName,
 		TriggerType: req.TriggerType,
 		TriggerRef:  req.TriggerRef,
+		TeamID:      activeTeamID,
 	}
 
 	// For executable agents, store the prompt as the description/context if empty
@@ -710,10 +718,10 @@ func (d *Dispatcher) ListenForStatusUpdates(ctx context.Context) error {
 func (d *Dispatcher) insertSession(ctx context.Context, s *internal.Session, sessionToken string) error {
 	scopeJSON, _ := json.Marshal(s.Scope)
 	_, err := d.db.Exec(ctx, `
-		INSERT INTO sessions (id, task_id, submitter, prompt, scope, provider, started_at, outcome, session_token, task_name, trigger_type, trigger_ref, repo)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+		INSERT INTO sessions (id, task_id, submitter, prompt, scope, provider, started_at, outcome, session_token, task_name, trigger_type, trigger_ref, repo, team_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 	`, s.ID, s.TaskID, s.Submitter, s.Prompt, scopeJSON, s.Provider, s.StartedAt, s.Status, sessionToken,
-		nilIfEmpty(s.TaskName), nilIfEmpty(s.TriggerType), nilIfEmpty(s.TriggerRef), nilIfEmpty(s.Repo))
+		nilIfEmpty(s.TaskName), nilIfEmpty(s.TriggerType), nilIfEmpty(s.TriggerRef), nilIfEmpty(s.Repo), s.TeamID)
 	return err
 }
 

--- a/internal/bridge/migrations/027_teams.sql
+++ b/internal/bridge/migrations/027_teams.sql
@@ -1,0 +1,184 @@
+-- 027_teams.sql
+-- Add teams for multi-user resource sharing.
+
+-- 1. Create teams tables.
+
+CREATE TABLE teams (
+    id         UUID PRIMARY KEY,
+    name       TEXT NOT NULL,
+    is_personal BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE team_members (
+    team_id  UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    username TEXT NOT NULL,
+    PRIMARY KEY (team_id, username)
+);
+CREATE INDEX idx_team_members_username ON team_members(username);
+
+CREATE TABLE team_settings (
+    team_id    UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    key        TEXT NOT NULL,
+    value      JSONB NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (team_id, key)
+);
+
+-- 2. Create a personal team for each existing user.
+
+INSERT INTO teams (id, name, is_personal, created_at)
+SELECT gen_random_uuid(), username || '''s workspace', true, NOW()
+FROM auth_users;
+
+INSERT INTO team_members (team_id, username)
+SELECT t.id, u.username
+FROM auth_users u
+JOIN teams t ON t.name = u.username || '''s workspace' AND t.is_personal = true;
+
+-- 3. Add team_id column (nullable) to resource tables.
+
+ALTER TABLE sessions ADD COLUMN team_id UUID;
+ALTER TABLE provider_credentials ADD COLUMN team_id UUID;
+ALTER TABLE security_profiles ADD COLUMN team_id UUID;
+ALTER TABLE agent_definitions ADD COLUMN team_id UUID;
+ALTER TABLE schedules ADD COLUMN team_id UUID;
+ALTER TABLE workflows ADD COLUMN team_id UUID;
+ALTER TABLE workflow_runs ADD COLUMN team_id UUID;
+ALTER TABLE mcp_tools ADD COLUMN team_id UUID;
+
+-- 4. Backfill team_id from owner/submitter via personal teams.
+
+UPDATE sessions s
+SET team_id = t.id
+FROM team_members tm
+JOIN teams t ON tm.team_id = t.id AND t.is_personal = true
+WHERE s.submitter = tm.username;
+
+UPDATE provider_credentials pc
+SET team_id = t.id
+FROM team_members tm
+JOIN teams t ON tm.team_id = t.id AND t.is_personal = true
+WHERE pc.owner = tm.username;
+
+-- Handle system credentials (owner = '_system' or owner = '') — assign to first team or leave NULL
+UPDATE provider_credentials SET team_id = NULL WHERE owner = '_system' OR owner = '';
+
+UPDATE security_profiles sp
+SET team_id = t.id
+FROM team_members tm
+JOIN teams t ON tm.team_id = t.id AND t.is_personal = true
+WHERE sp.owner = tm.username;
+
+UPDATE agent_definitions ad
+SET team_id = t.id
+FROM team_members tm
+JOIN teams t ON tm.team_id = t.id AND t.is_personal = true
+WHERE ad.owner = tm.username;
+
+UPDATE schedules sc
+SET team_id = t.id
+FROM team_members tm
+JOIN teams t ON tm.team_id = t.id AND t.is_personal = true
+WHERE sc.owner = tm.username;
+
+UPDATE workflows w
+SET team_id = t.id
+FROM team_members tm
+JOIN teams t ON tm.team_id = t.id AND t.is_personal = true
+WHERE w.owner = tm.username;
+
+UPDATE workflow_runs wr
+SET team_id = t.id
+FROM team_members tm
+JOIN teams t ON tm.team_id = t.id AND t.is_personal = true
+WHERE wr.owner = tm.username;
+
+UPDATE mcp_tools mt
+SET team_id = t.id
+FROM team_members tm
+JOIN teams t ON tm.team_id = t.id AND t.is_personal = true
+WHERE mt.owner = tm.username;
+
+-- 5. Set team_id to NOT NULL (except provider_credentials which has _system rows)
+--    and add foreign key constraints.
+
+-- For tables that may have NULL team_id (system credentials), allow nullable
+ALTER TABLE sessions ALTER COLUMN team_id SET NOT NULL;
+ALTER TABLE sessions ADD CONSTRAINT fk_sessions_team FOREIGN KEY (team_id) REFERENCES teams(id);
+
+-- provider_credentials: system credentials have no team, so keep nullable
+ALTER TABLE provider_credentials ADD CONSTRAINT fk_provider_credentials_team FOREIGN KEY (team_id) REFERENCES teams(id);
+
+ALTER TABLE security_profiles ALTER COLUMN team_id SET NOT NULL;
+ALTER TABLE security_profiles ADD CONSTRAINT fk_security_profiles_team FOREIGN KEY (team_id) REFERENCES teams(id);
+
+ALTER TABLE agent_definitions ALTER COLUMN team_id SET NOT NULL;
+ALTER TABLE agent_definitions ADD CONSTRAINT fk_agent_definitions_team FOREIGN KEY (team_id) REFERENCES teams(id);
+
+ALTER TABLE schedules ALTER COLUMN team_id SET NOT NULL;
+ALTER TABLE schedules ADD CONSTRAINT fk_schedules_team FOREIGN KEY (team_id) REFERENCES teams(id);
+
+ALTER TABLE workflows ALTER COLUMN team_id SET NOT NULL;
+ALTER TABLE workflows ADD CONSTRAINT fk_workflows_team FOREIGN KEY (team_id) REFERENCES teams(id);
+
+ALTER TABLE workflow_runs ALTER COLUMN team_id SET NOT NULL;
+ALTER TABLE workflow_runs ADD CONSTRAINT fk_workflow_runs_team FOREIGN KEY (team_id) REFERENCES teams(id);
+
+-- mcp_tools: team_id is nullable for builtin tools (team_id IS NULL means builtin/global).
+ALTER TABLE mcp_tools ADD CONSTRAINT fk_mcp_tools_team FOREIGN KEY (team_id) REFERENCES teams(id);
+
+-- 6. Drop owner columns from resource tables (keep submitter on sessions).
+
+ALTER TABLE provider_credentials DROP COLUMN owner;
+ALTER TABLE security_profiles DROP COLUMN owner;
+ALTER TABLE agent_definitions DROP COLUMN owner;
+ALTER TABLE schedules DROP COLUMN owner;
+ALTER TABLE workflows DROP COLUMN owner;
+ALTER TABLE workflow_runs DROP COLUMN owner;
+ALTER TABLE mcp_tools DROP COLUMN owner;
+
+-- 7. Recreate unique constraints with team_id.
+
+-- security_profiles: drop old unique index and create new one
+DROP INDEX IF EXISTS idx_security_profiles_name_owner;
+CREATE UNIQUE INDEX idx_security_profiles_name_team ON security_profiles(name, team_id);
+
+-- mcp_tools: drop old unique index and create new ones
+DROP INDEX IF EXISTS idx_mcp_tools_name_owner;
+CREATE UNIQUE INDEX idx_mcp_tools_name_team ON mcp_tools(name, team_id) WHERE team_id IS NOT NULL;
+CREATE UNIQUE INDEX idx_mcp_tools_name_builtin ON mcp_tools(name) WHERE team_id IS NULL;
+
+-- agent_definitions: change UNIQUE(source_key) to UNIQUE(source_key, team_id)
+ALTER TABLE agent_definitions DROP CONSTRAINT IF EXISTS agent_definitions_source_key_key;
+ALTER TABLE agent_definitions DROP CONSTRAINT IF EXISTS task_definitions_source_key_key;
+CREATE UNIQUE INDEX idx_agent_definitions_source_key_team ON agent_definitions(source_key, team_id);
+
+-- workflows: change UNIQUE(source_key) to UNIQUE(source_key, team_id)
+DROP INDEX IF EXISTS workflows_source_key_key;
+ALTER TABLE workflows DROP CONSTRAINT IF EXISTS workflows_source_key_key;
+CREATE UNIQUE INDEX idx_workflows_source_key_team ON workflows(source_key, team_id);
+
+-- Add indexes for team_id on frequently queried tables.
+CREATE INDEX idx_sessions_team ON sessions(team_id);
+CREATE INDEX idx_provider_credentials_team ON provider_credentials(team_id);
+CREATE INDEX idx_security_profiles_team ON security_profiles(team_id);
+CREATE INDEX idx_agent_definitions_team ON agent_definitions(team_id);
+CREATE INDEX idx_schedules_team ON schedules(team_id);
+CREATE INDEX idx_workflows_team ON workflows(team_id);
+CREATE INDEX idx_workflow_runs_team ON workflow_runs(team_id);
+CREATE INDEX idx_mcp_tools_team ON mcp_tools(team_id);
+
+-- Drop old owner indexes.
+DROP INDEX IF EXISTS idx_provider_credentials_owner;
+DROP INDEX IF EXISTS idx_schedules_owner;
+DROP INDEX IF EXISTS idx_workflows_owner;
+
+-- 8. Migrate user_settings agent repo entries to team_settings.
+
+INSERT INTO team_settings (team_id, key, value, updated_at)
+SELECT t.id, us.key, us.value, us.updated_at
+FROM user_settings us
+JOIN team_members tm ON us.username = tm.username
+JOIN teams t ON tm.team_id = t.id
+WHERE t.is_personal = true;

--- a/internal/bridge/poller.go
+++ b/internal/bridge/poller.go
@@ -65,7 +65,7 @@ type pollSchedule struct {
 	Repo      string
 	Provider  string
 	Timeout   int
-	Owner     string
+	TeamID    string
 	Debug     bool
 	SourceKey string
 	Trigger   *GitHubTrigger
@@ -81,7 +81,7 @@ func (p *GitHubPoller) PollAll(ctx context.Context) {
 	}
 
 	rows, err := p.db.Query(ctx, `
-		SELECT id, name, prompt, repo, provider, timeout, owner, debug, event_config, COALESCE(source_key, '')
+		SELECT id, name, prompt, repo, provider, timeout, team_id, debug, event_config, COALESCE(source_key, '')
 		FROM schedules
 		WHERE enabled = true
 		  AND COALESCE(trigger_type, 'cron') IN ('event', 'cron-and-event')
@@ -95,7 +95,7 @@ func (p *GitHubPoller) PollAll(ctx context.Context) {
 
 	// Group schedules by target repo.
 	type repoGroup struct {
-		owner     string
+		teamID    string
 		schedules []pollSchedule
 	}
 	repoMap := make(map[string]*repoGroup)
@@ -105,7 +105,7 @@ func (p *GitHubPoller) PollAll(ctx context.Context) {
 		var eventConfigJSON []byte
 
 		if err := rows.Scan(&ps.ID, &ps.Name, &ps.Prompt, &ps.Repo,
-			&ps.Provider, &ps.Timeout, &ps.Owner, &ps.Debug, &eventConfigJSON, &ps.SourceKey); err != nil {
+			&ps.Provider, &ps.Timeout, &ps.TeamID, &ps.Debug, &eventConfigJSON, &ps.SourceKey); err != nil {
 			log.Printf("poller: error scanning schedule: %v", err)
 			continue
 		}
@@ -133,7 +133,7 @@ func (p *GitHubPoller) PollAll(ctx context.Context) {
 				continue // Can't poll all of GitHub.
 			}
 			if _, ok := repoMap[repo]; !ok {
-				repoMap[repo] = &repoGroup{owner: ps.Owner}
+				repoMap[repo] = &repoGroup{teamID: ps.TeamID}
 			}
 			repoMap[repo].schedules = append(repoMap[repo].schedules, ps)
 		}
@@ -144,12 +144,12 @@ func (p *GitHubPoller) PollAll(ctx context.Context) {
 		return
 	}
 	for repo, group := range repoMap {
-		p.pollRepo(ctx, repo, group.owner, group.schedules)
+		p.pollRepo(ctx, repo, group.teamID, group.schedules)
 	}
 }
 
 // pollRepo fetches events from a single GitHub repo and dispatches matching tasks.
-func (p *GitHubPoller) pollRepo(ctx context.Context, repo, owner string, schedules []pollSchedule) {
+func (p *GitHubPoller) pollRepo(ctx context.Context, repo, teamID string, schedules []pollSchedule) {
 	// Load poll state (ETag for caching only).
 	var etag string
 	_ = p.db.QueryRow(ctx,
@@ -157,9 +157,9 @@ func (p *GitHubPoller) pollRepo(ctx context.Context, repo, owner string, schedul
 	).Scan(&etag)
 
 	// Acquire GitHub token.
-	token, apiHost, err := p.credStore.AcquireSCMTokenForOwner(ctx, "github", owner)
+	token, apiHost, err := p.credStore.AcquireSCMTokenForOwner(ctx, "github", teamID)
 	if err != nil {
-		log.Printf("poller: no GitHub credential for %s (owner %s): %v", repo, owner, err)
+		log.Printf("poller: no GitHub credential for %s (teamID %s): %v", repo, teamID, err)
 		return
 	}
 
@@ -500,7 +500,7 @@ func (p *GitHubPoller) pollRepo(ctx context.Context, repo, owner string, schedul
 			metaJSON, _ := json.Marshal(meta)
 			taskReq.Prompt = taskReq.Prompt + "\n\n" + enrichedContext + "\n\n[event: " + string(metaJSON) + "]"
 
-			_, err := p.dispatcher.DispatchTask(ctx, taskReq, sched.Owner)
+			_, err := p.dispatcher.DispatchTask(ctx, taskReq, "poller", sched.TeamID)
 			if err != nil {
 				log.Printf("poller: error dispatching schedule %s for %s: %v", sched.Name, eventRepo, err)
 				continue

--- a/internal/bridge/scheduler.go
+++ b/internal/bridge/scheduler.go
@@ -43,7 +43,7 @@ type Schedule struct {
 	LastRun     *time.Time `json:"last_run,omitempty"`
 	NextRun     *time.Time `json:"next_run,omitempty"`
 	CreatedAt   time.Time  `json:"created_at"`
-	Owner       string     `json:"owner,omitempty"`
+	TeamID      string     `json:"team_id,omitempty"`
 	Debug       bool          `json:"debug,omitempty"`
 	Source      string        `json:"source,omitempty"`
 	SourceKey   string        `json:"source_key,omitempty"`
@@ -308,7 +308,7 @@ func (s *Scheduler) tick(ctx context.Context) {
 	now := time.Now().UTC()
 
 	rows, err := s.db.Query(ctx, `
-		SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, last_run, next_run, created_at, owner, debug, source, source_key, trigger_type, event_config
+		SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, last_run, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config
 		FROM schedules
 		WHERE enabled = true AND next_run <= $1
 		  AND COALESCE(trigger_type, 'cron') IN ('cron', 'cron-and-event')
@@ -327,7 +327,7 @@ func (s *Scheduler) tick(ctx context.Context) {
 		if err := rows.Scan(
 			&sched.ID, &sched.Name, &sched.Cron, &sched.Prompt,
 			&sched.Repo, &sched.Provider, &sched.ScopePreset, &sched.Timeout,
-			&sched.Enabled, &sched.LastRun, &sched.NextRun, &sched.CreatedAt, &sched.Owner, &sched.Debug,
+			&sched.Enabled, &sched.LastRun, &sched.NextRun, &sched.CreatedAt, &sched.TeamID, &sched.Debug,
 			&source, &sourceKey, &triggerType, &eventConfigJSON,
 		); err != nil {
 			log.Printf("scheduler: error scanning schedule row: %v", err)
@@ -368,7 +368,7 @@ func (s *Scheduler) tick(ctx context.Context) {
 			TriggerType: "cron",
 		}
 
-		if _, err := s.dispatcher.DispatchTask(ctx, req, sched.Owner); err != nil {
+		if _, err := s.dispatcher.DispatchTask(ctx, req, "scheduler", sched.TeamID); err != nil {
 			log.Printf("scheduler: error dispatching schedule %s: %v", sched.ID, err)
 			continue
 		}
@@ -395,7 +395,7 @@ func (s *Scheduler) tick(ctx context.Context) {
 // CreateSchedule inserts a new schedule into the database. It generates a UUID
 // if sched.ID is empty, validates the cron expression, computes the initial
 // next_run, and sets created_at.
-func (s *Scheduler) CreateSchedule(ctx context.Context, sched *Schedule, owner string) error {
+func (s *Scheduler) CreateSchedule(ctx context.Context, sched *Schedule, teamID string) error {
 	if sched.ID == "" {
 		sched.ID = uuid.New().String()
 	}
@@ -411,7 +411,7 @@ func (s *Scheduler) CreateSchedule(ctx context.Context, sched *Schedule, owner s
 		// Event-only schedules don't need cron or next_run.
 		now := time.Now().UTC()
 		sched.CreatedAt = now
-		sched.Owner = owner
+		sched.TeamID = teamID
 	} else {
 		cronExpr, err := ParseCron(sched.Cron)
 		if err != nil {
@@ -420,7 +420,7 @@ func (s *Scheduler) CreateSchedule(ctx context.Context, sched *Schedule, owner s
 
 		now := time.Now().UTC()
 		sched.CreatedAt = now
-		sched.Owner = owner
+		sched.TeamID = teamID
 		nextRun := cronExpr.Next(now)
 		sched.NextRun = &nextRun
 	}
@@ -440,10 +440,10 @@ func (s *Scheduler) CreateSchedule(ctx context.Context, sched *Schedule, owner s
 	}
 
 	_, err := s.db.Exec(ctx, `
-		INSERT INTO schedules (id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, next_run, created_at, owner, debug, source, source_key, trigger_type, event_config)
+		INSERT INTO schedules (id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
 	`, sched.ID, sched.Name, sched.Cron, sched.Prompt, sched.Repo, sched.Provider,
-		sched.ScopePreset, sched.Timeout, sched.Enabled, sched.NextRun, sched.CreatedAt, owner, sched.Debug,
+		sched.ScopePreset, sched.Timeout, sched.Enabled, sched.NextRun, sched.CreatedAt, teamID, sched.Debug,
 		source, nilIfEmptySched(sched.SourceKey), triggerType, eventConfigJSON)
 	if err != nil {
 		return fmt.Errorf("inserting schedule: %w", err)
@@ -454,13 +454,13 @@ func (s *Scheduler) CreateSchedule(ctx context.Context, sched *Schedule, owner s
 
 // ListSchedules returns schedules from the database.
 // If owner is non-empty, only schedules belonging to that owner are returned.
-func (s *Scheduler) ListSchedules(ctx context.Context, owner string) ([]Schedule, error) {
-	query := `SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, last_run, next_run, created_at, owner, debug, source, source_key, trigger_type, event_config
+func (s *Scheduler) ListSchedules(ctx context.Context, teamID string) ([]Schedule, error) {
+	query := `SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, last_run, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config
 		FROM schedules`
 	args := []any{}
-	if owner != "" {
-		query += ` WHERE owner = $1`
-		args = append(args, owner)
+	if teamID != "" {
+		query += ` WHERE team_id = $1`
+		args = append(args, teamID)
 	}
 	query += ` ORDER BY created_at DESC`
 
@@ -478,7 +478,7 @@ func (s *Scheduler) ListSchedules(ctx context.Context, owner string) ([]Schedule
 		if err := rows.Scan(
 			&sched.ID, &sched.Name, &sched.Cron, &sched.Prompt,
 			&sched.Repo, &sched.Provider, &sched.ScopePreset, &sched.Timeout,
-			&sched.Enabled, &sched.LastRun, &sched.NextRun, &sched.CreatedAt, &sched.Owner, &sched.Debug,
+			&sched.Enabled, &sched.LastRun, &sched.NextRun, &sched.CreatedAt, &sched.TeamID, &sched.Debug,
 			&source, &sourceKey, &triggerType, &eventConfigJSON,
 		); err != nil {
 			return nil, fmt.Errorf("scanning schedule: %w", err)
@@ -509,13 +509,13 @@ func (s *Scheduler) ListSchedules(ctx context.Context, owner string) ([]Schedule
 
 // GetSchedule retrieves a single schedule by ID.
 // If owner is non-empty, only returns the schedule if it belongs to that owner.
-func (s *Scheduler) GetSchedule(ctx context.Context, id, owner string) (*Schedule, error) {
-	query := `SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, last_run, next_run, created_at, owner, debug, source, source_key, trigger_type, event_config
+func (s *Scheduler) GetSchedule(ctx context.Context, id, teamID string) (*Schedule, error) {
+	query := `SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, last_run, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config
 		FROM schedules WHERE id = $1`
 	args := []any{id}
-	if owner != "" {
-		query += ` AND owner = $2`
-		args = append(args, owner)
+	if teamID != "" {
+		query += ` AND team_id = $2`
+		args = append(args, teamID)
 	}
 
 	var sched Schedule
@@ -524,7 +524,7 @@ func (s *Scheduler) GetSchedule(ctx context.Context, id, owner string) (*Schedul
 	err := s.db.QueryRow(ctx, query, args...).Scan(
 		&sched.ID, &sched.Name, &sched.Cron, &sched.Prompt,
 		&sched.Repo, &sched.Provider, &sched.ScopePreset, &sched.Timeout,
-		&sched.Enabled, &sched.LastRun, &sched.NextRun, &sched.CreatedAt, &sched.Owner, &sched.Debug,
+		&sched.Enabled, &sched.LastRun, &sched.NextRun, &sched.CreatedAt, &sched.TeamID, &sched.Debug,
 		&source, &sourceKey, &triggerType, &eventConfigJSON,
 	)
 	if err != nil {
@@ -551,7 +551,7 @@ func (s *Scheduler) GetSchedule(ctx context.Context, id, owner string) (*Schedul
 // UpdateSchedule updates an existing schedule in the database. If the cron
 // expression has changed, it recomputes next_run.
 // If owner is non-empty, only updates the schedule if it belongs to that owner.
-func (s *Scheduler) UpdateSchedule(ctx context.Context, sched *Schedule, owner string) error {
+func (s *Scheduler) UpdateSchedule(ctx context.Context, sched *Schedule, teamID string) error {
 	triggerType := sched.TriggerType
 	if triggerType == "" {
 		triggerType = "cron"
@@ -585,9 +585,9 @@ func (s *Scheduler) UpdateSchedule(ctx context.Context, sched *Schedule, owner s
 	args := []any{sched.Name, sched.Cron, sched.Prompt, sched.Repo, sched.Provider,
 		sched.ScopePreset, sched.Timeout, sched.Enabled, sched.NextRun, sched.Debug,
 		triggerType, eventConfigJSON, sched.ID}
-	if owner != "" {
-		query += ` AND owner = $14`
-		args = append(args, owner)
+	if teamID != "" {
+		query += ` AND team_id = $14`
+		args = append(args, teamID)
 	}
 
 	_, err := s.db.Exec(ctx, query, args...)
@@ -600,12 +600,12 @@ func (s *Scheduler) UpdateSchedule(ctx context.Context, sched *Schedule, owner s
 
 // DeleteSchedule removes a schedule from the database.
 // If owner is non-empty, only deletes the schedule if it belongs to that owner.
-func (s *Scheduler) DeleteSchedule(ctx context.Context, id, owner string) error {
+func (s *Scheduler) DeleteSchedule(ctx context.Context, id, teamID string) error {
 	query := `DELETE FROM schedules WHERE id = $1`
 	args := []any{id}
-	if owner != "" {
-		query += ` AND owner = $2`
-		args = append(args, owner)
+	if teamID != "" {
+		query += ` AND team_id = $2`
+		args = append(args, teamID)
 	}
 
 	_, err := s.db.Exec(ctx, query, args...)
@@ -618,10 +618,10 @@ func (s *Scheduler) DeleteSchedule(ctx context.Context, id, owner string) error 
 // EnableSchedule sets the enabled flag for a schedule. When enabling, it
 // recomputes next_run from the current time.
 // If owner is non-empty, only updates the schedule if it belongs to that owner.
-func (s *Scheduler) EnableSchedule(ctx context.Context, id string, enabled bool, owner string) error {
+func (s *Scheduler) EnableSchedule(ctx context.Context, id string, enabled bool, teamID string) error {
 	if enabled {
 		// Recompute next_run when enabling (only for cron-based schedules).
-		sched, err := s.GetSchedule(ctx, id, owner)
+		sched, err := s.GetSchedule(ctx, id, teamID)
 		if err != nil {
 			return err
 		}
@@ -630,9 +630,9 @@ func (s *Scheduler) EnableSchedule(ctx context.Context, id string, enabled bool,
 		if sched.TriggerType == "event" {
 			query := `UPDATE schedules SET enabled = $1 WHERE id = $2`
 			args := []any{enabled, id}
-			if owner != "" {
-				query += ` AND owner = $3`
-				args = append(args, owner)
+			if teamID != "" {
+				query += ` AND team_id = $3`
+				args = append(args, teamID)
 			}
 			_, err = s.db.Exec(ctx, query, args...)
 			if err != nil {
@@ -649,9 +649,9 @@ func (s *Scheduler) EnableSchedule(ctx context.Context, id string, enabled bool,
 		nextRun := cronExpr.Next(now)
 		query := `UPDATE schedules SET enabled = $1, next_run = $2 WHERE id = $3`
 		args := []any{enabled, nextRun, id}
-		if owner != "" {
-			query += ` AND owner = $4`
-			args = append(args, owner)
+		if teamID != "" {
+			query += ` AND team_id = $4`
+			args = append(args, teamID)
 		}
 		_, err = s.db.Exec(ctx, query, args...)
 		if err != nil {
@@ -662,9 +662,9 @@ func (s *Scheduler) EnableSchedule(ctx context.Context, id string, enabled bool,
 
 	query := `UPDATE schedules SET enabled = $1 WHERE id = $2`
 	args := []any{enabled, id}
-	if owner != "" {
-		query += ` AND owner = $3`
-		args = append(args, owner)
+	if teamID != "" {
+		query += ` AND team_id = $3`
+		args = append(args, teamID)
 	}
 	_, err := s.db.Exec(ctx, query, args...)
 	if err != nil {

--- a/internal/bridge/security.go
+++ b/internal/bridge/security.go
@@ -34,7 +34,7 @@ type SecurityProfile struct {
 	DisplayName string                       `json:"display_name,omitempty" yaml:"display_name"`
 	Description string                       `json:"description,omitempty" yaml:"description"`
 	Tools       map[string]ProfileToolConfig `json:"tools" yaml:"tools"`
-	Owner       string                       `json:"owner,omitempty"`
+	TeamID      string                       `json:"team_id,omitempty"`
 	IsBuiltin   bool                         `json:"is_builtin"`
 	Source      string                       `json:"source"`
 	SourceRepo  string                       `json:"source_repo,omitempty"`
@@ -113,13 +113,13 @@ func NewProfileStore(db *pgxpool.Pool) *ProfileStore {
 	return &ProfileStore{db: db}
 }
 
-// CreateProfile inserts a new security profile owned by the given owner.
-func (ps *ProfileStore) CreateProfile(ctx context.Context, profile *SecurityProfile, owner string) error {
+// CreateProfile inserts a new security profile for the given team.
+func (ps *ProfileStore) CreateProfile(ctx context.Context, profile *SecurityProfile, teamID string) error {
 	if profile.ID == "" {
 		profile.ID = uuid.New().String()
 	}
 	now := time.Now().UTC()
-	profile.Owner = owner
+	profile.TeamID = teamID
 	profile.IsBuiltin = false
 	profile.CreatedAt = now
 	profile.UpdatedAt = now
@@ -130,10 +130,10 @@ func (ps *ProfileStore) CreateProfile(ctx context.Context, profile *SecurityProf
 	}
 
 	_, err = ps.db.Exec(ctx,
-		`INSERT INTO security_profiles (id, name, display_name, description, tools, owner, is_builtin, created_at, updated_at)
+		`INSERT INTO security_profiles (id, name, display_name, description, tools, team_id, is_builtin, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
 		profile.ID, profile.Name, profile.DisplayName, profile.Description,
-		string(toolsJSON), profile.Owner, profile.IsBuiltin,
+		string(toolsJSON), profile.TeamID, profile.IsBuiltin,
 		profile.CreatedAt, profile.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("inserting profile: %w", err)
@@ -141,14 +141,14 @@ func (ps *ProfileStore) CreateProfile(ctx context.Context, profile *SecurityProf
 	return nil
 }
 
-// ListProfiles returns the given owner's profiles.
-func (ps *ProfileStore) ListProfiles(ctx context.Context, owner string) ([]SecurityProfile, error) {
-	query := `SELECT id, name, display_name, description, tools, owner, is_builtin, source, source_repo, source_key, created_at, updated_at
+// ListProfiles returns the given team's profiles.
+func (ps *ProfileStore) ListProfiles(ctx context.Context, teamID string) ([]SecurityProfile, error) {
+	query := `SELECT id, name, display_name, description, tools, team_id, is_builtin, source, source_repo, source_key, created_at, updated_at
 		FROM security_profiles
-		WHERE owner = $1
+		WHERE team_id = $1
 		ORDER BY name ASC`
 
-	rows, err := ps.db.Query(ctx, query, owner)
+	rows, err := ps.db.Query(ctx, query, teamID)
 	if err != nil {
 		return nil, fmt.Errorf("querying profiles: %w", err)
 	}
@@ -170,20 +170,20 @@ func (ps *ProfileStore) ListProfiles(ctx context.Context, owner string) ([]Secur
 	return profiles, rows.Err()
 }
 
-// GetProfile looks up a profile by name, scoped to the given owner.
-func (ps *ProfileStore) GetProfile(ctx context.Context, name, owner string) (*SecurityProfile, error) {
-	query := `SELECT id, name, display_name, description, tools, owner, is_builtin, source, source_repo, source_key, created_at, updated_at
+// GetProfile looks up a profile by name, scoped to the given team.
+func (ps *ProfileStore) GetProfile(ctx context.Context, name, teamID string) (*SecurityProfile, error) {
+	query := `SELECT id, name, display_name, description, tools, team_id, is_builtin, source, source_repo, source_key, created_at, updated_at
 		FROM security_profiles
-		WHERE name = $1 AND owner = $2
+		WHERE name = $1 AND team_id = $2
 		ORDER BY source ASC
 		LIMIT 1`
 
-	row := ps.db.QueryRow(ctx, query, name, owner)
+	row := ps.db.QueryRow(ctx, query, name, teamID)
 	return scanProfileRow(row)
 }
 
 // UpdateProfile updates an existing profile. YAML-sourced profiles cannot be updated.
-func (ps *ProfileStore) UpdateProfile(ctx context.Context, profile *SecurityProfile, owner string) error {
+func (ps *ProfileStore) UpdateProfile(ctx context.Context, profile *SecurityProfile, teamID string) error {
 	toolsJSON, err := json.Marshal(profile.Tools)
 	if err != nil {
 		return fmt.Errorf("marshaling tools: %w", err)
@@ -193,9 +193,9 @@ func (ps *ProfileStore) UpdateProfile(ctx context.Context, profile *SecurityProf
 	result, err := ps.db.Exec(ctx,
 		`UPDATE security_profiles
 		SET display_name = $1, description = $2, tools = $3, updated_at = $4
-		WHERE name = $5 AND owner = $6 AND source != 'yaml'`,
+		WHERE name = $5 AND team_id = $6 AND source != 'yaml'`,
 		profile.DisplayName, profile.Description, string(toolsJSON), now,
-		profile.Name, owner)
+		profile.Name, teamID)
 	if err != nil {
 		return fmt.Errorf("updating profile: %w", err)
 	}
@@ -207,10 +207,10 @@ func (ps *ProfileStore) UpdateProfile(ctx context.Context, profile *SecurityProf
 }
 
 // DeleteProfile removes a profile. YAML-sourced profiles cannot be deleted.
-func (ps *ProfileStore) DeleteProfile(ctx context.Context, name, owner string) error {
+func (ps *ProfileStore) DeleteProfile(ctx context.Context, name, teamID string) error {
 	result, err := ps.db.Exec(ctx,
-		`DELETE FROM security_profiles WHERE name = $1 AND owner = $2 AND source != 'yaml'`,
-		name, owner)
+		`DELETE FROM security_profiles WHERE name = $1 AND team_id = $2 AND source != 'yaml'`,
+		name, teamID)
 	if err != nil {
 		return fmt.Errorf("deleting profile: %w", err)
 	}
@@ -222,12 +222,12 @@ func (ps *ProfileStore) DeleteProfile(ctx context.Context, name, owner string) e
 
 // MergeProfiles takes multiple profile names, looks them up, and returns a merged Scope
 // and merged tool config map. Union merge: operations unioned, repos unioned, wildcard wins.
-func (ps *ProfileStore) MergeProfiles(ctx context.Context, names []string, owner string) (internal.Scope, map[string]ProfileToolConfig, error) {
+func (ps *ProfileStore) MergeProfiles(ctx context.Context, names []string, teamID string) (internal.Scope, map[string]ProfileToolConfig, error) {
 	scope := internal.Scope{Services: make(map[string]internal.ServiceScope)}
 	merged := make(map[string]ProfileToolConfig)
 
 	for _, name := range names {
-		profile, err := ps.GetProfile(ctx, name, owner)
+		profile, err := ps.GetProfile(ctx, name, teamID)
 		if err != nil {
 			return scope, nil, fmt.Errorf("profile %q not found: %w", name, err)
 		}
@@ -286,7 +286,7 @@ func scanProfile(rows interface{ Scan(dest ...any) error }) (*SecurityProfile, e
 	var toolsJSON string
 
 	if err := rows.Scan(&p.ID, &p.Name, &p.DisplayName, &p.Description,
-		&toolsJSON, &p.Owner, &p.IsBuiltin, &p.Source, &p.SourceRepo, &p.SourceKey,
+		&toolsJSON, &p.TeamID, &p.IsBuiltin, &p.Source, &p.SourceRepo, &p.SourceKey,
 		&p.CreatedAt, &p.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("scanning profile: %w", err)
 	}
@@ -329,35 +329,35 @@ func (ps *ProfileStore) UpsertYAMLProfile(ctx context.Context, profile *Security
 	}
 
 	_, err = ps.db.Exec(ctx,
-		`INSERT INTO security_profiles (id, name, display_name, description, tools, owner, is_builtin, source, source_repo, source_key, created_at, updated_at)
+		`INSERT INTO security_profiles (id, name, display_name, description, tools, team_id, is_builtin, source, source_repo, source_key, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, false, 'yaml', $7, $8, NOW(), NOW())
 		ON CONFLICT (source_key) WHERE source_key != '' DO UPDATE SET
 			name = EXCLUDED.name,
 			display_name = EXCLUDED.display_name,
 			description = EXCLUDED.description,
 			tools = EXCLUDED.tools,
-			owner = EXCLUDED.owner,
+			team_id = EXCLUDED.team_id,
 			source_repo = EXCLUDED.source_repo,
 			updated_at = NOW()`,
 		profile.ID, profile.Name, profile.DisplayName, profile.Description,
-		string(toolsJSON), profile.Owner, profile.SourceRepo, profile.SourceKey)
+		string(toolsJSON), profile.TeamID, profile.SourceRepo, profile.SourceKey)
 	if err != nil {
 		return fmt.Errorf("upserting YAML profile: %w", err)
 	}
 	return nil
 }
 
-// DeleteYAMLProfilesByRepo removes all YAML-sourced profiles from the given repo and owner.
-func (ps *ProfileStore) DeleteYAMLProfilesByRepo(ctx context.Context, repoURL, owner string) error {
+// DeleteYAMLProfilesByRepo removes all YAML-sourced profiles from the given repo and team.
+func (ps *ProfileStore) DeleteYAMLProfilesByRepo(ctx context.Context, repoURL, teamID string) error {
 	_, err := ps.db.Exec(ctx,
-		`DELETE FROM security_profiles WHERE source = 'yaml' AND source_repo = $1 AND owner = $2`, repoURL, owner)
+		`DELETE FROM security_profiles WHERE source = 'yaml' AND source_repo = $1 AND team_id = $2`, repoURL, teamID)
 	return err
 }
 
-// ListYAMLProfileKeysByRepo returns source_keys for all YAML profiles from the given repo and owner.
-func (ps *ProfileStore) ListYAMLProfileKeysByRepo(ctx context.Context, repoURL, owner string) ([]string, error) {
+// ListYAMLProfileKeysByRepo returns source_keys for all YAML profiles from the given repo and team.
+func (ps *ProfileStore) ListYAMLProfileKeysByRepo(ctx context.Context, repoURL, teamID string) ([]string, error) {
 	rows, err := ps.db.Query(ctx,
-		`SELECT source_key FROM security_profiles WHERE source = 'yaml' AND source_repo = $1 AND owner = $2`, repoURL, owner)
+		`SELECT source_key FROM security_profiles WHERE source = 'yaml' AND source_repo = $1 AND team_id = $2`, repoURL, teamID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/bridge/taskdef.go
+++ b/internal/bridge/taskdef.go
@@ -67,7 +67,7 @@ type TaskDefinition struct {
 	CIGate      *CIGate               `json:"ci_gate,omitempty" yaml:"ci_gate"`
 
 	// Metadata (not from YAML).
-	Owner        string     `json:"owner,omitempty"`
+	TeamID       string     `json:"team_id,omitempty"`
 	SourceRepo   string     `json:"source_repo"`
 	SourceFile   string     `json:"source_file"`
 	SourceKey    string     `json:"source_key"`
@@ -155,8 +155,8 @@ func NewAgentDefStore(db *pgxpool.Pool) *AgentDefStore {
 	return &AgentDefStore{db: db}
 }
 
-// ListAgentDefinitions returns agent definitions owned by the given user, with parsed data and schedule info.
-func (s *AgentDefStore) ListAgentDefinitions(ctx context.Context, owner string) ([]TaskDefinition, error) {
+// ListAgentDefinitions returns agent definitions for the given team, with parsed data and schedule info.
+func (s *AgentDefStore) ListAgentDefinitions(ctx context.Context, teamID string) ([]TaskDefinition, error) {
 	rows, err := s.db.Query(ctx, `
 		SELECT td.id, td.name, td.description, td.source_repo, td.source_file, td.source_key,
 		       td.parsed, td.has_schedule, td.sync_error, td.last_synced,
@@ -164,9 +164,9 @@ func (s *AgentDefStore) ListAgentDefinitions(ctx context.Context, owner string) 
 		       s.next_run, s.last_run
 		FROM agent_definitions td
 		LEFT JOIN schedules s ON s.source_key = td.source_key AND s.source = 'yaml'
-		WHERE td.owner = $1
+		WHERE td.team_id = $1
 		ORDER BY td.name ASC
-	`, owner)
+	`, teamID)
 	if err != nil {
 		return nil, fmt.Errorf("querying agent definitions: %w", err)
 	}
@@ -218,8 +218,8 @@ func (s *AgentDefStore) ListAgentDefinitions(ctx context.Context, owner string) 
 	return defs, nil
 }
 
-// GetAgentDefinition retrieves a single agent definition by ID, scoped to the given owner.
-func (s *AgentDefStore) GetAgentDefinition(ctx context.Context, id, owner string) (*TaskDefinition, error) {
+// GetAgentDefinition retrieves a single agent definition by ID, scoped to the given team.
+func (s *AgentDefStore) GetAgentDefinition(ctx context.Context, id, teamID string) (*TaskDefinition, error) {
 	var td TaskDefinition
 	var parsedJSON []byte
 	var syncError *string
@@ -233,8 +233,8 @@ func (s *AgentDefStore) GetAgentDefinition(ctx context.Context, id, owner string
 		       s.next_run, s.last_run
 		FROM agent_definitions td
 		LEFT JOIN schedules s ON s.source_key = td.source_key AND s.source = 'yaml'
-		WHERE td.id = $1 AND td.owner = $2
-	`, id, owner).Scan(
+		WHERE td.id = $1 AND td.team_id = $2
+	`, id, teamID).Scan(
 		&td.ID, &td.Name, &td.Description, &td.SourceRepo, &td.SourceFile,
 		&td.SourceKey, &td.RawYAML, &parsedJSON, &hasSchedule, &syncError,
 		&td.LastSynced, &createdAt, &updatedAt,
@@ -288,9 +288,9 @@ func (s *AgentDefStore) UpsertAgentDefinition(ctx context.Context, def *TaskDefi
 
 	_, err = s.db.Exec(ctx, `
 		INSERT INTO agent_definitions (id, name, description, source_repo, source_file,
-		    source_key, raw_yaml, parsed, has_schedule, sync_error, last_synced, owner, created_at, updated_at)
+		    source_key, raw_yaml, parsed, has_schedule, sync_error, last_synced, team_id, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-		ON CONFLICT (source_key) DO UPDATE SET
+		ON CONFLICT (source_key, team_id) DO UPDATE SET
 		    name = EXCLUDED.name,
 		    description = EXCLUDED.description,
 		    source_repo = EXCLUDED.source_repo,
@@ -300,11 +300,11 @@ func (s *AgentDefStore) UpsertAgentDefinition(ctx context.Context, def *TaskDefi
 		    has_schedule = EXCLUDED.has_schedule,
 		    sync_error = EXCLUDED.sync_error,
 		    last_synced = EXCLUDED.last_synced,
-		    owner = EXCLUDED.owner,
+		    team_id = EXCLUDED.team_id,
 		    updated_at = EXCLUDED.updated_at
 	`, def.ID, def.Name, def.Description, def.SourceRepo, def.SourceFile,
 		def.SourceKey, def.RawYAML, parsedJSON, hasSchedule, nilIfEmpty(def.SyncError),
-		now, def.Owner, now, now,
+		now, def.TeamID, now, now,
 	)
 	if err != nil {
 		return fmt.Errorf("upserting agent definition: %w", err)
@@ -313,23 +313,23 @@ func (s *AgentDefStore) UpsertAgentDefinition(ctx context.Context, def *TaskDefi
 	return nil
 }
 
-// DeleteAgentDefinitionsByRepo removes all agent definitions from a given repo URL and owner.
-func (s *AgentDefStore) DeleteAgentDefinitionsByRepo(ctx context.Context, repoURL, owner string) error {
-	_, err := s.db.Exec(ctx, `DELETE FROM agent_definitions WHERE source_repo = $1 AND owner = $2`, repoURL, owner)
+// DeleteAgentDefinitionsByRepo removes all agent definitions from a given repo URL and team.
+func (s *AgentDefStore) DeleteAgentDefinitionsByRepo(ctx context.Context, repoURL, teamID string) error {
+	_, err := s.db.Exec(ctx, `DELETE FROM agent_definitions WHERE source_repo = $1 AND team_id = $2`, repoURL, teamID)
 	if err != nil {
 		return fmt.Errorf("deleting agent definitions for repo %s: %w", repoURL, err)
 	}
 	return nil
 }
 
-// ListAgentDefinitionsByRepo returns all agent definitions from a given repo URL and owner.
-func (s *AgentDefStore) ListAgentDefinitionsByRepo(ctx context.Context, repoURL, owner string) ([]TaskDefinition, error) {
+// ListAgentDefinitionsByRepo returns all agent definitions from a given repo URL and team.
+func (s *AgentDefStore) ListAgentDefinitionsByRepo(ctx context.Context, repoURL, teamID string) ([]TaskDefinition, error) {
 	rows, err := s.db.Query(ctx, `
 		SELECT id, name, description, source_repo, source_file, source_key,
 		       has_schedule, sync_error, last_synced, created_at, updated_at, parsed
-		FROM agent_definitions WHERE source_repo = $1 AND owner = $2
+		FROM agent_definitions WHERE source_repo = $1 AND team_id = $2
 		ORDER BY name ASC
-	`, repoURL, owner)
+	`, repoURL, teamID)
 	if err != nil {
 		return nil, fmt.Errorf("querying agent definitions for repo %s: %w", repoURL, err)
 	}

--- a/internal/bridge/tasksync.go
+++ b/internal/bridge/tasksync.go
@@ -103,14 +103,29 @@ func (s *AgentRepoSyncer) Stop() {
 	s.wg.Wait()
 }
 
+// resolveUsernameToTeamID looks up the personal team ID for a username.
+func (s *AgentRepoSyncer) resolveUsernameToTeamID(ctx context.Context, username string) string {
+	var teamID string
+	err := s.db.QueryRow(ctx, `
+		SELECT t.id FROM teams t
+		JOIN team_members tm ON t.id = tm.team_id
+		WHERE tm.username = $1 AND t.is_personal = true
+	`, username).Scan(&teamID)
+	if err != nil {
+		return ""
+	}
+	return teamID
+}
+
 // SyncAll collects all user agent repos and syncs each per-user.
 func (s *AgentRepoSyncer) SyncAll(ctx context.Context) error {
 	s.syncMu.Lock()
 	defer s.syncMu.Unlock()
 
-	// Collect per-user agent repos.
+	// Collect per-user agent repos from team_settings (new) and user_settings (legacy).
 	type userRepoSet struct {
 		username string
+		teamID   string
 		repos    []SkillRepo
 	}
 	var userRepoSets []userRepoSet
@@ -118,6 +133,39 @@ func (s *AgentRepoSyncer) SyncAll(ctx context.Context) error {
 
 	// Collect all users who have agent_repos configured (even if empty — they may need cleanup).
 	allUsersWithRepos := make(map[string][]SkillRepo)
+	// Build a username -> teamID map for later use.
+	usernameToTeamID := make(map[string]string)
+
+	// First, check team_settings for agent_repos (new path).
+	teamRows, teamErr := s.db.Query(ctx, `
+		SELECT tm.username, ts.team_id, ts.value
+		FROM team_settings ts
+		JOIN team_members tm ON ts.team_id = tm.team_id
+		JOIN teams t ON ts.team_id = t.id AND t.is_personal = true
+		WHERE ts.key = 'agent_repos'
+	`)
+	if teamErr == nil {
+		defer teamRows.Close()
+		for teamRows.Next() {
+			var username, teamID string
+			var value json.RawMessage
+			if err := teamRows.Scan(&username, &teamID, &value); err != nil {
+				continue
+			}
+			var repos []SkillRepo
+			if json.Unmarshal(value, &repos) != nil {
+				continue
+			}
+			allUsersWithRepos[username] = repos
+			usernameToTeamID[username] = teamID
+			if len(repos) > 0 {
+				userRepoSets = append(userRepoSets, userRepoSet{username: username, teamID: teamID, repos: repos})
+				totalRepos += len(repos)
+			}
+		}
+	}
+
+	// Fallback: also check user_settings for users not yet migrated.
 	rows, err := s.db.Query(ctx, `SELECT DISTINCT username FROM user_settings WHERE key = 'agent_repos'`)
 	if err == nil {
 		defer rows.Close()
@@ -126,10 +174,16 @@ func (s *AgentRepoSyncer) SyncAll(ctx context.Context) error {
 			if err := rows.Scan(&username); err != nil {
 				continue
 			}
+			// Skip users already handled via team_settings.
+			if _, handled := usernameToTeamID[username]; handled {
+				continue
+			}
 			if userRepos, err := s.settingsStore.GetUserAgentRepos(ctx, username); err == nil {
+				teamID := s.resolveUsernameToTeamID(ctx, username)
 				allUsersWithRepos[username] = userRepos
+				usernameToTeamID[username] = teamID
 				if len(userRepos) > 0 {
-					userRepoSets = append(userRepoSets, userRepoSet{username: username, repos: userRepos})
+					userRepoSets = append(userRepoSets, userRepoSet{username: username, teamID: teamID, repos: userRepos})
 					totalRepos += len(userRepos)
 				}
 			}
@@ -138,21 +192,25 @@ func (s *AgentRepoSyncer) SyncAll(ctx context.Context) error {
 
 	// Per-user cleanup: remove definitions/profiles for repos the user no longer has configured.
 	for username, repos := range allUsersWithRepos {
+		teamID := usernameToTeamID[username]
+		if teamID == "" {
+			continue
+		}
 		configuredURLs := make(map[string]bool)
 		for _, repo := range repos {
 			configuredURLs[repo.URL] = true
 		}
-		userDefs, err := s.defStore.ListAgentDefinitions(ctx, username)
+		userDefs, err := s.defStore.ListAgentDefinitions(ctx, teamID)
 		if err == nil {
 			removedRepos := make(map[string]bool)
 			for _, def := range userDefs {
 				if !configuredURLs[def.SourceRepo] && !removedRepos[def.SourceRepo] {
 					log.Printf("agent-repo-syncer: removing agent definitions, workflows, and profiles from %s for user %s (no longer configured)", def.SourceRepo, username)
-					_ = s.defStore.DeleteAgentDefinitionsByRepo(ctx, def.SourceRepo, username)
-					_ = s.profileStore.DeleteYAMLProfilesByRepo(ctx, def.SourceRepo, username)
-					_ = s.workflowStore.DeleteWorkflowsByRepo(ctx, def.SourceRepo, username)
+					_ = s.defStore.DeleteAgentDefinitionsByRepo(ctx, def.SourceRepo, teamID)
+					_ = s.profileStore.DeleteYAMLProfilesByRepo(ctx, def.SourceRepo, teamID)
+					_ = s.workflowStore.DeleteWorkflowsByRepo(ctx, def.SourceRepo, teamID)
 					// Also clean up schedules from this repo.
-					s.db.Exec(ctx, `DELETE FROM schedules WHERE source_key LIKE $1 AND owner = $2`, username+"::%", username)
+					s.db.Exec(ctx, `DELETE FROM schedules WHERE source_key LIKE $1 AND team_id = $2`, username+"::%", teamID)
 					removedRepos[def.SourceRepo] = true
 				}
 			}
@@ -167,6 +225,9 @@ func (s *AgentRepoSyncer) SyncAll(ctx context.Context) error {
 
 	var errs []string
 	for _, urs := range userRepoSets {
+		if urs.teamID == "" {
+			continue // Skip users without a team
+		}
 		for _, repo := range urs.repos {
 			if !repo.IsEnabled() {
 				// Repo is disabled — disable all its schedules but don't remove them.
@@ -177,7 +238,7 @@ func (s *AgentRepoSyncer) SyncAll(ctx context.Context) error {
 				log.Printf("agent-repo-syncer: repo %s disabled for user %s, schedules paused", repo.URL, urs.username)
 				continue
 			}
-			if err := s.syncRepo(ctx, repo, urs.username); err != nil {
+			if err := s.syncRepo(ctx, repo, urs.username, urs.teamID); err != nil {
 				errs = append(errs, fmt.Sprintf("%s (user %s): %v", repo.URL, urs.username, err))
 			}
 		}
@@ -189,8 +250,8 @@ func (s *AgentRepoSyncer) SyncAll(ctx context.Context) error {
 	return nil
 }
 
-// syncRepo clones or pulls a single repo and syncs its agent definitions for the given user.
-func (s *AgentRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username string) error {
+// syncRepo clones or pulls a single repo and syncs its agent definitions for the given user and team.
+func (s *AgentRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username, teamID string) error {
 	// Determine local clone directory.
 	name := repo.Name
 	if name == "" {
@@ -233,7 +294,7 @@ func (s *AgentRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username
 	}
 
 	// Sync security profiles from .alcove/security-profiles/*.yml.
-	s.syncSecurityProfiles(ctx, cloneDir, repo, username)
+	s.syncSecurityProfiles(ctx, cloneDir, repo, username, teamID)
 
 	// Read all .alcove/tasks/*.yml files.
 	tasksDir := filepath.Join(cloneDir, ".alcove", "tasks")
@@ -242,7 +303,7 @@ func (s *AgentRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username
 		if os.IsNotExist(err) {
 			log.Printf("agent-repo-syncer: no .alcove/tasks/ directory in %s", repo.URL)
 			// Remove any previously synced definitions from this repo.
-			return s.defStore.DeleteAgentDefinitionsByRepo(ctx, repo.URL, username)
+			return s.defStore.DeleteAgentDefinitionsByRepo(ctx, repo.URL, teamID)
 		}
 		return fmt.Errorf("reading agent definitions dir: %w", err)
 	}
@@ -277,7 +338,7 @@ func (s *AgentRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username
 				SourceKey:  sourceKey,
 				RawYAML:    string(data),
 				SyncError:  err.Error(),
-				Owner:      username,
+				TeamID:      teamID,
 			}
 			_ = s.defStore.UpsertAgentDefinition(ctx, errDef)
 			continue
@@ -287,7 +348,7 @@ func (s *AgentRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username
 		td.SourceFile = entry.Name()
 		td.SourceKey = sourceKey
 		td.RawYAML = string(data)
-		td.Owner = username
+		td.TeamID = teamID
 
 		if err := s.defStore.UpsertAgentDefinition(ctx, td); err != nil {
 			log.Printf("agent-repo-syncer: upsert error for %s: %v", sourceKey, err)
@@ -295,13 +356,13 @@ func (s *AgentRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username
 		}
 
 		// Reconcile schedule.
-		if err := s.reconcileSchedule(ctx, td, repo.URL, username); err != nil {
+		if err := s.reconcileSchedule(ctx, td, repo.URL, username, teamID); err != nil {
 			log.Printf("agent-repo-syncer: schedule reconcile error for %s: %v", sourceKey, err)
 		}
 	}
 
 	// Delete definitions that no longer exist in the repo.
-	existing, err := s.defStore.ListAgentDefinitionsByRepo(ctx, repo.URL, username)
+	existing, err := s.defStore.ListAgentDefinitionsByRepo(ctx, repo.URL, teamID)
 	if err != nil {
 		return fmt.Errorf("listing existing definitions: %w", err)
 	}
@@ -320,18 +381,18 @@ func (s *AgentRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username
 	log.Printf("agent-repo-syncer: synced %d agent definition(s) from %s", len(seenKeys), repo.URL)
 
 	// Sync workflow definitions from .alcove/workflows/*.yml.
-	if err := s.syncWorkflowDefinitions(ctx, cloneDir, repo, username); err != nil {
+	if err := s.syncWorkflowDefinitions(ctx, cloneDir, repo, username, teamID); err != nil {
 		log.Printf("agent-repo-syncer: workflow sync error for %s: %v", repo.URL, err)
 	}
 
 	// Validate profile references in agent definitions.
-	s.validateProfileReferences(ctx, repo.URL, username)
+	s.validateProfileReferences(ctx, repo.URL, teamID)
 
 	return nil
 }
 
 // syncSecurityProfiles syncs .alcove/security-profiles/*.yml from a cloned repo for the given user.
-func (s *AgentRepoSyncer) syncSecurityProfiles(ctx context.Context, cloneDir string, repo SkillRepo, username string) {
+func (s *AgentRepoSyncer) syncSecurityProfiles(ctx context.Context, cloneDir string, repo SkillRepo, username, teamID string) {
 	profilesDir := filepath.Join(cloneDir, ".alcove", "security-profiles")
 	entries, err := os.ReadDir(profilesDir)
 	if err != nil {
@@ -339,7 +400,7 @@ func (s *AgentRepoSyncer) syncSecurityProfiles(ctx context.Context, cloneDir str
 			log.Printf("agent-repo-syncer: error reading security-profiles dir: %v", err)
 		}
 		// No profiles dir — clean up any previously synced profiles from this repo.
-		_ = s.profileStore.DeleteYAMLProfilesByRepo(ctx, repo.URL, username)
+		_ = s.profileStore.DeleteYAMLProfilesByRepo(ctx, repo.URL, teamID)
 		return
 	}
 
@@ -369,7 +430,7 @@ func (s *AgentRepoSyncer) syncSecurityProfiles(ctx context.Context, cloneDir str
 		profile.Source = "yaml"
 		profile.SourceRepo = repo.URL
 		profile.SourceKey = sourceKey
-		profile.Owner = username
+		profile.TeamID = teamID
 
 		if err := s.profileStore.UpsertYAMLProfile(ctx, profile); err != nil {
 			log.Printf("agent-repo-syncer: profile upsert error for %s: %v", sourceKey, err)
@@ -377,7 +438,7 @@ func (s *AgentRepoSyncer) syncSecurityProfiles(ctx context.Context, cloneDir str
 	}
 
 	// Delete stale YAML profiles from this repo.
-	existingKeys, err := s.profileStore.ListYAMLProfileKeysByRepo(ctx, repo.URL, username)
+	existingKeys, err := s.profileStore.ListYAMLProfileKeysByRepo(ctx, repo.URL, teamID)
 	if err != nil {
 		log.Printf("agent-repo-syncer: error listing existing profile keys: %v", err)
 		return
@@ -396,15 +457,15 @@ func (s *AgentRepoSyncer) syncSecurityProfiles(ctx context.Context, cloneDir str
 // validateProfileReferences checks that all profile references in agent definitions
 // from the given repo resolve to known profiles. Sets sync_error on definitions
 // with unknown profile references.
-func (s *AgentRepoSyncer) validateProfileReferences(ctx context.Context, repoURL string, username string) {
-	defs, err := s.defStore.ListAgentDefinitionsByRepo(ctx, repoURL, username)
+func (s *AgentRepoSyncer) validateProfileReferences(ctx context.Context, repoURL string, teamID string) {
+	defs, err := s.defStore.ListAgentDefinitionsByRepo(ctx, repoURL, teamID)
 	if err != nil {
 		log.Printf("agent-repo-syncer: error listing definitions for validation: %v", err)
 		return
 	}
 
 	for _, def := range defs {
-		def.Owner = username // Ensure owner is set for any upserts below.
+		def.TeamID = teamID // Ensure team_id is set for any upserts below.
 		if def.SyncError != "" && !strings.HasPrefix(def.SyncError, "unknown security profile:") {
 			// Definition has a parse error (not a profile error) — skip validation.
 			continue
@@ -421,7 +482,7 @@ func (s *AgentRepoSyncer) validateProfileReferences(ctx context.Context, repoURL
 		// Check each referenced profile.
 		var missing []string
 		for _, profileName := range def.Profiles {
-			if _, err := s.profileStore.GetProfile(ctx, profileName, username); err != nil {
+			if _, err := s.profileStore.GetProfile(ctx, profileName, teamID); err != nil {
 				missing = append(missing, profileName)
 			}
 		}
@@ -489,7 +550,7 @@ func (s *AgentRepoSyncer) ValidateRepo(ctx context.Context, repo SkillRepo) ([]s
 }
 
 // reconcileSchedule creates, updates, or removes a schedule for an agent definition.
-func (s *AgentRepoSyncer) reconcileSchedule(ctx context.Context, td *TaskDefinition, repoURL string, username string) error {
+func (s *AgentRepoSyncer) reconcileSchedule(ctx context.Context, td *TaskDefinition, repoURL string, username, teamID string) error {
 	hasCron := td.Schedule != nil
 	hasTrigger := td.Trigger != nil
 
@@ -545,10 +606,10 @@ func (s *AgentRepoSyncer) reconcileSchedule(ctx context.Context, td *TaskDefinit
 		// No existing schedule — create one.
 		now := time.Now().UTC()
 		_, err = s.db.Exec(ctx, `
-			INSERT INTO schedules (id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, next_run, created_at, owner, debug, source, source_key, trigger_type, event_config)
+			INSERT INTO schedules (id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config)
 			VALUES ($1, $2, $3, $4, $5, $6, '', $7, $8, $9, $10, $15, $11, 'yaml', $12, $13, $14)
 		`, uuid.New().String(), td.Name, cronExpr, td.Prompt, td.Repo, td.Provider,
-			td.Timeout, enabled, nextRun, now, td.Debug, td.SourceKey, triggerType, eventConfigJSON, username)
+			td.Timeout, enabled, nextRun, now, td.Debug, td.SourceKey, triggerType, eventConfigJSON, teamID)
 		return err
 	}
 
@@ -564,14 +625,14 @@ func (s *AgentRepoSyncer) reconcileSchedule(ctx context.Context, td *TaskDefinit
 }
 
 // syncWorkflowDefinitions syncs .alcove/workflows/*.yml from a cloned repo for the given user.
-func (s *AgentRepoSyncer) syncWorkflowDefinitions(ctx context.Context, cloneDir string, repo SkillRepo, username string) error {
+func (s *AgentRepoSyncer) syncWorkflowDefinitions(ctx context.Context, cloneDir string, repo SkillRepo, username, teamID string) error {
 	workflowsDir := filepath.Join(cloneDir, ".alcove", "workflows")
 	entries, err := os.ReadDir(workflowsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			log.Printf("agent-repo-syncer: no .alcove/workflows/ directory in %s", repo.URL)
 			// Remove any previously synced workflows from this repo.
-			return s.workflowStore.DeleteWorkflowsByRepo(ctx, repo.URL, username)
+			return s.workflowStore.DeleteWorkflowsByRepo(ctx, repo.URL, teamID)
 		}
 		return fmt.Errorf("reading workflows dir: %w", err)
 	}
@@ -602,7 +663,7 @@ func (s *AgentRepoSyncer) syncWorkflowDefinitions(ctx context.Context, cloneDir 
 				Name:       entry.Name(),
 				SourceRepo: repo.URL,
 				SourceFile: entry.Name(),
-				Owner:      username,
+				TeamID:      teamID,
 			}
 			_ = s.workflowStore.UpsertWorkflow(ctx, errWorkflow, sourceKey, string(data), err.Error())
 			continue
@@ -610,7 +671,7 @@ func (s *AgentRepoSyncer) syncWorkflowDefinitions(ctx context.Context, cloneDir 
 
 		wd.SourceRepo = repo.URL
 		wd.SourceFile = entry.Name()
-		wd.Owner = username
+		wd.TeamID = teamID
 
 		if err := s.workflowStore.UpsertWorkflow(ctx, wd, sourceKey, string(data), ""); err != nil {
 			log.Printf("agent-repo-syncer: workflow upsert error for %s: %v", sourceKey, err)
@@ -618,13 +679,13 @@ func (s *AgentRepoSyncer) syncWorkflowDefinitions(ctx context.Context, cloneDir 
 		}
 
 		// Register workflow trigger if present.
-		if err := s.reconcileWorkflowTrigger(ctx, wd, sourceKey, username); err != nil {
+		if err := s.reconcileWorkflowTrigger(ctx, wd, sourceKey, username, teamID); err != nil {
 			log.Printf("agent-repo-syncer: workflow trigger reconcile error for %s: %v", sourceKey, err)
 		}
 	}
 
 	// Delete workflows that no longer exist in the repo.
-	existing, err := s.workflowStore.ListWorkflowsByRepo(ctx, repo.URL, username)
+	existing, err := s.workflowStore.ListWorkflowsByRepo(ctx, repo.URL, teamID)
 	if err != nil {
 		return fmt.Errorf("listing existing workflows: %w", err)
 	}
@@ -643,7 +704,7 @@ func (s *AgentRepoSyncer) syncWorkflowDefinitions(ctx context.Context, cloneDir 
 	log.Printf("agent-repo-syncer: synced %d workflow(s) from %s", len(seenKeys), repo.URL)
 
 	// Validate agent references in workflows.
-	s.validateWorkflowAgentReferences(ctx, repo.URL, username)
+	s.validateWorkflowAgentReferences(ctx, repo.URL, teamID)
 
 	return nil
 }
@@ -651,15 +712,15 @@ func (s *AgentRepoSyncer) syncWorkflowDefinitions(ctx context.Context, cloneDir 
 // validateWorkflowAgentReferences checks that all agents referenced in workflows
 // from the given repo resolve to known agent definitions. Sets sync_error on workflows
 // with unknown agent references.
-func (s *AgentRepoSyncer) validateWorkflowAgentReferences(ctx context.Context, repoURL string, username string) {
-	workflows, err := s.workflowStore.ListWorkflowsByRepo(ctx, repoURL, username)
+func (s *AgentRepoSyncer) validateWorkflowAgentReferences(ctx context.Context, repoURL string, teamID string) {
+	workflows, err := s.workflowStore.ListWorkflowsByRepo(ctx, repoURL, teamID)
 	if err != nil {
 		log.Printf("agent-repo-syncer: error listing workflows for validation: %v", err)
 		return
 	}
 
 	// Get all agent definitions for this user (across all repos).
-	agentDefs, err := s.defStore.ListAgentDefinitions(ctx, username)
+	agentDefs, err := s.defStore.ListAgentDefinitions(ctx, teamID)
 	if err != nil {
 		log.Printf("agent-repo-syncer: error listing agent definitions for validation: %v", err)
 		return
@@ -693,7 +754,7 @@ func (s *AgentRepoSyncer) validateWorkflowAgentReferences(ctx context.Context, r
 }
 
 // reconcileWorkflowTrigger creates, updates, or removes a schedule for a workflow trigger.
-func (s *AgentRepoSyncer) reconcileWorkflowTrigger(ctx context.Context, wd *WorkflowDefinition, sourceKey string, username string) error {
+func (s *AgentRepoSyncer) reconcileWorkflowTrigger(ctx context.Context, wd *WorkflowDefinition, sourceKey string, username, teamID string) error {
 	if wd.Trigger == nil {
 		// No trigger in YAML — remove any existing YAML-sourced schedule for this workflow.
 		_, err := s.db.Exec(ctx, `DELETE FROM schedules WHERE source_key = $1 AND source = 'yaml'`, sourceKey)
@@ -719,9 +780,9 @@ func (s *AgentRepoSyncer) reconcileWorkflowTrigger(ctx context.Context, wd *Work
 		now := time.Now().UTC()
 		// For workflow triggers, we create a schedule that points to the workflow (not an agent definition)
 		_, err = s.db.Exec(ctx, `
-			INSERT INTO schedules (id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, next_run, created_at, owner, debug, source, source_key, trigger_type, event_config)
+			INSERT INTO schedules (id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config)
 			VALUES ($1, $2, '', '', '', 'workflow', '', 0, $3, NULL, $4, $5, false, 'yaml', $6, $7, $8)
-		`, uuid.New().String(), wd.Name, enabled, now, username, sourceKey, triggerType, eventConfigJSON)
+		`, uuid.New().String(), wd.Name, enabled, now, teamID, sourceKey, triggerType, eventConfigJSON)
 		return err
 	}
 

--- a/internal/bridge/teams.go
+++ b/internal/bridge/teams.go
@@ -1,0 +1,469 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Team represents a team that owns shared resources.
+type Team struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	IsPersonal bool      `json:"is_personal"`
+	CreatedAt  time.Time `json:"created_at"`
+	Members    []string  `json:"members,omitempty"`
+}
+
+// TeamStore manages teams in PostgreSQL.
+type TeamStore struct {
+	db *pgxpool.Pool
+}
+
+// NewTeamStore creates a TeamStore with the given database pool.
+func NewTeamStore(db *pgxpool.Pool) *TeamStore {
+	return &TeamStore{db: db}
+}
+
+// ListTeamsForUser returns all teams the user is a member of.
+func (ts *TeamStore) ListTeamsForUser(ctx context.Context, username string) ([]Team, error) {
+	rows, err := ts.db.Query(ctx, `
+		SELECT t.id, t.name, t.is_personal, t.created_at
+		FROM teams t
+		JOIN team_members tm ON t.id = tm.team_id
+		WHERE tm.username = $1
+		ORDER BY t.is_personal DESC, t.name ASC
+	`, username)
+	if err != nil {
+		return nil, fmt.Errorf("querying teams: %w", err)
+	}
+	defer rows.Close()
+
+	var teams []Team
+	for rows.Next() {
+		var t Team
+		if err := rows.Scan(&t.ID, &t.Name, &t.IsPersonal, &t.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scanning team: %w", err)
+		}
+		teams = append(teams, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating teams: %w", err)
+	}
+
+	if teams == nil {
+		teams = []Team{}
+	}
+	return teams, nil
+}
+
+// GetTeam retrieves a team by ID including its members.
+func (ts *TeamStore) GetTeam(ctx context.Context, id string) (*Team, error) {
+	var t Team
+	err := ts.db.QueryRow(ctx, `
+		SELECT id, name, is_personal, created_at FROM teams WHERE id = $1
+	`, id).Scan(&t.ID, &t.Name, &t.IsPersonal, &t.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("team not found: %w", err)
+	}
+
+	// Fetch members.
+	rows, err := ts.db.Query(ctx, `SELECT username FROM team_members WHERE team_id = $1 ORDER BY username`, id)
+	if err != nil {
+		return nil, fmt.Errorf("querying team members: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var username string
+		if err := rows.Scan(&username); err != nil {
+			return nil, fmt.Errorf("scanning team member: %w", err)
+		}
+		t.Members = append(t.Members, username)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating team members: %w", err)
+	}
+	if t.Members == nil {
+		t.Members = []string{}
+	}
+
+	return &t, nil
+}
+
+// CreateTeam creates a new team and adds the creator as a member.
+func (ts *TeamStore) CreateTeam(ctx context.Context, name, creator string) (*Team, error) {
+	id := uuid.New().String()
+	now := time.Now().UTC()
+
+	tx, err := ts.db.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = tx.Exec(ctx, `INSERT INTO teams (id, name, is_personal, created_at) VALUES ($1, $2, false, $3)`,
+		id, name, now)
+	if err != nil {
+		return nil, fmt.Errorf("inserting team: %w", err)
+	}
+
+	_, err = tx.Exec(ctx, `INSERT INTO team_members (team_id, username) VALUES ($1, $2)`, id, creator)
+	if err != nil {
+		return nil, fmt.Errorf("adding creator as member: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("committing transaction: %w", err)
+	}
+
+	return &Team{
+		ID:         id,
+		Name:       name,
+		IsPersonal: false,
+		CreatedAt:  now,
+		Members:    []string{creator},
+	}, nil
+}
+
+// RenameTeam renames a team. Cannot rename personal teams.
+func (ts *TeamStore) RenameTeam(ctx context.Context, id, newName string) error {
+	result, err := ts.db.Exec(ctx,
+		`UPDATE teams SET name = $1 WHERE id = $2 AND is_personal = false`, newName, id)
+	if err != nil {
+		return fmt.Errorf("renaming team: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("team not found or is a personal team")
+	}
+	return nil
+}
+
+// DeleteTeam removes a team. Cannot delete personal teams.
+func (ts *TeamStore) DeleteTeam(ctx context.Context, id string) error {
+	result, err := ts.db.Exec(ctx, `DELETE FROM teams WHERE id = $1 AND is_personal = false`, id)
+	if err != nil {
+		return fmt.Errorf("deleting team: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("team not found or is a personal team")
+	}
+	return nil
+}
+
+// AddMember adds a user to a team. Cannot add members to personal teams.
+func (ts *TeamStore) AddMember(ctx context.Context, teamID, username string) error {
+	// Verify team is not personal.
+	var isPersonal bool
+	err := ts.db.QueryRow(ctx, `SELECT is_personal FROM teams WHERE id = $1`, teamID).Scan(&isPersonal)
+	if err != nil {
+		return fmt.Errorf("team not found: %w", err)
+	}
+	if isPersonal {
+		return fmt.Errorf("cannot add members to a personal team")
+	}
+
+	_, err = ts.db.Exec(ctx,
+		`INSERT INTO team_members (team_id, username) VALUES ($1, $2) ON CONFLICT DO NOTHING`, teamID, username)
+	if err != nil {
+		return fmt.Errorf("adding member: %w", err)
+	}
+	return nil
+}
+
+// RemoveMember removes a user from a team. Cannot remove from personal teams.
+func (ts *TeamStore) RemoveMember(ctx context.Context, teamID, username string) error {
+	// Verify team is not personal.
+	var isPersonal bool
+	err := ts.db.QueryRow(ctx, `SELECT is_personal FROM teams WHERE id = $1`, teamID).Scan(&isPersonal)
+	if err != nil {
+		return fmt.Errorf("team not found: %w", err)
+	}
+	if isPersonal {
+		return fmt.Errorf("cannot remove members from a personal team")
+	}
+
+	result, err := ts.db.Exec(ctx,
+		`DELETE FROM team_members WHERE team_id = $1 AND username = $2`, teamID, username)
+	if err != nil {
+		return fmt.Errorf("removing member: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("member not found")
+	}
+	return nil
+}
+
+// IsMember checks if a user is a member of a team.
+func (ts *TeamStore) IsMember(ctx context.Context, teamID, username string) (bool, error) {
+	var exists bool
+	err := ts.db.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM team_members WHERE team_id = $1 AND username = $2)`,
+		teamID, username).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("checking membership: %w", err)
+	}
+	return exists, nil
+}
+
+// GetPersonalTeamID returns the personal team ID for a user.
+func (ts *TeamStore) GetPersonalTeamID(ctx context.Context, username string) (string, error) {
+	var teamID string
+	err := ts.db.QueryRow(ctx, `
+		SELECT t.id FROM teams t
+		JOIN team_members tm ON t.id = tm.team_id
+		WHERE tm.username = $1 AND t.is_personal = true
+	`, username).Scan(&teamID)
+	if err != nil {
+		return "", fmt.Errorf("personal team not found for user %s: %w", username, err)
+	}
+	return teamID, nil
+}
+
+// CreatePersonalTeam creates a personal team for a user. Used during user creation.
+func (ts *TeamStore) CreatePersonalTeam(ctx context.Context, username string) (string, error) {
+	id := uuid.New().String()
+	now := time.Now().UTC()
+	name := username + "'s workspace"
+
+	tx, err := ts.db.Begin(ctx)
+	if err != nil {
+		return "", fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = tx.Exec(ctx,
+		`INSERT INTO teams (id, name, is_personal, created_at) VALUES ($1, $2, true, $3)`,
+		id, name, now)
+	if err != nil {
+		return "", fmt.Errorf("inserting personal team: %w", err)
+	}
+
+	_, err = tx.Exec(ctx,
+		`INSERT INTO team_members (team_id, username) VALUES ($1, $2)`, id, username)
+	if err != nil {
+		return "", fmt.Errorf("adding user to personal team: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return "", fmt.Errorf("committing transaction: %w", err)
+	}
+
+	return id, nil
+}
+
+// --- Team Settings ---
+
+// GetTeamAgentRepos returns a team's agent repos.
+func (ts *TeamStore) GetTeamAgentRepos(ctx context.Context, teamID string) ([]SkillRepo, error) {
+	var value json.RawMessage
+	err := ts.db.QueryRow(ctx,
+		`SELECT value FROM team_settings WHERE team_id = $1 AND key = 'agent_repos'`, teamID).Scan(&value)
+	if err != nil {
+		return nil, fmt.Errorf("team agent repos not found: %w", err)
+	}
+	var repos []SkillRepo
+	if err := json.Unmarshal(value, &repos); err != nil {
+		return nil, fmt.Errorf("unmarshaling team agent repos: %w", err)
+	}
+	return repos, nil
+}
+
+// SetTeamAgentRepos saves a team's agent repos.
+func (ts *TeamStore) SetTeamAgentRepos(ctx context.Context, teamID string, repos []SkillRepo) error {
+	value, err := json.Marshal(repos)
+	if err != nil {
+		return fmt.Errorf("marshaling team agent repos: %w", err)
+	}
+	_, err = ts.db.Exec(ctx, `
+		INSERT INTO team_settings (team_id, key, value, updated_at) VALUES ($1, 'agent_repos', $2, $3)
+		ON CONFLICT (team_id, key) DO UPDATE SET value = $2, updated_at = $3
+	`, teamID, value, time.Now().UTC())
+	return err
+}
+
+// --- HTTP Handlers ---
+
+func (a *API) handleTeams(w http.ResponseWriter, r *http.Request) {
+	user := r.Header.Get("X-Alcove-User")
+	if user == "" {
+		respondError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		teams, err := a.teamStore.ListTeamsForUser(r.Context(), user)
+		if err != nil {
+			log.Printf("error: listing teams: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to list teams")
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]any{
+			"teams": teams,
+			"count": len(teams),
+		})
+	case http.MethodPost:
+		var req struct {
+			Name string `json:"name"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+			return
+		}
+		if req.Name == "" {
+			respondError(w, http.StatusBadRequest, "name is required")
+			return
+		}
+		team, err := a.teamStore.CreateTeam(r.Context(), req.Name, user)
+		if err != nil {
+			log.Printf("error: creating team: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to create team: "+err.Error())
+			return
+		}
+		respondJSON(w, http.StatusCreated, team)
+	default:
+		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (a *API) handleTeam(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/teams/")
+	parts := strings.SplitN(path, "/", 2)
+	teamID := parts[0]
+
+	if teamID == "" {
+		respondError(w, http.StatusBadRequest, "team id required")
+		return
+	}
+
+	user := r.Header.Get("X-Alcove-User")
+	if user == "" {
+		respondError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	isAdmin := r.Header.Get("X-Alcove-Admin") == "true"
+
+	// Check membership or admin.
+	isMember, err := a.teamStore.IsMember(r.Context(), teamID, user)
+	if err != nil {
+		respondError(w, http.StatusNotFound, "team not found")
+		return
+	}
+	if !isMember && !isAdmin {
+		respondError(w, http.StatusForbidden, "access denied")
+		return
+	}
+
+	// Handle /api/v1/teams/{id}/members or /api/v1/teams/{id}/members/{username}
+	if len(parts) == 2 && strings.HasPrefix(parts[1], "members") {
+		a.handleTeamMembersRoute(w, r, teamID, parts[1])
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		team, err := a.teamStore.GetTeam(r.Context(), teamID)
+		if err != nil {
+			respondError(w, http.StatusNotFound, "team not found")
+			return
+		}
+		respondJSON(w, http.StatusOK, team)
+	case http.MethodPut:
+		var req struct {
+			Name string `json:"name"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+			return
+		}
+		if req.Name == "" {
+			respondError(w, http.StatusBadRequest, "name is required")
+			return
+		}
+		if err := a.teamStore.RenameTeam(r.Context(), teamID, req.Name); err != nil {
+			log.Printf("error: renaming team %s: %v", teamID, err)
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]bool{"updated": true})
+	case http.MethodDelete:
+		// Cancel running sessions for this team before deleting.
+		_, _ = a.db.Exec(r.Context(),
+			`UPDATE sessions SET outcome = 'cancelled', finished_at = NOW() WHERE team_id = $1 AND outcome = 'running'`,
+			teamID)
+
+		if err := a.teamStore.DeleteTeam(r.Context(), teamID); err != nil {
+			log.Printf("error: deleting team %s: %v", teamID, err)
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]bool{"deleted": true})
+	default:
+		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (a *API) handleTeamMembersRoute(w http.ResponseWriter, r *http.Request, teamID, membersPath string) {
+	// membersPath is "members" or "members/{username}"
+	membersParts := strings.SplitN(membersPath, "/", 2)
+
+	if len(membersParts) == 1 {
+		// POST /api/v1/teams/{id}/members — add member
+		if r.Method != http.MethodPost {
+			respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		var req struct {
+			Username string `json:"username"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+			return
+		}
+		if req.Username == "" {
+			respondError(w, http.StatusBadRequest, "username is required")
+			return
+		}
+		if err := a.teamStore.AddMember(r.Context(), teamID, req.Username); err != nil {
+			log.Printf("error: adding member to team %s: %v", teamID, err)
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		respondJSON(w, http.StatusCreated, map[string]bool{"added": true})
+	} else {
+		// DELETE /api/v1/teams/{id}/members/{username} — remove member
+		username := membersParts[1]
+		if r.Method != http.MethodDelete {
+			respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		if err := a.teamStore.RemoveMember(r.Context(), teamID, username); err != nil {
+			log.Printf("error: removing member from team %s: %v", teamID, err)
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]bool{"removed": true})
+	}
+}

--- a/internal/bridge/tools.go
+++ b/internal/bridge/tools.go
@@ -36,7 +36,7 @@ type ToolDefinition struct {
 	AuthHeader  string          `json:"auth_header,omitempty"`
 	AuthFormat  string          `json:"auth_format,omitempty"`
 	Operations  json.RawMessage `json:"operations"`             // [{name, description, risk}]
-	Owner       string          `json:"owner,omitempty"`
+	TeamID      string          `json:"team_id,omitempty"`
 	CreatedAt   time.Time       `json:"created_at"`
 }
 
@@ -58,12 +58,12 @@ func NewToolStore(db *pgxpool.Pool) *ToolStore {
 }
 
 // CreateTool inserts a new custom tool into the registry.
-func (ts *ToolStore) CreateTool(ctx context.Context, tool *ToolDefinition, owner string) error {
+func (ts *ToolStore) CreateTool(ctx context.Context, tool *ToolDefinition, teamID string) error {
 	if tool.ID == "" {
 		tool.ID = uuid.New().String()
 	}
 	tool.CreatedAt = time.Now().UTC()
-	tool.Owner = owner
+	tool.TeamID = teamID
 	tool.ToolType = "custom"
 
 	if tool.MCPArgs == nil {
@@ -80,12 +80,12 @@ func (ts *ToolStore) CreateTool(ctx context.Context, tool *ToolDefinition, owner
 	}
 
 	_, err := ts.db.Exec(ctx,
-		`INSERT INTO mcp_tools (id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, owner, created_at)
+		`INSERT INTO mcp_tools (id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, team_id, created_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
 		tool.ID, tool.Name, tool.DisplayName, tool.ToolType,
 		tool.MCPCommand, string(tool.MCPArgs), tool.APIHost,
 		tool.AuthHeader, tool.AuthFormat, string(tool.Operations),
-		tool.Owner, tool.CreatedAt)
+		tool.TeamID, tool.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("inserting tool: %w", err)
 	}
@@ -93,13 +93,13 @@ func (ts *ToolStore) CreateTool(ctx context.Context, tool *ToolDefinition, owner
 }
 
 // ListTools returns ALL builtin tools plus the given owner's custom tools.
-func (ts *ToolStore) ListTools(ctx context.Context, owner string) ([]ToolDefinition, error) {
-	query := `SELECT id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, owner, created_at
+func (ts *ToolStore) ListTools(ctx context.Context, teamID string) ([]ToolDefinition, error) {
+	query := `SELECT id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, team_id, created_at
 		FROM mcp_tools
-		WHERE tool_type = 'builtin' OR owner = $1
+		WHERE tool_type = 'builtin' OR team_id = $1
 		ORDER BY tool_type ASC, name ASC`
 
-	rows, err := ts.db.Query(ctx, query, owner)
+	rows, err := ts.db.Query(ctx, query, teamID)
 	if err != nil {
 		return nil, fmt.Errorf("querying tools: %w", err)
 	}
@@ -113,7 +113,7 @@ func (ts *ToolStore) ListTools(ctx context.Context, owner string) ([]ToolDefinit
 
 		if err := rows.Scan(&t.ID, &t.Name, &t.DisplayName, &t.ToolType,
 			&mcpCommand, &mcpArgs, &apiHost, &authHeader, &authFormat,
-			&operations, &t.Owner, &t.CreatedAt); err != nil {
+			&operations, &t.TeamID, &t.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scanning tool: %w", err)
 		}
 
@@ -144,20 +144,20 @@ func (ts *ToolStore) ListTools(ctx context.Context, owner string) ([]ToolDefinit
 
 // GetTool looks up a tool by name. Returns builtin tools regardless of owner;
 // returns custom tools only if the owner matches.
-func (ts *ToolStore) GetTool(ctx context.Context, name, owner string) (*ToolDefinition, error) {
-	query := `SELECT id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, owner, created_at
+func (ts *ToolStore) GetTool(ctx context.Context, name, teamID string) (*ToolDefinition, error) {
+	query := `SELECT id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, team_id, created_at
 		FROM mcp_tools
-		WHERE name = $1 AND (tool_type = 'builtin' OR owner = $2)
+		WHERE name = $1 AND (tool_type = 'builtin' OR team_id = $2)
 		LIMIT 1`
 
 	var t ToolDefinition
 	var mcpCommand, apiHost, authHeader, authFormat *string
 	var mcpArgs, operations string
 
-	err := ts.db.QueryRow(ctx, query, name, owner).Scan(
+	err := ts.db.QueryRow(ctx, query, name, teamID).Scan(
 		&t.ID, &t.Name, &t.DisplayName, &t.ToolType,
 		&mcpCommand, &mcpArgs, &apiHost, &authHeader, &authFormat,
-		&operations, &t.Owner, &t.CreatedAt)
+		&operations, &t.TeamID, &t.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("tool %q not found: %w", name, err)
 	}
@@ -181,7 +181,7 @@ func (ts *ToolStore) GetTool(ctx context.Context, name, owner string) (*ToolDefi
 }
 
 // UpdateTool updates an existing custom tool. Builtin tools cannot be updated.
-func (ts *ToolStore) UpdateTool(ctx context.Context, tool *ToolDefinition, owner string) error {
+func (ts *ToolStore) UpdateTool(ctx context.Context, tool *ToolDefinition, teamID string) error {
 	if tool.MCPArgs == nil {
 		tool.MCPArgs = json.RawMessage(`[]`)
 	}
@@ -193,10 +193,10 @@ func (ts *ToolStore) UpdateTool(ctx context.Context, tool *ToolDefinition, owner
 		`UPDATE mcp_tools
 		SET display_name = $1, mcp_command = $2, mcp_args = $3, api_host = $4,
 		    auth_header = $5, auth_format = $6, operations = $7
-		WHERE name = $8 AND tool_type = 'custom' AND owner = $9`,
+		WHERE name = $8 AND tool_type = 'custom' AND team_id = $9`,
 		tool.DisplayName, tool.MCPCommand, string(tool.MCPArgs), tool.APIHost,
 		tool.AuthHeader, tool.AuthFormat, string(tool.Operations),
-		tool.Name, owner)
+		tool.Name, teamID)
 	if err != nil {
 		return fmt.Errorf("updating tool: %w", err)
 	}
@@ -207,10 +207,10 @@ func (ts *ToolStore) UpdateTool(ctx context.Context, tool *ToolDefinition, owner
 }
 
 // DeleteTool removes a custom tool from the registry. Builtin tools cannot be deleted.
-func (ts *ToolStore) DeleteTool(ctx context.Context, name, owner string) error {
+func (ts *ToolStore) DeleteTool(ctx context.Context, name, teamID string) error {
 	result, err := ts.db.Exec(ctx,
-		`DELETE FROM mcp_tools WHERE name = $1 AND tool_type = 'custom' AND owner = $2`,
-		name, owner)
+		`DELETE FROM mcp_tools WHERE name = $1 AND tool_type = 'custom' AND team_id = $2`,
+		name, teamID)
 	if err != nil {
 		return fmt.Errorf("deleting tool: %w", err)
 	}
@@ -322,9 +322,9 @@ func (ts *ToolStore) SeedBuiltinTools(ctx context.Context) error {
 	for _, b := range builtins {
 		id := uuid.New().String()
 		_, err := ts.db.Exec(ctx,
-			`INSERT INTO mcp_tools (id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, owner, created_at)
-			VALUES ($1, $2, $3, 'builtin', $4, $5, $6, $7, $8, $9, '', NOW())
-			ON CONFLICT (name, owner) DO UPDATE SET
+			`INSERT INTO mcp_tools (id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, team_id, created_at)
+			VALUES ($1, $2, $3, 'builtin', $4, $5, $6, $7, $8, $9, NULL, NOW())
+			ON CONFLICT (name) WHERE team_id IS NULL DO UPDATE SET
 				display_name = EXCLUDED.display_name,
 				mcp_command = EXCLUDED.mcp_command,
 				mcp_args = EXCLUDED.mcp_args,

--- a/internal/bridge/workflow.go
+++ b/internal/bridge/workflow.go
@@ -36,7 +36,7 @@ type WorkflowDefinition struct {
 	// Metadata (not from YAML).
 	SourceRepo string `json:"source_repo,omitempty"`
 	SourceFile string `json:"source_file,omitempty"`
-	Owner      string `json:"owner,omitempty"`
+	TeamID     string `json:"team_id,omitempty"`
 }
 
 // WorkflowStep represents a single step in a workflow.
@@ -410,9 +410,9 @@ func (s *WorkflowStore) UpsertWorkflow(ctx context.Context, wd *WorkflowDefiniti
 	now := time.Now().UTC()
 
 	_, err = s.db.Exec(ctx, `
-		INSERT INTO workflows (id, name, source_repo, source_file, source_key, raw_yaml, parsed, sync_error, last_synced, owner, created_at, updated_at)
+		INSERT INTO workflows (id, name, source_repo, source_file, source_key, raw_yaml, parsed, sync_error, last_synced, team_id, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-		ON CONFLICT (source_key) DO UPDATE SET
+		ON CONFLICT (source_key, team_id) DO UPDATE SET
 			name = EXCLUDED.name,
 			source_repo = EXCLUDED.source_repo,
 			source_file = EXCLUDED.source_file,
@@ -420,9 +420,9 @@ func (s *WorkflowStore) UpsertWorkflow(ctx context.Context, wd *WorkflowDefiniti
 			parsed = EXCLUDED.parsed,
 			sync_error = EXCLUDED.sync_error,
 			last_synced = EXCLUDED.last_synced,
-			owner = EXCLUDED.owner,
+			team_id = EXCLUDED.team_id,
 			updated_at = EXCLUDED.updated_at
-	`, id, wd.Name, wd.SourceRepo, wd.SourceFile, sourceKey, rawYAML, parsedJSON, nilIfEmpty(syncError), now, wd.Owner, now, now)
+	`, id, wd.Name, wd.SourceRepo, wd.SourceFile, sourceKey, rawYAML, parsedJSON, nilIfEmpty(syncError), now, wd.TeamID, now, now)
 	if err != nil {
 		return fmt.Errorf("upserting workflow: %w", err)
 	}
@@ -431,13 +431,13 @@ func (s *WorkflowStore) UpsertWorkflow(ctx context.Context, wd *WorkflowDefiniti
 }
 
 // ListWorkflowsByRepo returns all workflow definitions from a given repo URL and owner.
-func (s *WorkflowStore) ListWorkflowsByRepo(ctx context.Context, repoURL, owner string) ([]StoredWorkflowDefinition, error) {
+func (s *WorkflowStore) ListWorkflowsByRepo(ctx context.Context, repoURL, teamID string) ([]StoredWorkflowDefinition, error) {
 	rows, err := s.db.Query(ctx, `
-		SELECT id, name, source_repo, source_file, source_key, raw_yaml, parsed, sync_error, last_synced, owner
+		SELECT id, name, source_repo, source_file, source_key, raw_yaml, parsed, sync_error, last_synced, team_id
 		FROM workflows
-		WHERE source_repo = $1 AND owner = $2
+		WHERE source_repo = $1 AND team_id = $2
 		ORDER BY name ASC
-	`, repoURL, owner)
+	`, repoURL, teamID)
 	if err != nil {
 		return nil, fmt.Errorf("querying workflows for repo %s: %w", repoURL, err)
 	}
@@ -451,7 +451,7 @@ func (s *WorkflowStore) ListWorkflowsByRepo(ctx context.Context, repoURL, owner 
 
 		if err := rows.Scan(
 			&swd.ID, &swd.Name, &swd.SourceRepo, &swd.SourceFile,
-			&swd.SourceKey, &swd.RawYAML, &parsedJSON, &syncError, &swd.LastSynced, &swd.Owner,
+			&swd.SourceKey, &swd.RawYAML, &parsedJSON, &syncError, &swd.LastSynced, &swd.TeamID,
 		); err != nil {
 			return nil, fmt.Errorf("scanning workflow: %w", err)
 		}
@@ -481,8 +481,8 @@ func (s *WorkflowStore) ListWorkflowsByRepo(ctx context.Context, repoURL, owner 
 }
 
 // DeleteWorkflowsByRepo removes all workflow definitions from a given repo URL and owner.
-func (s *WorkflowStore) DeleteWorkflowsByRepo(ctx context.Context, repoURL, owner string) error {
-	_, err := s.db.Exec(ctx, `DELETE FROM workflows WHERE source_repo = $1 AND owner = $2`, repoURL, owner)
+func (s *WorkflowStore) DeleteWorkflowsByRepo(ctx context.Context, repoURL, teamID string) error {
+	_, err := s.db.Exec(ctx, `DELETE FROM workflows WHERE source_repo = $1 AND team_id = $2`, repoURL, teamID)
 	if err != nil {
 		return fmt.Errorf("deleting workflows for repo %s: %w", repoURL, err)
 	}
@@ -490,15 +490,15 @@ func (s *WorkflowStore) DeleteWorkflowsByRepo(ctx context.Context, repoURL, owne
 }
 
 // ListWorkflows returns all workflow definitions owned by the given user.
-func (s *WorkflowStore) ListWorkflows(ctx context.Context, owner string) ([]StoredWorkflowDefinition, error) {
+func (s *WorkflowStore) ListWorkflows(ctx context.Context, teamID string) ([]StoredWorkflowDefinition, error) {
 	rows, err := s.db.Query(ctx, `
-		SELECT id, name, source_repo, source_file, source_key, raw_yaml, parsed, sync_error, last_synced, owner
+		SELECT id, name, source_repo, source_file, source_key, raw_yaml, parsed, sync_error, last_synced, team_id
 		FROM workflows
-		WHERE owner = $1
+		WHERE team_id = $1
 		ORDER BY name ASC
-	`, owner)
+	`, teamID)
 	if err != nil {
-		return nil, fmt.Errorf("querying workflows for owner %s: %w", owner, err)
+		return nil, fmt.Errorf("querying workflows for team %s: %w", teamID, err)
 	}
 	defer rows.Close()
 
@@ -510,7 +510,7 @@ func (s *WorkflowStore) ListWorkflows(ctx context.Context, owner string) ([]Stor
 
 		if err := rows.Scan(
 			&swd.ID, &swd.Name, &swd.SourceRepo, &swd.SourceFile,
-			&swd.SourceKey, &swd.RawYAML, &parsedJSON, &syncError, &swd.LastSynced, &swd.Owner,
+			&swd.SourceKey, &swd.RawYAML, &parsedJSON, &syncError, &swd.LastSynced, &swd.TeamID,
 		); err != nil {
 			return nil, fmt.Errorf("scanning workflow: %w", err)
 		}

--- a/internal/bridge/workflow_engine.go
+++ b/internal/bridge/workflow_engine.go
@@ -60,7 +60,7 @@ type WorkflowRun struct {
 	StepOutputs map[string]interface{} `json:"step_outputs"`
 	StartedAt   *time.Time             `json:"started_at,omitempty"`
 	FinishedAt  *time.Time             `json:"finished_at,omitempty"`
-	Owner       string                 `json:"owner"`
+	TeamID      string                 `json:"team_id"`
 	CreatedAt   time.Time              `json:"created_at"`
 }
 
@@ -77,7 +77,7 @@ type WorkflowRunStep struct {
 }
 
 // StartWorkflowRun creates a new workflow run and dispatches initial steps.
-func (we *WorkflowEngine) StartWorkflowRun(ctx context.Context, workflowID, triggerType, triggerRef, owner string) (*WorkflowRun, error) {
+func (we *WorkflowEngine) StartWorkflowRun(ctx context.Context, workflowID, triggerType, triggerRef, teamID string) (*WorkflowRun, error) {
 	// Get the workflow definition
 	workflow, err := we.getWorkflowByID(ctx, workflowID)
 	if err != nil {
@@ -94,7 +94,7 @@ func (we *WorkflowEngine) StartWorkflowRun(ctx context.Context, workflowID, trig
 		TriggerType: triggerType,
 		TriggerRef:  triggerRef,
 		StepOutputs: make(map[string]interface{}),
-		Owner:       owner,
+		TeamID:      teamID,
 		CreatedAt:   now,
 	}
 
@@ -177,7 +177,7 @@ func (we *WorkflowEngine) dispatchStep(ctx context.Context, run *WorkflowRun, st
 	}
 
 	// Get the agent definition
-	agentDef, err := we.defStore.GetAgentDefinition(ctx, step.Agent, run.Owner)
+	agentDef, err := we.defStore.GetAgentDefinition(ctx, step.Agent, run.TeamID)
 	if err != nil {
 		return fmt.Errorf("getting agent definition %s: %w", step.Agent, err)
 	}
@@ -193,12 +193,12 @@ func (we *WorkflowEngine) dispatchStep(ctx context.Context, run *WorkflowRun, st
 		taskReq.Repo = step.Repo
 
 		// Validate cross-repo access: ensure credentials are available for the target repo
-		if err := we.validateCrossRepoCredentials(ctx, step.Repo, run.Owner); err != nil {
+		if err := we.validateCrossRepoCredentials(ctx, step.Repo, run.TeamID); err != nil {
 			return fmt.Errorf("cross-repo credential validation failed for repo %s: %w", step.Repo, err)
 		}
 
 		// Apply cross-repo enhancements to the task request
-		if err := we.enhanceTaskRequestForRepo(ctx, &taskReq, step.Repo, run.Owner); err != nil {
+		if err := we.enhanceTaskRequestForRepo(ctx, &taskReq, step.Repo, run.TeamID); err != nil {
 			return fmt.Errorf("cross-repo enhancement failed for repo %s: %w", step.Repo, err)
 		}
 	}
@@ -209,7 +209,7 @@ func (we *WorkflowEngine) dispatchStep(ctx context.Context, run *WorkflowRun, st
 	}
 
 	// Dispatch the task
-	session, err := we.dispatcher.DispatchTask(ctx, taskReq, run.Owner)
+	session, err := we.dispatcher.DispatchTask(ctx, taskReq, "workflow", run.TeamID)
 	if err != nil {
 		return fmt.Errorf("dispatching task for step %s: %w", step.ID, err)
 	}
@@ -572,7 +572,7 @@ func (we *WorkflowEngine) RecoverWorkflows(ctx context.Context) error {
 
 	// Query for running workflow runs
 	rows, err := we.db.Query(ctx, `
-		SELECT id, workflow_id, trigger_type, trigger_ref, current_step, step_outputs, owner
+		SELECT id, workflow_id, trigger_type, trigger_ref, current_step, step_outputs, team_id
 		FROM workflow_runs
 		WHERE status = 'running'
 	`)
@@ -583,10 +583,10 @@ func (we *WorkflowEngine) RecoverWorkflows(ctx context.Context) error {
 
 	var recovered int
 	for rows.Next() {
-		var runID, workflowID, triggerType, triggerRef, currentStep, owner string
+		var runID, workflowID, triggerType, triggerRef, currentStep, teamID string
 		var stepOutputsJSON []byte
 
-		if err := rows.Scan(&runID, &workflowID, &triggerType, &triggerRef, &currentStep, &stepOutputsJSON, &owner); err != nil {
+		if err := rows.Scan(&runID, &workflowID, &triggerType, &triggerRef, &currentStep, &stepOutputsJSON, &teamID); err != nil {
 			log.Printf("error scanning workflow run: %v", err)
 			continue
 		}
@@ -598,7 +598,7 @@ func (we *WorkflowEngine) RecoverWorkflows(ctx context.Context) error {
 			TriggerType: triggerType,
 			TriggerRef:  triggerRef,
 			CurrentStep: currentStep,
-			Owner:       owner,
+			TeamID:      teamID,
 		}
 
 		if stepOutputsJSON != nil {
@@ -745,7 +745,7 @@ func (we *WorkflowEngine) RejectStep(ctx context.Context, runID, stepID string) 
 // GetWorkflowRun retrieves a workflow run by ID.
 func (we *WorkflowEngine) GetWorkflowRun(ctx context.Context, runID string) (*WorkflowRun, error) {
 	row := we.db.QueryRow(ctx, `
-		SELECT id, workflow_id, status, trigger_type, trigger_ref, current_step, step_outputs, started_at, finished_at, owner, created_at
+		SELECT id, workflow_id, status, trigger_type, trigger_ref, current_step, step_outputs, started_at, finished_at, team_id, created_at
 		FROM workflow_runs
 		WHERE id = $1
 	`, runID)
@@ -757,7 +757,7 @@ func (we *WorkflowEngine) GetWorkflowRun(ctx context.Context, runID string) (*Wo
 
 	if err := row.Scan(
 		&run.ID, &run.WorkflowID, &run.Status, &triggerType, &triggerRef,
-		&currentStep, &stepOutputsJSON, &run.StartedAt, &run.FinishedAt, &run.Owner, &run.CreatedAt,
+		&currentStep, &stepOutputsJSON, &run.StartedAt, &run.FinishedAt, &run.TeamID, &run.CreatedAt,
 	); err != nil {
 		return nil, fmt.Errorf("getting workflow run %s: %w", runID, err)
 	}
@@ -783,18 +783,18 @@ func (we *WorkflowEngine) GetWorkflowRun(ctx context.Context, runID string) (*Wo
 }
 
 // ListWorkflowRuns lists workflow runs, optionally filtered by status and owner.
-func (we *WorkflowEngine) ListWorkflowRuns(ctx context.Context, status, owner string) ([]WorkflowRun, error) {
+func (we *WorkflowEngine) ListWorkflowRuns(ctx context.Context, status, teamID string) ([]WorkflowRun, error) {
 	query := `
-		SELECT id, workflow_id, status, trigger_type, trigger_ref, current_step, step_outputs, started_at, finished_at, owner, created_at
+		SELECT id, workflow_id, status, trigger_type, trigger_ref, current_step, step_outputs, started_at, finished_at, team_id, created_at
 		FROM workflow_runs
 		WHERE 1=1
 	`
 	args := []interface{}{}
 	argN := 1
 
-	if owner != "" {
-		query += fmt.Sprintf(" AND owner = $%d", argN)
-		args = append(args, owner)
+	if teamID != "" {
+		query += fmt.Sprintf(" AND team_id = $%d", argN)
+		args = append(args, teamID)
 		argN++
 	}
 	if status != "" {
@@ -819,7 +819,7 @@ func (we *WorkflowEngine) ListWorkflowRuns(ctx context.Context, status, owner st
 
 		if err := rows.Scan(
 			&run.ID, &run.WorkflowID, &run.Status, &triggerType, &triggerRef,
-			&currentStep, &stepOutputsJSON, &run.StartedAt, &run.FinishedAt, &run.Owner, &run.CreatedAt,
+			&currentStep, &stepOutputsJSON, &run.StartedAt, &run.FinishedAt, &run.TeamID, &run.CreatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scanning workflow run: %w", err)
 		}
@@ -897,9 +897,9 @@ func (we *WorkflowEngine) insertWorkflowRun(ctx context.Context, run *WorkflowRu
 	}
 
 	_, err = we.db.Exec(ctx, `
-		INSERT INTO workflow_runs (id, workflow_id, status, trigger_type, trigger_ref, current_step, step_outputs, owner, created_at)
+		INSERT INTO workflow_runs (id, workflow_id, status, trigger_type, trigger_ref, current_step, step_outputs, team_id, created_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-	`, run.ID, run.WorkflowID, run.Status, run.TriggerType, run.TriggerRef, run.CurrentStep, stepOutputsJSON, run.Owner, run.CreatedAt)
+	`, run.ID, run.WorkflowID, run.Status, run.TriggerType, run.TriggerRef, run.CurrentStep, stepOutputsJSON, run.TeamID, run.CreatedAt)
 
 	return err
 }
@@ -1022,7 +1022,7 @@ func (we *WorkflowEngine) getWorkflowRunSteps(ctx context.Context, runID string)
 func (we *WorkflowEngine) getStepAndRunBySessionID(ctx context.Context, sessionID string) (*WorkflowRunStep, *WorkflowRun, error) {
 	row := we.db.QueryRow(ctx, `
 		SELECT wrs.id, wrs.run_id, wrs.step_id, wrs.session_id, wrs.status, wrs.outputs, wrs.started_at, wrs.finished_at,
-		       wr.id, wr.workflow_id, wr.status, wr.trigger_type, wr.trigger_ref, wr.current_step, wr.step_outputs, wr.owner
+		       wr.id, wr.workflow_id, wr.status, wr.trigger_type, wr.trigger_ref, wr.current_step, wr.step_outputs, wr.team_id
 		FROM workflow_run_steps wrs
 		JOIN workflow_runs wr ON wrs.run_id = wr.id
 		WHERE wrs.session_id = $1
@@ -1036,7 +1036,7 @@ func (we *WorkflowEngine) getStepAndRunBySessionID(ctx context.Context, sessionI
 
 	err := row.Scan(
 		&step.ID, &step.RunID, &step.StepID, &sessionIDPtr, &step.Status, &stepOutputsJSON, &stepStartedAt, &stepFinishedAt,
-		&run.ID, &run.WorkflowID, &run.Status, &run.TriggerType, &run.TriggerRef, &run.CurrentStep, &runStepOutputsJSON, &run.Owner,
+		&run.ID, &run.WorkflowID, &run.Status, &run.TriggerType, &run.TriggerRef, &run.CurrentStep, &runStepOutputsJSON, &run.TeamID,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/internal/types.go
+++ b/internal/types.go
@@ -62,6 +62,7 @@ type Session struct {
 	TriggerContext string     `json:"trigger_context,omitempty"` // keep for backward compat
 	TriggerType    string     `json:"trigger_type,omitempty"`
 	TriggerRef     string     `json:"trigger_ref,omitempty"`
+	TeamID         string     `json:"team_id,omitempty"`
 }
 
 // Artifact represents an output produced by a task (PR, commit, etc.).

--- a/scripts/test-teams.sh
+++ b/scripts/test-teams.sh
@@ -1,0 +1,548 @@
+#!/bin/bash
+# test-teams.sh — Tests for the teams management API.
+#
+# Verifies team CRUD, membership management, personal team constraints,
+# team-scoped resource isolation, cross-team isolation, and backward
+# compatibility with existing API endpoints.
+#
+# Prerequisites:
+#   - Bridge running at BRIDGE_URL (default http://localhost:8080)
+#   - AUTH_BACKEND=postgres with PostgreSQL accessible
+#   - ADMIN_PASSWORD set in the environment
+#
+# Usage:
+#   ADMIN_PASSWORD=<pw> ./scripts/test-teams.sh
+#
+# Tests:
+#   - Personal team auto-creation
+#   - Team CRUD (create, list, get, update, delete)
+#   - Membership management (add/remove members)
+#   - Personal team constraints (cannot delete, add members, or rename)
+#   - Team-scoped resource isolation (credentials scoped to teams)
+#   - Cross-team isolation (same-name credentials in different teams)
+#   - Backward compatibility (API works without X-Alcove-Team header)
+
+set -euo pipefail
+
+BRIDGE_URL="${BRIDGE_URL:-http://localhost:8080}"
+PASS=0
+FAIL=0
+
+log() { echo ">>> $*"; }
+pass() { echo "  PASS: $*"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $*"; FAIL=$((FAIL+1)); }
+
+# --- Setup ---
+log "Setting up..."
+ADMIN_TOKEN=$(curl -s -X POST "$BRIDGE_URL/api/v1/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"admin\",\"password\":\"${ADMIN_PASSWORD}\"}" | python3 -c "import json,sys; d=json.load(sys.stdin); t=d.get('token',''); print(t) if t else sys.exit('Login failed: ' + json.dumps(d))")
+
+# Create test users
+curl -s -X POST "$BRIDGE_URL/api/v1/users" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"team-alice","password":"teamalice123","is_admin":false}' > /dev/null 2>&1 || true
+
+curl -s -X POST "$BRIDGE_URL/api/v1/users" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"team-bob","password":"teambob12345","is_admin":false}' > /dev/null 2>&1 || true
+
+ALICE_TOKEN=$(curl -s -X POST "$BRIDGE_URL/api/v1/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"team-alice","password":"teamalice123"}' | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('token',''))")
+
+BOB_TOKEN=$(curl -s -X POST "$BRIDGE_URL/api/v1/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"team-bob","password":"teambob12345"}' | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('token',''))")
+
+echo "  Alice token: ${ALICE_TOKEN:0:10}..."
+echo "  Bob token: ${BOB_TOKEN:0:10}..."
+
+# =====================================================================
+# Test 1: Personal team auto-creation
+# =====================================================================
+log "Test 1: Personal team auto-creation"
+
+TEAMS_RESULT=$(curl -s "$BRIDGE_URL/api/v1/teams" \
+  -H "Authorization: Bearer $ALICE_TOKEN")
+TEAM_COUNT=$(echo "$TEAMS_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('teams',[])))")
+if [ "$TEAM_COUNT" = "1" ]; then
+  pass "Alice has exactly one team"
+else
+  fail "Alice has $TEAM_COUNT teams (expected 1)"
+fi
+
+IS_PERSONAL=$(echo "$TEAMS_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); teams=d.get('teams',[]); print(teams[0].get('is_personal',False) if teams else 'NONE')")
+if [ "$IS_PERSONAL" = "True" ]; then
+  pass "Alice's team is personal"
+else
+  fail "Alice's team is_personal=$IS_PERSONAL (expected True)"
+fi
+
+PERSONAL_TEAM_ID=$(echo "$TEAMS_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); teams=d.get('teams',[]); print(teams[0].get('id','') if teams else '')")
+
+# Verify Alice is a member of her personal team
+PERSONAL_DETAIL=$(curl -s "$BRIDGE_URL/api/v1/teams/$PERSONAL_TEAM_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN")
+ALICE_IS_MEMBER=$(echo "$PERSONAL_DETAIL" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+members=[m.get('username','') for m in d.get('members',[])]
+print('yes' if 'team-alice' in members else 'no')
+")
+if [ "$ALICE_IS_MEMBER" = "yes" ]; then
+  pass "Alice is a member of her personal team"
+else
+  fail "Alice is not a member of her personal team"
+fi
+
+# =====================================================================
+# Test 2: Team CRUD
+# =====================================================================
+log "Test 2: Create team"
+
+CREATE_RESULT=$(curl -s -X POST "$BRIDGE_URL/api/v1/teams" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"test-team"}')
+TEST_TEAM_ID=$(echo "$CREATE_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+if [ "$TEST_TEAM_ID" != "ERROR" ]; then
+  pass "Created team: $TEST_TEAM_ID"
+else
+  fail "Failed to create team: $CREATE_RESULT"
+fi
+
+# Verify it appears in the list
+log "Test 2b: Team appears in list"
+LIST_RESULT=$(curl -s "$BRIDGE_URL/api/v1/teams" \
+  -H "Authorization: Bearer $ALICE_TOKEN")
+HAS_TEST_TEAM=$(echo "$LIST_RESULT" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+ids=[t.get('id','') for t in d.get('teams',[])]
+print('yes' if '$TEST_TEAM_ID' in ids else 'no')
+")
+if [ "$HAS_TEST_TEAM" = "yes" ]; then
+  pass "Team appears in list"
+else
+  fail "Team not found in list"
+fi
+
+# Get team detail
+log "Test 2c: Get team detail"
+DETAIL=$(curl -s "$BRIDGE_URL/api/v1/teams/$TEST_TEAM_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN")
+DETAIL_NAME=$(echo "$DETAIL" | python3 -c "import json,sys; print(json.load(sys.stdin).get('name',''))")
+CREATOR_IS_MEMBER=$(echo "$DETAIL" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+members=[m.get('username','') for m in d.get('members',[])]
+print('yes' if 'team-alice' in members else 'no')
+")
+if [ "$DETAIL_NAME" = "test-team" ]; then
+  pass "Team detail name is correct"
+else
+  fail "Team detail name is '$DETAIL_NAME' (expected 'test-team')"
+fi
+if [ "$CREATOR_IS_MEMBER" = "yes" ]; then
+  pass "Creator is a member of the team"
+else
+  fail "Creator is not a member of the team"
+fi
+
+# Rename team
+log "Test 2d: Rename team"
+RENAME_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$BRIDGE_URL/api/v1/teams/$TEST_TEAM_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"renamed-team"}')
+if [ "$RENAME_CODE" = "200" ]; then
+  pass "Renamed team (HTTP 200)"
+else
+  fail "Rename returned $RENAME_CODE (expected 200)"
+fi
+
+RENAMED_NAME=$(curl -s "$BRIDGE_URL/api/v1/teams/$TEST_TEAM_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "import json,sys; print(json.load(sys.stdin).get('name',''))")
+if [ "$RENAMED_NAME" = "renamed-team" ]; then
+  pass "Team name updated to 'renamed-team'"
+else
+  fail "Team name is '$RENAMED_NAME' (expected 'renamed-team')"
+fi
+
+# Delete team
+log "Test 2e: Delete team"
+DEL_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$BRIDGE_URL/api/v1/teams/$TEST_TEAM_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN")
+if [ "$DEL_CODE" = "200" ]; then
+  pass "Deleted team (HTTP 200)"
+else
+  fail "Delete returned $DEL_CODE (expected 200)"
+fi
+
+# Verify it's gone
+GONE_CHECK=$(curl -s "$BRIDGE_URL/api/v1/teams" \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+ids=[t.get('id','') for t in d.get('teams',[])]
+print('found' if '$TEST_TEAM_ID' in ids else 'gone')
+")
+if [ "$GONE_CHECK" = "gone" ]; then
+  pass "Team confirmed deleted from list"
+else
+  fail "Team still appears in list after deletion"
+fi
+
+# =====================================================================
+# Test 3: Membership management
+# =====================================================================
+log "Test 3: Membership management"
+
+# Create a team for membership tests
+MEMBER_TEAM=$(curl -s -X POST "$BRIDGE_URL/api/v1/teams" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"member-test-team"}')
+MEMBER_TEAM_ID=$(echo "$MEMBER_TEAM" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+if [ "$MEMBER_TEAM_ID" = "ERROR" ]; then
+  fail "Failed to create team for membership test"
+else
+  pass "Created team for membership test"
+fi
+
+# Add Bob as a member
+log "Test 3b: Add member"
+ADD_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BRIDGE_URL/api/v1/teams/$MEMBER_TEAM_ID/members" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"team-bob"}')
+if [ "$ADD_CODE" = "200" ] || [ "$ADD_CODE" = "201" ]; then
+  pass "Added Bob as member (HTTP $ADD_CODE)"
+else
+  fail "Add member returned $ADD_CODE (expected 200 or 201)"
+fi
+
+# Verify Bob is in members list
+BOB_IN_MEMBERS=$(curl -s "$BRIDGE_URL/api/v1/teams/$MEMBER_TEAM_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+members=[m.get('username','') for m in d.get('members',[])]
+print('yes' if 'team-bob' in members else 'no')
+")
+if [ "$BOB_IN_MEMBERS" = "yes" ]; then
+  pass "Bob appears in team members"
+else
+  fail "Bob not found in team members"
+fi
+
+# Remove Bob
+log "Test 3c: Remove member"
+REMOVE_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+  "$BRIDGE_URL/api/v1/teams/$MEMBER_TEAM_ID/members/team-bob" \
+  -H "Authorization: Bearer $ALICE_TOKEN")
+if [ "$REMOVE_CODE" = "200" ]; then
+  pass "Removed Bob from team (HTTP 200)"
+else
+  fail "Remove member returned $REMOVE_CODE (expected 200)"
+fi
+
+# Verify Bob is gone
+BOB_GONE=$(curl -s "$BRIDGE_URL/api/v1/teams/$MEMBER_TEAM_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+members=[m.get('username','') for m in d.get('members',[])]
+print('yes' if 'team-bob' in members else 'no')
+")
+if [ "$BOB_GONE" = "no" ]; then
+  pass "Bob removed from team members"
+else
+  fail "Bob still in team members after removal"
+fi
+
+# Cleanup
+curl -s -X DELETE "$BRIDGE_URL/api/v1/teams/$MEMBER_TEAM_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN" > /dev/null 2>&1
+
+# =====================================================================
+# Test 4: Personal team constraints
+# =====================================================================
+log "Test 4: Personal team constraints"
+
+# Try to delete personal team
+DEL_PERSONAL_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+  "$BRIDGE_URL/api/v1/teams/$PERSONAL_TEAM_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN")
+if [ "$DEL_PERSONAL_CODE" = "400" ] || [ "$DEL_PERSONAL_CODE" = "403" ]; then
+  pass "Cannot delete personal team (HTTP $DEL_PERSONAL_CODE)"
+else
+  fail "Delete personal team returned $DEL_PERSONAL_CODE (expected 400 or 403)"
+fi
+
+# Try to add member to personal team
+ADD_PERSONAL_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+  "$BRIDGE_URL/api/v1/teams/$PERSONAL_TEAM_ID/members" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"team-bob"}')
+if [ "$ADD_PERSONAL_CODE" = "400" ] || [ "$ADD_PERSONAL_CODE" = "403" ]; then
+  pass "Cannot add member to personal team (HTTP $ADD_PERSONAL_CODE)"
+else
+  fail "Add member to personal team returned $ADD_PERSONAL_CODE (expected 400 or 403)"
+fi
+
+# Try to rename personal team
+RENAME_PERSONAL_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+  "$BRIDGE_URL/api/v1/teams/$PERSONAL_TEAM_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"hacked-personal"}')
+if [ "$RENAME_PERSONAL_CODE" = "400" ] || [ "$RENAME_PERSONAL_CODE" = "403" ]; then
+  pass "Cannot rename personal team (HTTP $RENAME_PERSONAL_CODE)"
+else
+  fail "Rename personal team returned $RENAME_PERSONAL_CODE (expected 400 or 403)"
+fi
+
+# =====================================================================
+# Test 5: Team-scoped resource isolation
+# =====================================================================
+log "Test 5: Team-scoped resource isolation"
+
+# Create team-a
+TEAM_A_RESULT=$(curl -s -X POST "$BRIDGE_URL/api/v1/teams" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"team-a"}')
+TEAM_A_ID=$(echo "$TEAM_A_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+if [ "$TEAM_A_ID" != "ERROR" ]; then
+  pass "Created team-a"
+else
+  fail "Failed to create team-a: $TEAM_A_RESULT"
+fi
+
+# Create a credential scoped to team-a
+CRED_A_RESULT=$(curl -s -X POST "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Alcove-Team: $TEAM_A_ID" \
+  -d '{"name":"team-a-cred","provider":"anthropic","auth_type":"api_key","credential":"sk-ant-team-a-key"}')
+CRED_A_ID=$(echo "$CRED_A_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+if [ "$CRED_A_ID" != "ERROR" ]; then
+  pass "Created credential in team-a"
+else
+  fail "Failed to create credential in team-a: $CRED_A_RESULT"
+fi
+
+# List credentials with X-Alcove-Team set to team-a — should see the credential
+TEAM_A_CREDS=$(curl -s "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "X-Alcove-Team: $TEAM_A_ID" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+names=[c.get('name','') for c in d.get('credentials',[])]
+print('yes' if 'team-a-cred' in names else 'no')
+")
+if [ "$TEAM_A_CREDS" = "yes" ]; then
+  pass "Credential visible in team-a scope"
+else
+  fail "Credential not visible in team-a scope"
+fi
+
+# List credentials WITHOUT X-Alcove-Team (defaults to personal team) — should NOT see it
+PERSONAL_CREDS=$(curl -s "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+names=[c.get('name','') for c in d.get('credentials',[])]
+print('yes' if 'team-a-cred' in names else 'no')
+")
+if [ "$PERSONAL_CREDS" = "no" ]; then
+  pass "Credential NOT visible in personal team scope"
+else
+  fail "Credential visible in personal team scope (should be isolated)"
+fi
+
+# Delete team-a (credential should cascade-delete)
+curl -s -X DELETE "$BRIDGE_URL/api/v1/teams/$TEAM_A_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN" > /dev/null 2>&1
+
+# Verify credential is gone after team deletion
+CRED_AFTER_DELETE=$(curl -s -o /dev/null -w "%{http_code}" \
+  "$BRIDGE_URL/api/v1/credentials/$CRED_A_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN")
+if [ "$CRED_AFTER_DELETE" = "404" ]; then
+  pass "Credential cascade-deleted with team"
+else
+  fail "Credential still exists after team deletion (HTTP $CRED_AFTER_DELETE)"
+fi
+
+# =====================================================================
+# Test 6: Cross-team isolation
+# =====================================================================
+log "Test 6: Cross-team isolation"
+
+# Create team-x and team-y
+TEAM_X_RESULT=$(curl -s -X POST "$BRIDGE_URL/api/v1/teams" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"team-x"}')
+TEAM_X_ID=$(echo "$TEAM_X_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+
+TEAM_Y_RESULT=$(curl -s -X POST "$BRIDGE_URL/api/v1/teams" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"team-y"}')
+TEAM_Y_ID=$(echo "$TEAM_Y_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+
+if [ "$TEAM_X_ID" != "ERROR" ] && [ "$TEAM_Y_ID" != "ERROR" ]; then
+  pass "Created team-x and team-y"
+else
+  fail "Failed to create teams: team-x=$TEAM_X_ID, team-y=$TEAM_Y_ID"
+fi
+
+# Create credential with same name in team-x
+CRED_X_RESULT=$(curl -s -w "\n%{http_code}" -X POST "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Alcove-Team: $TEAM_X_ID" \
+  -d '{"name":"shared-name-cred","provider":"anthropic","auth_type":"api_key","credential":"sk-ant-team-x-key"}')
+CRED_X_CODE=$(echo "$CRED_X_RESULT" | tail -1)
+CRED_X_ID=$(echo "$CRED_X_RESULT" | head -1 | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+if [ "$CRED_X_ID" != "ERROR" ]; then
+  pass "Created credential in team-x"
+else
+  fail "Failed to create credential in team-x (HTTP $CRED_X_CODE)"
+fi
+
+# Create credential with same name in team-y — should succeed (unique per team)
+CRED_Y_RESULT=$(curl -s -w "\n%{http_code}" -X POST "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Alcove-Team: $TEAM_Y_ID" \
+  -d '{"name":"shared-name-cred","provider":"anthropic","auth_type":"api_key","credential":"sk-ant-team-y-key"}')
+CRED_Y_CODE=$(echo "$CRED_Y_RESULT" | tail -1)
+CRED_Y_ID=$(echo "$CRED_Y_RESULT" | head -1 | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+if [ "$CRED_Y_ID" != "ERROR" ]; then
+  pass "Same-name credential allowed in team-y (unique per team)"
+else
+  fail "Same-name credential rejected in team-y (HTTP $CRED_Y_CODE, expected success)"
+fi
+
+# List credentials for team-x — see only team-x's credential
+TEAM_X_CRED_IDS=$(curl -s "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "X-Alcove-Team: $TEAM_X_ID" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+ids=[c.get('id','') for c in d.get('credentials',[])]
+print(' '.join(ids))
+")
+if echo "$TEAM_X_CRED_IDS" | grep -q "$CRED_X_ID"; then
+  pass "Team-x credential visible in team-x scope"
+else
+  fail "Team-x credential NOT visible in team-x scope"
+fi
+if echo "$TEAM_X_CRED_IDS" | grep -q "$CRED_Y_ID"; then
+  fail "Team-y credential visible in team-x scope (isolation broken)"
+else
+  pass "Team-y credential NOT visible in team-x scope"
+fi
+
+# List credentials for team-y — see only team-y's credential
+TEAM_Y_CRED_IDS=$(curl -s "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "X-Alcove-Team: $TEAM_Y_ID" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+ids=[c.get('id','') for c in d.get('credentials',[])]
+print(' '.join(ids))
+")
+if echo "$TEAM_Y_CRED_IDS" | grep -q "$CRED_Y_ID"; then
+  pass "Team-y credential visible in team-y scope"
+else
+  fail "Team-y credential NOT visible in team-y scope"
+fi
+if echo "$TEAM_Y_CRED_IDS" | grep -q "$CRED_X_ID"; then
+  fail "Team-x credential visible in team-y scope (isolation broken)"
+else
+  pass "Team-x credential NOT visible in team-y scope"
+fi
+
+# Cleanup: delete both teams (credentials should cascade-delete)
+curl -s -X DELETE "$BRIDGE_URL/api/v1/teams/$TEAM_X_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN" > /dev/null 2>&1
+curl -s -X DELETE "$BRIDGE_URL/api/v1/teams/$TEAM_Y_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN" > /dev/null 2>&1
+
+# =====================================================================
+# Test 7: Backward compatibility
+# =====================================================================
+log "Test 7: Backward compatibility"
+
+# Create a credential WITHOUT X-Alcove-Team header (should use personal team)
+COMPAT_CRED_RESULT=$(curl -s -X POST "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"compat-cred","provider":"anthropic","auth_type":"api_key","credential":"sk-ant-compat-key"}')
+COMPAT_CRED_ID=$(echo "$COMPAT_CRED_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+if [ "$COMPAT_CRED_ID" != "ERROR" ]; then
+  pass "Created credential without X-Alcove-Team header"
+else
+  fail "Failed to create credential without X-Alcove-Team: $COMPAT_CRED_RESULT"
+fi
+
+# List credentials without X-Alcove-Team — should see the credential
+COMPAT_LIST=$(curl -s "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+names=[c.get('name','') for c in d.get('credentials',[])]
+print('yes' if 'compat-cred' in names else 'no')
+")
+if [ "$COMPAT_LIST" = "yes" ]; then
+  pass "Credential visible without X-Alcove-Team header (personal team default)"
+else
+  fail "Credential not visible without X-Alcove-Team header"
+fi
+
+# Create a schedule WITHOUT X-Alcove-Team header (should use personal team)
+COMPAT_SCHED_RESULT=$(curl -s -X POST "$BRIDGE_URL/api/v1/schedules" \
+  -H "Authorization: Bearer $ALICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"compat-schedule","cron":"0 * * * *","prompt":"backward compat test","enabled":false}')
+COMPAT_SCHED_ID=$(echo "$COMPAT_SCHED_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+if [ "$COMPAT_SCHED_ID" != "ERROR" ]; then
+  pass "Created schedule without X-Alcove-Team header"
+else
+  fail "Failed to create schedule without X-Alcove-Team: $COMPAT_SCHED_RESULT"
+fi
+
+# List schedules without X-Alcove-Team — should see the schedule
+COMPAT_SCHED_LIST=$(curl -s "$BRIDGE_URL/api/v1/schedules" \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+names=[s.get('name','') for s in d.get('schedules',[])]
+print('yes' if 'compat-schedule' in names else 'no')
+")
+if [ "$COMPAT_SCHED_LIST" = "yes" ]; then
+  pass "Schedule visible without X-Alcove-Team header (personal team default)"
+else
+  fail "Schedule not visible without X-Alcove-Team header"
+fi
+
+# Cleanup
+curl -s -X DELETE "$BRIDGE_URL/api/v1/credentials/$COMPAT_CRED_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN" > /dev/null 2>&1
+curl -s -X DELETE "$BRIDGE_URL/api/v1/schedules/$COMPAT_SCHED_ID" \
+  -H "Authorization: Bearer $ALICE_TOKEN" > /dev/null 2>&1
+
+# --- Summary ---
+echo ""
+log "=== Test Summary ==="
+echo "  Total: $((PASS+FAIL))  Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then exit 1; else echo "  All tests passed."; fi

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2521,6 +2521,178 @@ details[open] > .tx-tool-expand-toggle::before {
     margin-left: 21px;
 }
 
+/* === Team Switcher === */
+.team-switcher {
+    position: relative;
+    margin-right: 8px;
+}
+
+.team-switcher-toggle {
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    padding: 6px 12px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    transition: border-color 0.2s;
+    max-width: 200px;
+}
+
+.team-switcher-toggle:hover {
+    border-color: var(--accent);
+}
+
+.active-team-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.team-switcher-menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 4px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    min-width: 220px;
+    max-height: 320px;
+    overflow-y: auto;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    z-index: 100;
+}
+
+.team-switcher-menu[hidden] {
+    display: none !important;
+}
+
+.team-switcher-item {
+    display: block;
+    width: 100%;
+    padding: 10px 16px;
+    background: transparent;
+    border: none;
+    color: var(--text);
+    font-size: 13px;
+    text-align: left;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.team-switcher-item:hover {
+    background: var(--bg-input);
+}
+
+.team-switcher-item.active {
+    color: var(--status-running);
+    font-weight: 600;
+}
+
+.team-switcher-separator {
+    height: 1px;
+    background: var(--border);
+    margin: 4px 0;
+}
+
+.team-switcher-manage {
+    display: block;
+    width: 100%;
+    padding: 10px 16px;
+    background: transparent;
+    border: none;
+    border-top: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 12px;
+    text-align: left;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.team-switcher-manage:hover {
+    background: var(--bg-input);
+    color: var(--text);
+}
+
+/* === Teams Page === */
+.team-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 16px;
+    margin-bottom: 12px;
+    cursor: pointer;
+    transition: border-color var(--transition), background var(--transition);
+}
+
+.team-card:hover {
+    border-color: var(--text-muted);
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.team-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.team-card-name {
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--text);
+}
+
+.team-card-badge {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: rgba(52, 152, 219, 0.15);
+    color: var(--status-running);
+    font-weight: 500;
+}
+
+.team-card-meta {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 6px;
+}
+
+/* Team detail members */
+.team-member-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background: rgba(0, 0, 0, 0.15);
+    border-radius: 6px;
+    margin-bottom: 6px;
+    font-size: 13px;
+}
+
+.team-member-name {
+    font-weight: 500;
+    color: var(--text);
+}
+
+.team-member-remove {
+    cursor: pointer;
+    color: var(--status-error);
+    background: none;
+    border: none;
+    font-size: 14px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    transition: background 0.15s;
+}
+
+.team-member-remove:hover {
+    background: rgba(231, 76, 60, 0.15);
+}
+
 /* === Footer === */
 .alcove-footer {
     text-align: center;

--- a/web/index.html
+++ b/web/index.html
@@ -61,11 +61,21 @@
                 <a href="#credentials" class="nav-tab" data-tab="credentials">Credentials</a>
                 <a href="#security" class="nav-tab" data-tab="security">Security</a>
                 <a href="#repos" class="nav-tab" data-tab="repos">Repos</a>
+                <a href="#teams" class="nav-tab" data-tab="teams">Teams</a>
                 <div style="flex:1;"></div>
                 <a href="#account" class="nav-tab" data-tab="account" id="account-tab" hidden>Account</a>
                 <a href="#users" class="nav-tab nav-admin-only" data-tab="users" hidden>Users</a>
             </nav>
             <div class="top-bar-right">
+                <div class="team-switcher" id="team-switcher">
+                    <button class="team-switcher-toggle" id="team-switcher-toggle">
+                        <span id="active-team-name" class="active-team-name">My Workspace</span>
+                        <span class="dropdown-arrow">&#9662;</span>
+                    </button>
+                    <div class="team-switcher-menu" id="team-switcher-menu" hidden>
+                        <div id="team-switcher-list"></div>
+                    </div>
+                </div>
                 <div class="user-dropdown" id="user-dropdown">
                     <button class="user-dropdown-toggle" id="user-dropdown-toggle">
                         <span id="user-info" class="user-info"></span>
@@ -501,6 +511,101 @@
                             <div>
                                 <button id="skill-repo-add-inline" class="btn btn-small btn-primary">Add</button>
                             </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Teams -->
+            <div id="page-teams" class="page" hidden>
+                <div class="page-header">
+                    <h2>Teams</h2>
+                    <button id="show-create-team" class="btn btn-small btn-primary">Create Team</button>
+                </div>
+
+                <div id="create-team-form-container" class="form-card" hidden>
+                    <form id="create-team-form">
+                        <div class="form-group">
+                            <label for="new-team-name">Team Name <span class="required">*</span></label>
+                            <input type="text" id="new-team-name" class="input" placeholder="e.g., Backend Team" required>
+                        </div>
+                        <div id="create-team-error" class="error-message" role="alert" hidden></div>
+                        <div style="display:flex;gap:8px;margin-top:16px;">
+                            <button type="submit" class="btn btn-primary">Create Team</button>
+                            <button type="button" id="cancel-create-team" class="btn btn-outline">Cancel</button>
+                        </div>
+                    </form>
+                </div>
+
+                <div id="teams-list"></div>
+                <div id="teams-empty" class="empty-state" hidden><p>No teams found.</p></div>
+                <div id="teams-loading" class="loading-state" hidden><div class="spinner"></div><p>Loading teams...</p></div>
+            </div>
+
+            <!-- Team Detail -->
+            <div id="page-team-detail" class="page" hidden>
+                <div class="page-header">
+                    <button id="back-to-teams" class="btn btn-small btn-outline">Back to Teams</button>
+                    <h2 id="team-detail-title">Team Detail</h2>
+                </div>
+
+                <div id="team-detail-content">
+                    <!-- Team Name Section -->
+                    <div class="form-card" style="margin-bottom:24px;">
+                        <h3>Team Settings</h3>
+                        <div id="team-name-section">
+                            <div class="form-group">
+                                <label for="team-detail-name">Team Name</label>
+                                <div style="display:flex;gap:8px;align-items:center;">
+                                    <input type="text" id="team-detail-name" class="input" style="max-width:300px;">
+                                    <button id="team-save-name" class="btn btn-small btn-primary">Save</button>
+                                </div>
+                            </div>
+                            <div id="team-name-error" class="error-message" role="alert" hidden></div>
+                            <div id="team-name-success" class="success-message" role="status" hidden></div>
+                        </div>
+                        <div id="team-delete-section" style="margin-top:16px;padding-top:16px;border-top:1px solid var(--border);">
+                            <button id="team-delete-btn" class="btn btn-small btn-outline" style="color:var(--status-error);border-color:var(--status-error);">Delete Team</button>
+                        </div>
+                    </div>
+
+                    <!-- Members Section -->
+                    <div class="form-card" style="margin-bottom:24px;">
+                        <h3>Members</h3>
+                        <div id="team-members-list" style="margin-bottom:16px;"></div>
+                        <div id="team-add-member-section">
+                            <div style="display:flex;gap:8px;align-items:flex-end;">
+                                <div style="flex:1;max-width:300px;">
+                                    <label class="input-label">Username</label>
+                                    <input type="text" id="team-add-member-username" class="input" placeholder="username">
+                                </div>
+                                <button id="team-add-member-btn" class="btn btn-small btn-primary">Add Member</button>
+                            </div>
+                            <div id="team-member-error" class="error-message" role="alert" hidden style="margin-top:8px;"></div>
+                            <div id="team-member-success" class="success-message" role="status" hidden style="margin-top:8px;"></div>
+                        </div>
+                    </div>
+
+                    <!-- Agent Repos Section (team-scoped) -->
+                    <div class="form-card" style="margin-bottom:24px;">
+                        <h3>Agent Repos</h3>
+                        <p class="form-help" style="margin-bottom:12px;">Git repositories containing <code>.alcove/tasks/</code> with YAML agent definitions and <code>.alcove/security-profiles/</code> with security profiles.</p>
+                        <div id="team-task-repos-list"></div>
+                        <div class="repo-add-form" style="margin-top:12px;">
+                            <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end;">
+                                <div style="flex:2;min-width:200px;">
+                                    <label class="input-label">Repository URL</label>
+                                    <input type="text" id="team-task-repo-url" class="input" placeholder="https://github.com/org/repo.git">
+                                </div>
+                                <div style="flex:0.5;min-width:80px;">
+                                    <label class="input-label">Branch</label>
+                                    <input type="text" id="team-task-repo-ref" class="input" placeholder="main">
+                                </div>
+                                <div>
+                                    <button id="team-task-repo-add" class="btn btn-small btn-primary">Add</button>
+                                </div>
+                            </div>
+                            <div id="team-task-repo-status" class="form-help" style="margin-top:6px;" hidden></div>
                         </div>
                     </div>
                 </div>
@@ -1132,6 +1237,22 @@ cat ~/.config/gcloud/application_default_credentials.json   # or just cat and co
             </div>
         </form>
     </template>
+
+    <!-- Delete Team Confirmation Modal -->
+    <div id="delete-team-modal" class="modal-overlay" hidden>
+        <div class="modal-card">
+            <h3>Delete Team</h3>
+            <p class="form-help" style="margin-bottom:12px;">Are you sure you want to delete <strong id="delete-team-name"></strong>?</p>
+            <div class="warning-message" style="background: #fee; border: 1px solid #f66; border-radius: 6px; padding: 12px; margin-bottom: 16px;">
+                <strong>Warning:</strong> This action cannot be undone. All team data including credentials, sessions, and configurations associated with this team will be permanently deleted.
+            </div>
+            <div id="delete-team-error" class="error-message" role="alert" hidden></div>
+            <div style="display:flex;gap:8px;margin-top:16px;">
+                <button id="confirm-delete-team" class="btn btn-primary" style="background:var(--status-error);">Delete Team</button>
+                <button id="cancel-delete-team" class="btn btn-outline">Cancel</button>
+            </div>
+        </div>
+    </div>
 
     <script src="js/app.js"></script>
 </body>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -22,6 +22,10 @@
         if (token && !rhIdentityMode) {
             headers['Authorization'] = 'Bearer ' + token;
         }
+        // Include active team header on all requests
+        if (activeTeamId) {
+            headers['X-Alcove-Team'] = activeTeamId;
+        }
         const opts = { method, headers };
         if (body) opts.body = JSON.stringify(body);
         const resp = await fetch(basePath + path, opts);
@@ -124,6 +128,11 @@
     let proxyLogSortField = 'timestamp';
     let proxyLogSortAsc = true;
 
+    // Teams state
+    let teamsList = [];
+    let activeTeamId = null;
+    let viewingTeamId = null;
+
     // ---------------------
     // Auth
     // ---------------------
@@ -187,6 +196,8 @@
         }).catch(() => {});
         updateAdminUI(); // also call immediately with cached value
         updateRHIdentityUI();
+        // Load teams for the switcher (non-blocking)
+        loadTeams().catch(function() {});
         startSystemStateCheck();
     }
 
@@ -281,11 +292,14 @@
         e.stopPropagation();
         const menu = $('#user-dropdown-menu');
         menu.hidden = !menu.hidden;
+        // Close team switcher if open
+        hide($('#team-switcher-menu'));
     });
 
-    // Close dropdown when clicking outside
+    // Close dropdowns when clicking outside
     document.addEventListener('click', () => {
         hide($('#user-dropdown-menu'));
+        hide($('#team-switcher-menu'));
     });
 
     // Prevent menu clicks from closing
@@ -1230,13 +1244,14 @@
         stopSSE();
 
         const route = getRoute();
-        const pages = ['sessions', 'task-new', 'schedules', 'repos', 'credentials', 'security', 'tools', 'session-detail', 'users', 'account', 'workflows', 'workflow-detail'];
+        const pages = ['sessions', 'task-new', 'schedules', 'repos', 'credentials', 'security', 'tools', 'session-detail', 'users', 'account', 'workflows', 'workflow-detail', 'teams', 'team-detail'];
         pages.forEach((p) => hide($('#page-' + p)));
 
         // Update active nav tab
         var navRoute = route.startsWith('session/') ? 'sessions' : route;
         if (navRoute === 'tools' || navRoute === 'tools-admin') navRoute = 'security';
         if (route.startsWith('workflow-run/')) navRoute = 'workflows';
+        if (route.startsWith('team/')) navRoute = 'teams';
         $$('.nav-tab').forEach((tab) => {
             tab.classList.toggle('active', tab.dataset.tab === navRoute);
         });
@@ -1290,6 +1305,13 @@
         } else if (route === 'account') {
             show($('#page-account'));
             loadAccountPage();
+        } else if (route === 'teams') {
+            show($('#page-teams'));
+            loadTeamsPage();
+        } else if (route.startsWith('team/')) {
+            var teamId = route.replace('team/', '');
+            show($('#page-team-detail'));
+            loadTeamDetail(teamId);
         } else {
             show($('#page-sessions'));
             loadSessions();
@@ -6270,6 +6292,567 @@
     }
 
     // ---------------------
+    // Teams
+    // ---------------------
+
+    async function loadTeams() {
+        try {
+            // Temporarily clear activeTeamId so this request is not scoped
+            var savedTeamId = activeTeamId;
+            activeTeamId = null;
+            var resp = await api('GET', '/api/v1/teams');
+            activeTeamId = savedTeamId;
+            if (!resp.ok) return;
+            var data = await resp.json();
+            teamsList = data.teams || [];
+
+            // Restore active team from localStorage or default to personal
+            var savedId = localStorage.getItem('alcove_active_team');
+            var found = teamsList.find(function(t) { return t.id === savedId; });
+            if (found) {
+                activeTeamId = found.id;
+            } else {
+                // Default to personal team
+                var personal = teamsList.find(function(t) { return t.is_personal; });
+                activeTeamId = personal ? personal.id : (teamsList.length > 0 ? teamsList[0].id : null);
+            }
+            if (activeTeamId) {
+                localStorage.setItem('alcove_active_team', activeTeamId);
+            }
+            renderTeamSwitcher();
+        } catch (err) {
+            // Teams API may not be available yet; fail silently
+            console.debug('Failed to load teams:', err);
+        }
+    }
+
+    function getActiveTeamName() {
+        if (!activeTeamId || teamsList.length === 0) return 'My Workspace';
+        var team = teamsList.find(function(t) { return t.id === activeTeamId; });
+        if (!team) return 'My Workspace';
+        return team.is_personal ? 'My Workspace' : team.name;
+    }
+
+    function renderTeamSwitcher() {
+        var nameEl = $('#active-team-name');
+        if (nameEl) nameEl.textContent = getActiveTeamName();
+
+        var listEl = $('#team-switcher-list');
+        if (!listEl) return;
+
+        var html = '';
+        for (var i = 0; i < teamsList.length; i++) {
+            var t = teamsList[i];
+            var displayName = t.is_personal ? 'My Workspace' : escapeHtml(t.name);
+            var isActive = t.id === activeTeamId;
+            html += '<button class="team-switcher-item' + (isActive ? ' active' : '') + '" data-team-id="' + escapeHtml(t.id) + '">' + displayName + '</button>';
+        }
+        html += '<button class="team-switcher-manage" id="team-switcher-manage-btn">Manage Teams</button>';
+        listEl.innerHTML = html;
+
+        // Event listeners for team items
+        listEl.querySelectorAll('.team-switcher-item').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                var teamId = btn.getAttribute('data-team-id');
+                if (teamId !== activeTeamId) {
+                    activeTeamId = teamId;
+                    localStorage.setItem('alcove_active_team', teamId);
+                    renderTeamSwitcher();
+                    hide($('#team-switcher-menu'));
+                    // Reload the current view with new team context
+                    handleRoute();
+                } else {
+                    hide($('#team-switcher-menu'));
+                }
+            });
+        });
+
+        var manageBtn = $('#team-switcher-manage-btn');
+        if (manageBtn) {
+            manageBtn.addEventListener('click', function() {
+                hide($('#team-switcher-menu'));
+                navigate('teams');
+            });
+        }
+    }
+
+    // Team switcher toggle
+    $('#team-switcher-toggle').addEventListener('click', function(e) {
+        e.stopPropagation();
+        var menu = $('#team-switcher-menu');
+        menu.hidden = !menu.hidden;
+        // Close user dropdown if open
+        hide($('#user-dropdown-menu'));
+    });
+
+    // Prevent team menu clicks from closing via document handler
+    $('#team-switcher-menu').addEventListener('click', function(e) {
+        e.stopPropagation();
+    });
+
+    // Teams list page
+    async function loadTeamsPage() {
+        var listEl = $('#teams-list');
+        var emptyEl = $('#teams-empty');
+        var loadingEl = $('#teams-loading');
+
+        show(loadingEl);
+        hide(emptyEl);
+        listEl.innerHTML = '';
+
+        try {
+            var savedTeamId = activeTeamId;
+            activeTeamId = null;
+            var resp = await api('GET', '/api/v1/teams');
+            activeTeamId = savedTeamId;
+            if (!resp.ok) {
+                hide(loadingEl);
+                listEl.innerHTML = '<p class="error-message">Failed to load teams.</p>';
+                return;
+            }
+            var data = await resp.json();
+            var teams = data.teams || [];
+            hide(loadingEl);
+
+            if (teams.length === 0) {
+                show(emptyEl);
+                return;
+            }
+
+            var html = '';
+            for (var i = 0; i < teams.length; i++) {
+                var t = teams[i];
+                var displayName = t.is_personal ? 'My Workspace (Personal)' : escapeHtml(t.name);
+                var badge = t.is_personal ? '<span class="team-card-badge">Personal</span>' : '';
+                var isActive = t.id === activeTeamId;
+                var activeIndicator = isActive ? '<span class="team-card-badge" style="background:rgba(46,204,113,0.15);color:var(--status-completed);">Active</span>' : '';
+                var createdDate = t.created_at ? new Date(t.created_at).toLocaleDateString() : '';
+                html += '<div class="team-card" data-team-id="' + escapeHtml(t.id) + '">';
+                html += '<div class="team-card-header">';
+                html += '<span class="team-card-name">' + displayName + '</span>';
+                html += '<span style="display:flex;gap:6px;">' + activeIndicator + badge + '</span>';
+                html += '</div>';
+                if (createdDate) html += '<div class="team-card-meta">Created ' + escapeHtml(createdDate) + '</div>';
+                html += '</div>';
+            }
+            listEl.innerHTML = html;
+
+            // Click handlers for team cards
+            listEl.querySelectorAll('.team-card').forEach(function(card) {
+                card.addEventListener('click', function() {
+                    var teamId = card.getAttribute('data-team-id');
+                    navigate('team/' + teamId);
+                });
+            });
+        } catch (err) {
+            hide(loadingEl);
+            if (err.message !== 'unauthorized' && err.message !== 'rh-identity-auth-error') {
+                listEl.innerHTML = '<p class="error-message">Failed to load teams.</p>';
+            }
+        }
+    }
+
+    // Create team
+    $('#show-create-team').addEventListener('click', function() {
+        show($('#create-team-form-container'));
+        hide($('#create-team-error'));
+        $('#new-team-name').value = '';
+        $('#new-team-name').focus();
+    });
+
+    $('#cancel-create-team').addEventListener('click', function() {
+        hide($('#create-team-form-container'));
+    });
+
+    $('#create-team-form').addEventListener('submit', async function(e) {
+        e.preventDefault();
+        var name = $('#new-team-name').value.trim();
+        if (!name) return;
+
+        var errEl = $('#create-team-error');
+        hide(errEl);
+
+        try {
+            var savedTeamId = activeTeamId;
+            activeTeamId = null;
+            var resp = await api('POST', '/api/v1/teams', { name: name });
+            activeTeamId = savedTeamId;
+            if (!resp.ok) {
+                var data = await resp.json().catch(function() { return {}; });
+                errEl.textContent = data.error || data.message || 'Failed to create team.';
+                show(errEl);
+                return;
+            }
+            hide($('#create-team-form-container'));
+            // Refresh teams list and switcher
+            await loadTeams();
+            loadTeamsPage();
+        } catch (err) {
+            if (err.message !== 'unauthorized' && err.message !== 'rh-identity-auth-error') {
+                errEl.textContent = 'Failed to create team.';
+                show(errEl);
+            }
+        }
+    });
+
+    // Team detail page
+    async function loadTeamDetail(teamId) {
+        viewingTeamId = teamId;
+
+        try {
+            var savedTeamId = activeTeamId;
+            activeTeamId = null;
+            var resp = await api('GET', '/api/v1/teams/' + teamId);
+            activeTeamId = savedTeamId;
+            if (!resp.ok) {
+                $('#team-detail-content').innerHTML = '<p class="error-message">Failed to load team details.</p>';
+                return;
+            }
+            var team = await resp.json();
+
+            // Set title
+            var displayName = team.is_personal ? 'My Workspace' : team.name;
+            $('#team-detail-title').textContent = displayName;
+
+            // Team name editing
+            var nameInput = $('#team-detail-name');
+            nameInput.value = team.name;
+            if (team.is_personal) {
+                nameInput.disabled = true;
+                $('#team-save-name').hidden = true;
+            } else {
+                nameInput.disabled = false;
+                $('#team-save-name').hidden = false;
+            }
+            hide($('#team-name-error'));
+            hide($('#team-name-success'));
+
+            // Delete section
+            var deleteSection = $('#team-delete-section');
+            if (team.is_personal) {
+                deleteSection.hidden = true;
+            } else {
+                deleteSection.hidden = false;
+            }
+
+            // Members
+            renderTeamMembers(team.members || [], team.is_personal);
+
+            // Add member section visibility
+            var addMemberSection = $('#team-add-member-section');
+            if (team.is_personal) {
+                addMemberSection.hidden = true;
+            } else {
+                addMemberSection.hidden = false;
+            }
+            hide($('#team-member-error'));
+            hide($('#team-member-success'));
+
+            // Load agent repos for this team
+            loadTeamTaskRepos(teamId);
+
+        } catch (err) {
+            if (err.message !== 'unauthorized' && err.message !== 'rh-identity-auth-error') {
+                $('#team-detail-content').innerHTML = '<p class="error-message">Failed to load team details.</p>';
+            }
+        }
+    }
+
+    function renderTeamMembers(members, isPersonal) {
+        var listEl = $('#team-members-list');
+        if (!members || members.length === 0) {
+            listEl.innerHTML = '<p style="color:var(--text-muted);font-size:13px;">No members.</p>';
+            return;
+        }
+        var html = '';
+        for (var i = 0; i < members.length; i++) {
+            var m = members[i];
+            var username = m.username || m;
+            html += '<div class="team-member-item">';
+            html += '<span class="team-member-name">' + escapeHtml(username) + '</span>';
+            if (!isPersonal) {
+                html += '<button class="team-member-remove" data-username="' + escapeHtml(username) + '" title="Remove member">x</button>';
+            }
+            html += '</div>';
+        }
+        listEl.innerHTML = html;
+
+        // Remove member handlers
+        if (!isPersonal) {
+            listEl.querySelectorAll('.team-member-remove').forEach(function(btn) {
+                btn.addEventListener('click', async function() {
+                    var username = btn.getAttribute('data-username');
+                    await removeTeamMember(viewingTeamId, username);
+                });
+            });
+        }
+    }
+
+    // Save team name
+    $('#team-save-name').addEventListener('click', async function() {
+        var name = $('#team-detail-name').value.trim();
+        if (!name) return;
+
+        var errEl = $('#team-name-error');
+        var successEl = $('#team-name-success');
+        hide(errEl);
+        hide(successEl);
+
+        try {
+            var savedTeamId = activeTeamId;
+            activeTeamId = null;
+            var resp = await api('PUT', '/api/v1/teams/' + viewingTeamId, { name: name });
+            activeTeamId = savedTeamId;
+            if (!resp.ok) {
+                var data = await resp.json().catch(function() { return {}; });
+                errEl.textContent = data.error || data.message || 'Failed to update team name.';
+                show(errEl);
+                return;
+            }
+            successEl.textContent = 'Team name updated.';
+            show(successEl);
+            $('#team-detail-title').textContent = name;
+            // Refresh team list in switcher
+            await loadTeams();
+        } catch (err) {
+            if (err.message !== 'unauthorized' && err.message !== 'rh-identity-auth-error') {
+                errEl.textContent = 'Failed to update team name.';
+                show(errEl);
+            }
+        }
+    });
+
+    // Add team member
+    $('#team-add-member-btn').addEventListener('click', async function() {
+        var username = $('#team-add-member-username').value.trim();
+        if (!username) return;
+
+        var errEl = $('#team-member-error');
+        var successEl = $('#team-member-success');
+        hide(errEl);
+        hide(successEl);
+
+        try {
+            var savedTeamId = activeTeamId;
+            activeTeamId = null;
+            var resp = await api('POST', '/api/v1/teams/' + viewingTeamId + '/members', { username: username });
+            activeTeamId = savedTeamId;
+            if (!resp.ok) {
+                var data = await resp.json().catch(function() { return {}; });
+                errEl.textContent = data.error || data.message || 'Failed to add member.';
+                show(errEl);
+                return;
+            }
+            $('#team-add-member-username').value = '';
+            successEl.textContent = 'Member added.';
+            show(successEl);
+            // Reload team detail
+            loadTeamDetail(viewingTeamId);
+        } catch (err) {
+            if (err.message !== 'unauthorized' && err.message !== 'rh-identity-auth-error') {
+                errEl.textContent = 'Failed to add member.';
+                show(errEl);
+            }
+        }
+    });
+
+    async function removeTeamMember(teamId, username) {
+        if (!confirm('Remove ' + username + ' from this team?')) return;
+
+        try {
+            var savedTeamId = activeTeamId;
+            activeTeamId = null;
+            var resp = await api('DELETE', '/api/v1/teams/' + teamId + '/members/' + encodeURIComponent(username));
+            activeTeamId = savedTeamId;
+            if (!resp.ok) {
+                var data = await resp.json().catch(function() { return {}; });
+                alert(data.error || data.message || 'Failed to remove member.');
+                return;
+            }
+            loadTeamDetail(teamId);
+        } catch (err) {
+            if (err.message !== 'unauthorized' && err.message !== 'rh-identity-auth-error') {
+                alert('Failed to remove member.');
+            }
+        }
+    }
+
+    // Delete team
+    $('#team-delete-btn').addEventListener('click', function() {
+        var team = teamsList.find(function(t) { return t.id === viewingTeamId; });
+        if (!team) return;
+        $('#delete-team-name').textContent = team.name;
+        hide($('#delete-team-error'));
+        show($('#delete-team-modal'));
+    });
+
+    $('#cancel-delete-team').addEventListener('click', function() {
+        hide($('#delete-team-modal'));
+    });
+
+    $('#delete-team-modal').addEventListener('click', function(e) {
+        if (e.target === e.currentTarget) hide(e.currentTarget);
+    });
+
+    $('#confirm-delete-team').addEventListener('click', async function() {
+        var errEl = $('#delete-team-error');
+        hide(errEl);
+
+        try {
+            var savedTeamId = activeTeamId;
+            activeTeamId = null;
+            var resp = await api('DELETE', '/api/v1/teams/' + viewingTeamId);
+            activeTeamId = savedTeamId;
+            if (!resp.ok) {
+                var data = await resp.json().catch(function() { return {}; });
+                errEl.textContent = data.error || data.message || 'Failed to delete team.';
+                show(errEl);
+                return;
+            }
+            hide($('#delete-team-modal'));
+            // If deleting the active team, switch to personal team
+            if (viewingTeamId === activeTeamId) {
+                localStorage.removeItem('alcove_active_team');
+            }
+            await loadTeams();
+            navigate('teams');
+        } catch (err) {
+            if (err.message !== 'unauthorized' && err.message !== 'rh-identity-auth-error') {
+                errEl.textContent = 'Failed to delete team.';
+                show(errEl);
+            }
+        }
+    });
+
+    // Back to teams
+    $('#back-to-teams').addEventListener('click', function() {
+        navigate('teams');
+    });
+
+    // Team-scoped agent repos
+    var teamTaskReposList = [];
+
+    async function loadTeamTaskRepos(teamId) {
+        var listEl = $('#team-task-repos-list');
+        if (!listEl) return;
+        listEl.innerHTML = '<div class="loading-state"><div class="spinner"></div><p>Loading...</p></div>';
+        try {
+            var savedTeamId = activeTeamId;
+            activeTeamId = teamId;
+            var resp = await api('GET', '/api/v1/user/settings/agent-repos');
+            activeTeamId = savedTeamId;
+            if (!resp.ok) {
+                listEl.innerHTML = '<p class="error-message">Failed to load agent repos.</p>';
+                return;
+            }
+            var data = await resp.json();
+            teamTaskReposList = data.repos || [];
+            renderTeamTaskRepos(teamId);
+        } catch (err) {
+            listEl.innerHTML = '<p class="error-message">Failed to load agent repos.</p>';
+        }
+    }
+
+    function renderTeamTaskRepos(teamId) {
+        var listEl = $('#team-task-repos-list');
+        if (!listEl) return;
+        if (teamTaskReposList.length === 0) {
+            listEl.innerHTML = '<p style="color:var(--text-muted);font-size:13px;">No agent repos configured for this team.</p>';
+            return;
+        }
+        var html = '';
+        for (var i = 0; i < teamTaskReposList.length; i++) {
+            var r = teamTaskReposList[i];
+            var isEnabled = r.enabled === undefined || r.enabled === null || r.enabled === true;
+            var displayUrl = (r.url || '').replace(/^https?:\/\//, '').replace(/\.git$/, '');
+            var toggleTitle = isEnabled ? 'Pause sessions from this repo' : 'Resume sessions from this repo';
+            html += '<div class="repo-item ' + (isEnabled ? 'repo-active' : 'repo-paused') + '">';
+            html += '<label class="toggle-switch" title="' + toggleTitle + '"><input type="checkbox" class="team-repo-enabled" data-index="' + i + '"' + (isEnabled ? ' checked' : '') + '><span class="toggle-slider"></span></label>';
+            html += '<span class="' + (isEnabled ? 'toggle-label-active' : 'toggle-label-paused') + '">' + (isEnabled ? 'Active' : 'Paused') + '</span>';
+            html += '<span class="repo-item-url">' + escapeHtml(displayUrl) + '</span>';
+            if (r.ref && r.ref !== 'main') html += ' <span class="repo-item-ref">' + escapeHtml(r.ref) + '</span>';
+            html += ' <button class="btn btn-small btn-outline team-repo-remove" data-index="' + i + '" style="color:var(--status-error);border-color:var(--status-error);padding:2px 8px;font-size:11px;">Remove</button>';
+            if (!isEnabled) html += '<div class="repo-paused-message">Sessions from this repo are paused.</div>';
+            html += '</div>';
+        }
+        listEl.innerHTML = html;
+
+        listEl.querySelectorAll('.team-repo-enabled').forEach(function(cb) {
+            cb.addEventListener('change', async function() {
+                var idx = parseInt(cb.getAttribute('data-index'), 10);
+                teamTaskReposList[idx].enabled = cb.checked;
+                await saveTeamTaskRepos(teamId);
+            });
+        });
+
+        listEl.querySelectorAll('.team-repo-remove').forEach(function(btn) {
+            btn.addEventListener('click', async function() {
+                var idx = parseInt(btn.getAttribute('data-index'), 10);
+                teamTaskReposList.splice(idx, 1);
+                await saveTeamTaskRepos(teamId);
+            });
+        });
+    }
+
+    async function saveTeamTaskRepos(teamId) {
+        try {
+            var savedTeamId = activeTeamId;
+            activeTeamId = teamId;
+            var resp = await api('PUT', '/api/v1/user/settings/agent-repos', { repos: teamTaskReposList });
+            activeTeamId = savedTeamId;
+            if (!resp.ok) {
+                alert('Failed to save agent repos.');
+            }
+            renderTeamTaskRepos(teamId);
+        } catch (err) {
+            alert('Failed to save agent repos.');
+        }
+    }
+
+    $('#team-task-repo-add').addEventListener('click', async function() {
+        var url = $('#team-task-repo-url').value.trim();
+        if (!url) return;
+        var ref = $('#team-task-repo-ref').value.trim() || 'main';
+        var name = '';
+        var parts = url.replace(/\.git$/, '').split('/');
+        name = parts[parts.length - 1] || 'repo';
+
+        var btn = $('#team-task-repo-add');
+        var statusEl = $('#team-task-repo-status');
+        btn.disabled = true;
+        btn.textContent = 'Validating...';
+        statusEl.removeAttribute('hidden');
+        statusEl.style.color = 'var(--text-muted)';
+        statusEl.textContent = 'Cloning and validating repository...';
+
+        try {
+            var savedTeamId = activeTeamId;
+            activeTeamId = viewingTeamId;
+            var resp = await api('POST', '/api/v1/agent-repos/validate', { url: url, ref: ref, name: name });
+            activeTeamId = savedTeamId;
+            var data = await resp.json();
+            if (!data.valid) {
+                statusEl.style.color = 'var(--status-error)';
+                statusEl.textContent = 'Validation failed: ' + (data.error || 'unknown error');
+                btn.disabled = false;
+                btn.textContent = 'Add';
+                return;
+            }
+            teamTaskReposList.push({ url: url, ref: ref, name: name });
+            $('#team-task-repo-url').value = '';
+            $('#team-task-repo-ref').value = '';
+            statusEl.style.color = 'var(--status-running)';
+            statusEl.textContent = 'Found ' + data.agent_definition_count + ' agent definition(s): ' + data.agent_definitions.join(', ');
+            await saveTeamTaskRepos(viewingTeamId);
+        } catch (err) {
+            statusEl.style.color = 'var(--status-error)';
+            statusEl.textContent = 'Validation error: ' + err.message;
+        }
+        btn.disabled = false;
+        btn.textContent = 'Add';
+    });
+
+    // ---------------------
     // Init
     // ---------------------
     // Try to detect rh-identity mode by calling /api/v1/auth/me without a token.
@@ -6334,6 +6917,11 @@
 
         // Load version footer
         await loadVersionFooter();
+
+        // Load teams for the team switcher (if logged in)
+        if (isLoggedIn()) {
+            await loadTeams();
+        }
 
         handleRoute();
     })();


### PR DESCRIPTION
## Summary

- Introduce teams as the universal ownership unit — every resource belongs to a team, every user belongs to one or more teams
- Auto-create a personal team ("My Workspace") for each user on signup
- Team switcher in dashboard nav, `alcove teams` CLI subcommands, `X-Alcove-Team` header on all API requests
- Equal permissions: all team members have full access, no roles
- Self-service: any user creates teams, any member invites/removes others, admins can override
- Database migration replaces `owner` column with `team_id` across all resource tables
- Agent repos move from user settings to team-scoped settings

## Changes

- **Migration** (`027_teams.sql`): creates teams/team_members/team_settings tables, backfills team_id, drops owner columns
- **Backend** (`teams.go`, `api.go`, `credentials.go`, `security.go`, `taskdef.go`, `scheduler.go`, `workflow.go`, `tools.go`, `tasksync.go`, `dispatcher.go`): new team CRUD handlers, all existing handlers migrated from owner to team_id
- **Auth** (`auth.go`, `postgres.go`, `rh_identity.go`): X-Alcove-Team middleware, personal team creation on user signup
- **Frontend** (`index.html`, `app.js`, `style.css`): team switcher dropdown, team management page, X-Alcove-Team header on all API calls
- **CLI** (`main.go`, `teams.go`): teams subcommands, --team flag, active_team config
- **Tests** (`test-teams.sh`): functional tests covering CRUD, membership, isolation, backward compatibility
- **Docs**: getting-started, configuration, development-guide, implementation-status, CLAUDE.md

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Unit tests pass
- [ ] Functional tests pass (including new test-teams.sh)
- [ ] Existing tests still pass (backward compatibility via personal team default)

Design spec: `docs/superpowers/specs/2026-04-14-teams-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)