### PR TITLE
Fix workflow steps display in dashboard

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6167,8 +6167,14 @@
         var card = document.createElement('div');
         card.className = 'workflow-def-card';
 
-        var stepCount = workflow.steps ? Object.keys(workflow.steps).length : 0;
-        var dag = buildMiniDAG(workflow.steps || {});
+        // Convert workflow array to steps map for rendering
+        var stepsMap = {};
+        var stepsArray = workflow.workflow || [];
+        if (Array.isArray(stepsArray)) {
+            stepsArray.forEach(function(s) { if (s.id) stepsMap[s.id] = s; });
+        }
+        var stepCount = Object.keys(stepsMap).length;
+        var dag = buildMiniDAG(stepsMap);
         var triggerInfo = buildTriggerInfo(workflow.trigger);
         var lastSynced = workflow.last_synced ? new Date(workflow.last_synced).toLocaleString() : 'Never';
         var sourceRepo = workflow.source_repo || 'Unknown';


### PR DESCRIPTION
## Summary

- Fix workflow steps rendering: read from `workflow` array field, not `steps` map

## Root Cause

The API returns workflow steps as an array in the `workflow` field (matching the YAML schema), but the JS dashboard looked for `steps` as an object map. Result: "0 steps" and "No steps defined" for all workflows.

## Test plan

- [x] E2E: workflow cards show step names in DAG instead of "No steps defined"
- [x] Verified locally with Feature Development Pipeline (3 steps) and Release Pipeline (1 step)