### PR TITLE
Fix config validation rejecting docker as a valid runtime

### DIFF
--- a/internal/bridge/config.go
+++ b/internal/bridge/config.go
@@ -246,8 +246,8 @@ func (c *Config) parseConfigFile(path string) error {
 }
 
 func (c *Config) validate() error {
-	if c.RuntimeType != "podman" && c.RuntimeType != "kubernetes" {
-		return fmt.Errorf("invalid runtime %q: must be \"podman\" or \"kubernetes\"", c.RuntimeType)
+	if c.RuntimeType != "podman" && c.RuntimeType != "docker" && c.RuntimeType != "kubernetes" {
+		return fmt.Errorf("invalid runtime %q: must be \"podman\", \"docker\", or \"kubernetes\"", c.RuntimeType)
 	}
 	if c.AuthBackend != "memory" && c.AuthBackend != "postgres" && c.AuthBackend != "rh-identity" {
 		return fmt.Errorf("invalid AUTH_BACKEND %q: must be \"memory\", \"postgres\", or \"rh-identity\"", c.AuthBackend)


### PR DESCRIPTION
## Summary

- Config validation in `config.go:249` only allowed `podman` and `kubernetes`, rejecting `docker` before the runtime factory ever saw it
- The runtime factory in `runtime.go` already handles `docker` correctly — this validation was just never updated when Docker support was added

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)