### PR TITLE
Fix session list: support comma-separated status filter

### DIFF
--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -881,9 +881,20 @@ func (a *API) listSessions(ctx context.Context, status, repo, since, until, team
 		argN++
 	}
 	if status != "" {
-		whereClause += fmt.Sprintf(" AND s.outcome = $%d", argN)
-		args = append(args, status)
-		argN++
+		statuses := strings.Split(status, ",")
+		if len(statuses) == 1 {
+			whereClause += fmt.Sprintf(" AND s.outcome = $%d", argN)
+			args = append(args, status)
+			argN++
+		} else {
+			placeholders := make([]string, len(statuses))
+			for i, s := range statuses {
+				placeholders[i] = fmt.Sprintf("$%d", argN)
+				args = append(args, s)
+				argN++
+			}
+			whereClause += " AND s.outcome IN (" + strings.Join(placeholders, ",") + ")"
+		}
 	}
 	if repo != "" {
 		whereClause += fmt.Sprintf(" AND s.prompt ILIKE '%%' || $%d || '%%'", argN)


### PR DESCRIPTION
## Summary

- Support comma-separated status values in the sessions list API

## Root Cause

The frontend sends `status=completed,error,cancelled,timeout` to exclude running sessions from the paginated list. The backend did an exact string match (`outcome = 'completed,error,cancelled,timeout'`) which matched nothing, causing 0 results even when sessions exist.

## Test plan

- [ ] Sessions page shows completed sessions for teams with runs
- [x] `?status=completed,error` returns results locally