### PR TITLE
Add Docker CLI to Bridge container image

### DIFF
--- a/build/Containerfile.bridge
+++ b/build/Containerfile.bridge
@@ -12,8 +12,8 @@ ARG VERSION=dev
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.Version=${VERSION}" -o /out/bridge ./cmd/bridge
 
 # Stage 2: Runtime
-# Use ubi9 (not ubi9-minimal) because we need podman for container management.
-# Bridge creates Skiff+Gate containers via the podman CLI.
+# Use ubi9 (not ubi9-minimal) because we need container CLIs for management.
+# Bridge creates Skiff+Gate containers via the podman or docker CLI.
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
 ARG VERSION=dev
@@ -29,8 +29,11 @@ COPY --from=builder /out/bridge /usr/local/bin/bridge
 # Copy dashboard static files
 COPY web/ /web/
 
-# Install podman for container management (Bridge creates Skiff+Gate containers)
+# Install podman and docker CLIs for container management (Bridge creates
+# Skiff+Gate containers via whichever runtime is configured).
 RUN dnf install -y podman git && \
+    curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-27.5.1.tgz | \
+    tar xz --strip-components=1 -C /usr/local/bin docker/docker && \
     useradd -m -u 1001 -s /sbin/nologin alcove && \
     mkdir -p /tmp/podman-config /tmp/podman-data && \
     chmod 777 /tmp/podman-config /tmp/podman-data && \


### PR DESCRIPTION
## Summary

- Bridge shells out to the `docker` CLI when `RUNTIME=docker` but the image only included `podman`
- Downloads the static Docker CLI binary (27.5.1) into `/usr/local/bin/docker` during image build
- Docker runtime now works out of the box without mounting the CLI from the host

## Test plan

- [x] Containerfile syntax valid
- [ ] CI passes (image builds successfully with Docker CLI included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)