### PR TITLE
Fix team scoping: log errors and fall back to personal team

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -336,7 +336,13 @@ func AuthMiddleware(store Authenticator, mgr UserManager, db ...*pgxpool.Pool) f
 				// Resolve team ID.
 				isAdmin := r.Header.Get("X-Alcove-Admin") == "true"
 				teamHeader := r.Header.Get("X-Alcove-Team")
-				if teamID, err := resolveTeamID(r.Context(), dbPool, username, teamHeader, isAdmin); err == nil && teamID != "" {
+				teamID, err := resolveTeamID(r.Context(), dbPool, username, teamHeader, isAdmin)
+				if err != nil {
+					log.Printf("auth: team resolution failed for user=%s team=%s: %v (falling back to personal team)", username, teamHeader, err)
+					// Fall back to personal team.
+					teamID, _ = resolveTeamID(r.Context(), dbPool, username, "", isAdmin)
+				}
+				if teamID != "" {
 					r.Header.Set("X-Alcove-Team-ID", teamID)
 				}
 				next.ServeHTTP(w, r)
@@ -419,7 +425,13 @@ func AuthMiddleware(store Authenticator, mgr UserManager, db ...*pgxpool.Pool) f
 			// Resolve team ID.
 			isAdmin := r.Header.Get("X-Alcove-Admin") == "true"
 			teamHeader := r.Header.Get("X-Alcove-Team")
-			if teamID, err := resolveTeamID(r.Context(), dbPool, username, teamHeader, isAdmin); err == nil && teamID != "" {
+			teamID, err := resolveTeamID(r.Context(), dbPool, username, teamHeader, isAdmin)
+			if err != nil {
+				log.Printf("auth: team resolution failed for user=%s team=%s: %v (falling back to personal team)", username, teamHeader, err)
+				// Fall back to personal team.
+				teamID, _ = resolveTeamID(r.Context(), dbPool, username, "", isAdmin)
+			}
+			if teamID != "" {
 				r.Header.Set("X-Alcove-Team-ID", teamID)
 			}
 


### PR DESCRIPTION
## Summary

- Log team resolution errors instead of silently swallowing them
- Fall back to personal team when requested team resolution fails

## Root Cause

When `resolveTeamID()` returned an error, the auth middleware silently skipped setting `X-Alcove-Team-ID`. API handlers then received empty team ID and fell back to returning **all** data (sessions, credentials, etc.) instead of team-scoped results. This made the dashboard show identical data regardless of which team was selected.

## Test plan

- [ ] Switch teams in the dashboard — verify sessions and credentials change per team
- [ ] Check Bridge logs for "team resolution failed" messages to diagnose why resolution was failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)