### PR TITLE
Fix default Gate and Skiff image refs to use GHCR

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,8 +90,8 @@ can also be set in `alcove.yaml` (see [alcove.yaml](#alcoveyaml) above).
 | `VERTEX_PROJECT` | string | _(unset)_ | Google Cloud project ID. Registers the `vertex` provider when set. |
 | `VERTEX_API_KEY` | string | _(unset)_ | API key for Google Vertex AI. Auto-migrated to credential store on startup. |
 | `VERTEX_MODEL` | string | `claude-sonnet-4-20250514` | Default model for the Vertex AI provider. |
-| `SKIFF_IMAGE` | string | `localhost/alcove-skiff-base:dev` | Container image for Skiff workers. |
-| `GATE_IMAGE` | string | `localhost/alcove-gate:dev` | Container image for Gate sidecars. |
+| `SKIFF_IMAGE` | string | `ghcr.io/bmbouter/alcove-skiff-base:latest` | Container image for Skiff workers. |
+| `GATE_IMAGE` | string | `ghcr.io/bmbouter/alcove-gate:latest` | Container image for Gate sidecars. |
 | `ALCOVE_NETWORK` | string | `alcove-internal` | Podman network name for internal container networking (created with `--internal` flag, no external access). |
 | `ALCOVE_EXTERNAL_NETWORK` | string | `alcove-external` | External podman network for Gate egress. Gate bridges both networks; Skiff is attached only to the internal network. |
 | `BRIDGE_URL` | string | `http://alcove-bridge:<port>` | URL where Bridge can be reached by Skiff/Gate containers. |

--- a/docs/design/implementation-status.md
+++ b/docs/design/implementation-status.md
@@ -384,8 +384,8 @@ LEDGER_DATABASE_URL="postgres://alcove:alcove@localhost:5432/alcove?sslmode=disa
 HAIL_URL="nats://localhost:4222" \
 RUNTIME=podman \
 BRIDGE_PORT=8080 \
-SKIFF_IMAGE="localhost/alcove-skiff-base:dev" \
-GATE_IMAGE="localhost/alcove-gate:dev" \
+SKIFF_IMAGE="ghcr.io/bmbouter/alcove-skiff-base:latest" \
+GATE_IMAGE="ghcr.io/bmbouter/alcove-gate:latest" \
 ./bin/bridge
 
 # 4. In another terminal, use the CLI or curl
@@ -459,8 +459,8 @@ See the full roadmap in [architecture-decisions.md](architecture-decisions.md#ro
 | `HAIL_URL` | (required) | NATS server URL |
 | `RUNTIME` | `podman` | Container runtime (`podman`, `docker`, or `kubernetes`) |
 | `BRIDGE_PORT` | `8080` | HTTP server port |
-| `SKIFF_IMAGE` | `localhost/alcove-skiff-base:dev` | Skiff container image |
-| `GATE_IMAGE` | `localhost/alcove-gate:dev` | Gate container image |
+| `SKIFF_IMAGE` | `ghcr.io/bmbouter/alcove-skiff-base:latest` | Skiff container image |
+| `GATE_IMAGE` | `ghcr.io/bmbouter/alcove-gate:latest` | Gate container image |
 | `ALCOVE_NETWORK` | `alcove-internal` | Podman internal network name |
 | `ALCOVE_EXTERNAL_NETWORK` | `alcove-external` | Podman external network name (Gate egress) |
 | `AUTH_BACKEND` | `memory` | Auth backend: `memory`, `postgres`, or `rh-identity` |

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -141,8 +141,8 @@ Bridge reads these environment variables:
 | `LEDGER_DATABASE_URL` | PostgreSQL connection string | `postgres://alcove:alcove@localhost:5432/alcove?sslmode=disable` |
 | `HAIL_URL` | NATS server URL | `nats://localhost:4222` |
 | `RUNTIME` | Container runtime to use | `podman` or `kubernetes` |
-| `SKIFF_IMAGE` | Skiff container image | `localhost/alcove-skiff-base:dev` |
-| `GATE_IMAGE` | Gate container image | `localhost/alcove-gate:dev` |
+| `SKIFF_IMAGE` | Skiff container image | `ghcr.io/bmbouter/alcove-skiff-base:latest` |
+| `GATE_IMAGE` | Gate container image | `ghcr.io/bmbouter/alcove-gate:latest` |
 | `ALCOVE_WEB_DIR` | Path to dashboard static files | `/web` or `./web` |
 | `ALCOVE_NETWORK` | Podman internal network name | `alcove-internal` |
 | `ALCOVE_EXTERNAL_NETWORK` | Podman external network for Gate egress | `alcove-external` |

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -633,8 +633,8 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 	// Start Skiff pod via Runtime.
 	spec := runtime.TaskSpec{
 		TaskID:      taskID,
-		Image:       envOrDefault("SKIFF_IMAGE", "localhost/alcove-skiff-base:dev"),
-		GateImage:   envOrDefault("GATE_IMAGE", "localhost/alcove-gate:dev"),
+		Image:       envOrDefault("SKIFF_IMAGE", "ghcr.io/bmbouter/alcove-skiff-base:latest"),
+		GateImage:   envOrDefault("GATE_IMAGE", "ghcr.io/bmbouter/alcove-gate:latest"),
 		Env:         skiffEnv,
 		GateEnv:     gateEnv,
 		Timeout:     int64(timeout),


### PR DESCRIPTION
## Summary

- Change default GATE_IMAGE and SKIFF_IMAGE fallbacks from `localhost/alcove-*:dev` to `ghcr.io/bmbouter/alcove-*:latest`
- Update documentation to match

## Root Cause

The dispatcher defaults to `localhost/alcove-gate:dev` and `localhost/alcove-skiff-base:dev` when env vars are not set. These only exist on developer machines after `make up`. Standalone Docker deployments (e.g., QNAP) fail because the images don't exist and Docker can't pull from `localhost/`.

Local dev is unaffected — `make up` explicitly sets `GATE_IMAGE` and `SKIFF_IMAGE` to `localhost/alcove-*:$(VERSION)`.

Fixes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)