### PR TITLE
Fix workflow template validation to allow trigger.* templates

### DIFF
--- a/internal/bridge/workflow.go
+++ b/internal/bridge/workflow.go
@@ -399,9 +399,9 @@ func splitByOperatorForValidation(s, operator string) []string {
 func validateInputsTemplateSyntax(inputs map[string]interface{}) error {
 	for key, value := range inputs {
 		if str, ok := value.(string); ok {
-			// Check for template syntax like "{{steps.implement.outputs.summary}}"
+			// Check for template syntax like "{{steps.implement.outputs.summary}}" or "{{trigger.issue_number}}"
 			if strings.Contains(str, "{{") && strings.Contains(str, "}}") {
-				if !strings.Contains(str, "steps.") {
+				if !strings.Contains(str, "steps.") && !strings.Contains(str, "trigger.") {
 					return fmt.Errorf("input '%s' contains invalid template syntax: %s", key, str)
 				}
 			}


### PR DESCRIPTION
## Summary

- Allow `{{trigger.*}}` templates in workflow step inputs alongside `{{steps.*}}`

## Root Cause

The `validateInputsTemplateSyntax` function only allowed templates containing `steps.`, rejecting `{{trigger.issue_number}}` used in the feature pipeline workflow. This caused a sync error for `feature-pipeline.yml`.

## Test plan

- [x] Build + vet + tests pass
- [ ] Sync bmbouter/alcove on HCMAI — feature-pipeline.yml should import without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)