### PR TITLE
Fix team switching showing stale cached data

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -471,6 +471,7 @@ func isSessionIngestionPath(path string) bool {
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(v)
 }

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -2724,6 +2724,7 @@ func (a *API) handleWorkflowRunByID(w http.ResponseWriter, r *http.Request) {
 
 func respondJSON(w http.ResponseWriter, code int, v any) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(v)
 }


### PR DESCRIPTION
## Summary

- Add `Cache-Control: no-store` to all JSON API responses to prevent browser caching

## Root Cause

The Bridge API didn't set any cache-control headers. When switching teams in the dashboard, the browser returned cached responses from the previous team's request instead of fetching fresh data, making it appear as though both teams had identical schedules/agent definitions.

## Test plan

- [ ] Switch teams in the dashboard and verify the Schedules page shows different data per team
- [ ] Verify API responses include `Cache-Control: no-store` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)