### PR TITLE
Fix Docker network syntax: use separate --network flags

### DIFF
--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -130,7 +130,7 @@ func (d *DockerRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHandle,
 	}
 	gateArgs = append(gateArgs,
 		"--name", gateName,
-		"--network", internalNet+","+externalNet,
+		"--network", internalNet, "--network", externalNet,
 	)
 	for k, v := range spec.GateEnv {
 		gateArgs = append(gateArgs, "--env", k+"="+v)

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -59,8 +59,8 @@ func TestDockerRunTask_CreatesContainers(t *testing.T) {
 	if !strings.Contains(gateArgs, "--name gate-task-1") {
 		t.Errorf("gate call missing --name gate-task-1: %s", gateArgs)
 	}
-	if !strings.Contains(gateArgs, "--network test-internal,test-external") {
-		t.Errorf("gate call missing dual network (test-internal,test-external): %s", gateArgs)
+	if !strings.Contains(gateArgs, "--network test-internal --network test-external") {
+		t.Errorf("gate call missing dual network (--network test-internal --network test-external): %s", gateArgs)
 	}
 	if !strings.Contains(gateArgs, "quay.io/alcove/gate:latest") {
 		t.Errorf("gate call missing gate image: %s", gateArgs)


### PR DESCRIPTION
## Summary

- Use separate `--network` flags instead of comma-separated syntax for Docker gate containers

## Root Cause

`docker.go:133` used `--network alcove-internal,alcove-external` (single flag, comma-separated). This is not supported on all Docker versions (fails on QNAP Docker 27.1.2-qnap8).

## Fix

Changed to `--network alcove-internal --network alcove-external` (two separate flags), which is the standard Docker syntax.

Podman runtime unchanged (comma syntax works natively). Kubernetes unaffected (uses NetworkPolicy).

Fixes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)