### PR TITLE
Add generic secrets: arbitrary env vars for agent containers

### DIFF
--- a/cmd/alcove/credentials.go
+++ b/cmd/alcove/credentials.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+func newCredentialsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "credentials",
+		Short:   "Manage team credentials and secrets",
+		Aliases: []string{"creds"},
+	}
+	cmd.AddCommand(
+		newCredentialsListCmd(),
+		newCredentialsCreateCmd(),
+		newCredentialsDeleteCmd(),
+	)
+	return cmd
+}
+
+// ---------- credentials list ----------
+
+func newCredentialsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List credentials for the active team",
+		RunE:  runCredentialsList,
+	}
+}
+
+func runCredentialsList(cmd *cobra.Command, _ []string) error {
+	teamName := resolveTeamName(cmd)
+	if teamName == "" {
+		return fmt.Errorf("no active team; use 'alcove teams use <name>' or --team to set one")
+	}
+
+	teamID, err := resolveTeamID(cmd, teamName)
+	if err != nil {
+		return err
+	}
+
+	resp, err := apiRequestRaw(cmd, http.MethodGet, "/api/v1/credentials", nil, teamID)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Credentials []credentialInfo `json:"credentials"`
+		Count       int             `json:"count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(result)
+	}
+
+	if len(result.Credentials) == 0 {
+		fmt.Fprintln(os.Stderr, "No credentials found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tPROVIDER\tTYPE\tCREATED")
+	for _, c := range result.Credentials {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.Name, c.Provider, c.AuthType, c.CreatedAt)
+	}
+	return w.Flush()
+}
+
+// credentialInfo represents a credential returned from the API.
+type credentialInfo struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Provider  string `json:"provider"`
+	AuthType  string `json:"auth_type"`
+	ProjectID string `json:"project_id,omitempty"`
+	Region    string `json:"region,omitempty"`
+	APIHost   string `json:"api_host,omitempty"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+	TeamID    string `json:"team_id,omitempty"`
+}
+
+// ---------- credentials create ----------
+
+func newCredentialsCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new credential for the active team",
+		RunE:  runCredentialsCreate,
+	}
+	cmd.Flags().String("name", "", "Credential name (required)")
+	cmd.Flags().String("provider", "generic", "Provider name (e.g., anthropic, google-vertex, github, gitlab)")
+	cmd.Flags().String("auth-type", "secret", "Auth type (e.g., api_key, service_account, secret)")
+	cmd.Flags().String("secret", "", "Shorthand: sets provider=generic, auth-type=secret, and uses value as credential")
+	cmd.Flags().String("credential", "", "Credential value (e.g., API key, service account JSON)")
+	cmd.Flags().String("project-id", "", "GCP project ID (Vertex AI only)")
+	cmd.Flags().String("region", "", "GCP region (Vertex AI only)")
+	cmd.Flags().String("api-host", "", "Custom API host (e.g., self-hosted GitLab URL)")
+	return cmd
+}
+
+func runCredentialsCreate(cmd *cobra.Command, _ []string) error {
+	teamName := resolveTeamName(cmd)
+	if teamName == "" {
+		return fmt.Errorf("no active team; use 'alcove teams use <name>' or --team to set one")
+	}
+
+	teamID, err := resolveTeamID(cmd, teamName)
+	if err != nil {
+		return err
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	provider, _ := cmd.Flags().GetString("provider")
+	authType, _ := cmd.Flags().GetString("auth-type")
+	secret, _ := cmd.Flags().GetString("secret")
+	credential, _ := cmd.Flags().GetString("credential")
+	projectID, _ := cmd.Flags().GetString("project-id")
+	region, _ := cmd.Flags().GetString("region")
+	apiHost, _ := cmd.Flags().GetString("api-host")
+
+	// --secret shorthand
+	if secret != "" {
+		provider = "generic"
+		authType = "secret"
+		credential = secret
+	}
+
+	if name == "" || credential == "" {
+		return fmt.Errorf("--name and either --secret or --credential are required")
+	}
+
+	payload := map[string]string{
+		"name":       name,
+		"provider":   provider,
+		"auth_type":  authType,
+		"credential": credential,
+	}
+	if projectID != "" {
+		payload["project_id"] = projectID
+	}
+	if region != "" {
+		payload["region"] = region
+	}
+	if apiHost != "" {
+		payload["api_host"] = apiHost
+	}
+
+	resp, err := apiRequestRaw(cmd, http.MethodPost, "/api/v1/credentials", payload, teamID)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result credentialInfo
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(result)
+	}
+
+	fmt.Fprintf(os.Stderr, "Credential created: %s (id: %s)\n", result.Name, result.ID)
+	return nil
+}
+
+// ---------- credentials delete ----------
+
+func newCredentialsDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a credential by ID",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runCredentialsDelete,
+	}
+}
+
+func runCredentialsDelete(cmd *cobra.Command, args []string) error {
+	credID := args[0]
+
+	teamName := resolveTeamName(cmd)
+	if teamName == "" {
+		return fmt.Errorf("no active team; use 'alcove teams use <name>' or --team to set one")
+	}
+
+	teamID, err := resolveTeamID(cmd, teamName)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/api/v1/credentials/%s", credID)
+
+	resp, err := apiRequestRaw(cmd, http.MethodDelete, path, nil, teamID)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(map[string]string{"id": credID, "status": "deleted"})
+	}
+
+	fmt.Fprintf(os.Stderr, "Credential %s deleted\n", credID)
+	return nil
+}

--- a/cmd/alcove/main.go
+++ b/cmd/alcove/main.go
@@ -102,6 +102,7 @@ func main() {
 		newProfileCmd(),
 		newTeamsCmd(),
 		newCatalogCmd(),
+		newCredentialsCmd(),
 		newVersionCmd(),
 	)
 

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -1242,11 +1242,10 @@ func (a *API) handleCredentials(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// Enforce one LLM credential per team.
-		scmProviders := map[string]bool{"github": true, "gitlab": true, "jira": true}
-		if !scmProviders[req.Provider] {
+		if ProviderCategory(req.Provider) == "llm" {
 			existing, _ := a.credStore.ListCredentials(r.Context(), teamID)
 			for _, c := range existing {
-				if !scmProviders[c.Provider] {
+				if ProviderCategory(c.Provider) == "llm" {
 					respondJSON(w, http.StatusConflict, map[string]any{
 						"error":               "you already have an LLM credential configured",
 						"existing_credential": c.Name,

--- a/internal/bridge/credentials.go
+++ b/internal/bridge/credentials.go
@@ -45,6 +45,18 @@ type Credential struct {
 	TeamID    string    `json:"team_id,omitempty"`
 }
 
+// ProviderCategory returns the category for a given provider string.
+func ProviderCategory(provider string) string {
+	switch provider {
+	case "anthropic", "google-vertex", "claude-oauth":
+		return "llm"
+	case "github", "gitlab", "jira", "splunk":
+		return "scm"
+	default:
+		return "generic"
+	}
+}
+
 // CredentialStore manages encrypted credential storage in PostgreSQL.
 type CredentialStore struct {
 	db  *pgxpool.Pool
@@ -243,7 +255,7 @@ func (cs *CredentialStore) AcquireToken(ctx context.Context, providerName string
 	}
 
 	switch authType {
-	case "api_key", "oauth_token":
+	case "api_key", "oauth_token", "secret":
 		return &TokenResult{
 			Token:     string(raw),
 			TokenType: authType,
@@ -301,7 +313,7 @@ func (cs *CredentialStore) AcquireSystemToken(ctx context.Context, providerName 
 	}
 
 	switch authType {
-	case "api_key", "oauth_token":
+	case "api_key", "oauth_token", "secret":
 		return &TokenResult{
 			Token:     string(raw),
 			TokenType: authType,
@@ -423,7 +435,7 @@ func (cs *CredentialStore) FirstAvailableProvider(ctx context.Context) (*Credent
 		`SELECT id, name, provider, auth_type, project_id, region, api_host, created_at, updated_at, COALESCE(team_id::text, '')
 		FROM provider_credentials
 		WHERE team_id IS NOT NULL
-		AND provider NOT IN ('github', 'gitlab', 'jira')
+		AND provider NOT IN ('github', 'gitlab', 'jira', 'splunk', 'generic')
 		ORDER BY created_at ASC LIMIT 1`,
 	).Scan(&c.ID, &c.Name, &c.Provider, &c.AuthType,
 		&c.ProjectID, &c.Region, &c.APIHost, &c.CreatedAt, &c.UpdatedAt, &c.TeamID)
@@ -458,7 +470,7 @@ func (cs *CredentialStore) ListDistinctProviders(ctx context.Context) ([]Credent
 		`SELECT DISTINCT ON (provider) id, name, provider, auth_type, project_id, region, api_host, created_at, updated_at, COALESCE(team_id::text, '')
 		FROM provider_credentials
 		WHERE team_id IS NOT NULL
-		AND provider NOT IN ('github', 'gitlab', 'jira')
+		AND provider NOT IN ('github', 'gitlab', 'jira', 'splunk', 'generic')
 		ORDER BY provider, created_at DESC`)
 	if err != nil {
 		return nil, fmt.Errorf("querying distinct providers: %w", err)

--- a/internal/bridge/credentials_test.go
+++ b/internal/bridge/credentials_test.go
@@ -65,6 +65,32 @@ func TestEncryptDecryptOAuthTokenRoundtrip(t *testing.T) {
 	}
 }
 
+func TestProviderCategory(t *testing.T) {
+	tests := []struct {
+		provider string
+		want     string
+	}{
+		{"anthropic", "llm"},
+		{"google-vertex", "llm"},
+		{"claude-oauth", "llm"},
+		{"github", "scm"},
+		{"gitlab", "scm"},
+		{"jira", "scm"},
+		{"splunk", "scm"},
+		{"generic", "generic"},
+		{"unknown-thing", "generic"},
+		{"", "generic"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			got := ProviderCategory(tt.provider)
+			if got != tt.want {
+				t.Errorf("ProviderCategory(%q) = %q, want %q", tt.provider, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDeriveKey(t *testing.T) {
 	key := deriveKey("my-master-password")
 	if len(key) != 32 {

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -624,20 +624,20 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 	}
 
 	// Resolve credentials from agent definition.
-	// Inject real credential tokens into Skiff environment variables.
-	for envVar, providerName := range req.Credentials {
-		tokenResult, err := d.credStore.AcquireToken(ctx, providerName)
-		if err != nil {
-			// Try SCM token path
-			token, _, err := d.credStore.AcquireSCMTokenWithHost(ctx, providerName)
-			if err != nil {
-				log.Printf("warning: credential %q not found for env var %s", providerName, envVar)
-				continue
-			}
-			skiffEnv[envVar] = token
+	for envVar, credName := range req.Credentials {
+		// Try AcquireToken first (works for LLM and generic secrets).
+		tokenResult, err := d.credStore.AcquireToken(ctx, credName)
+		if err == nil {
+			skiffEnv[envVar] = tokenResult.Token
 			continue
 		}
-		skiffEnv[envVar] = tokenResult.Token
+		// Fall back to SCM token path.
+		token, _, err := d.credStore.AcquireSCMTokenWithHost(ctx, credName)
+		if err != nil {
+			log.Printf("warning: credential %q not found for env var %s", credName, envVar)
+			continue
+		}
+		skiffEnv[envVar] = token
 	}
 
 	// Start Skiff pod via Runtime.

--- a/scripts/test-generic-secrets.sh
+++ b/scripts/test-generic-secrets.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# test-generic-secrets.sh — API tests for generic secrets (issue #276).
+set -euo pipefail
+
+BRIDGE_URL="${BRIDGE_URL:-http://localhost:8080}"
+PASS=0
+FAIL=0
+
+log() { echo ""; echo ">>> $*"; }
+pass() { echo "  PASS: $*"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $*"; FAIL=$((FAIL+1)); }
+
+# Setup
+log "Setup"
+USER_TOKEN=$(curl -s -X POST "$BRIDGE_URL/api/v1/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"admin\",\"password\":\"${ADMIN_PASSWORD:-admin}\"}" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")
+if [ -z "$USER_TOKEN" ]; then echo "Login failed"; exit 1; fi
+
+TEAM_ID=$(curl -s "$BRIDGE_URL/api/v1/teams" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  | python3 -c "import json,sys; t=[x for x in json.load(sys.stdin).get('teams',[]) if x.get('is_personal')]; print(t[0]['id'] if t else '')")
+pass "Setup (team=$TEAM_ID)"
+
+# Test 1: Create generic secret
+log "Test 1: Create generic secret"
+RESP=$(curl -s -X POST "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Alcove-Team: $TEAM_ID" \
+  -d '{"name":"my-api-key","provider":"generic","auth_type":"secret","credential":"sk-test-123"}')
+SECRET_ID=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+if [ "$SECRET_ID" != "ERROR" ]; then
+  pass "Created generic secret (id=$SECRET_ID)"
+else
+  fail "Create failed: $RESP"
+fi
+
+# Test 2: Generic secret appears in list
+log "Test 2: Generic secret in list"
+LIST=$(curl -s "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "X-Alcove-Team: $TEAM_ID")
+HAS_SECRET=$(echo "$LIST" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+names=[c['name'] for c in d.get('credentials',[]) if c.get('provider')=='generic']
+print('yes' if 'my-api-key' in names else 'no')
+")
+if [ "$HAS_SECRET" = "yes" ]; then
+  pass "Generic secret appears in credential list"
+else
+  fail "Generic secret not found in list"
+fi
+
+# Test 3: Create LLM credential alongside generic (should work)
+log "Test 3: LLM + generic coexistence"
+LLM_RESP=$(curl -s -X POST "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Alcove-Team: $TEAM_ID" \
+  -d '{"name":"My LLM","provider":"anthropic","auth_type":"api_key","credential":"sk-ant-fake"}')
+LLM_ID=$(echo "$LLM_RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+if [ "$LLM_ID" != "ERROR" ]; then
+  pass "Created LLM credential alongside generic secret"
+else
+  fail "LLM create failed: $LLM_RESP"
+fi
+
+# Test 4: Second LLM should be rejected (one-per-team limit still works)
+log "Test 4: One LLM per team limit"
+LLM2_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Alcove-Team: $TEAM_ID" \
+  -d '{"name":"Second LLM","provider":"google-vertex","auth_type":"service_account","credential":"{}","project_id":"p","region":"r"}')
+if [ "$LLM2_CODE" = "409" ]; then
+  pass "Second LLM rejected (HTTP 409)"
+else
+  fail "Second LLM returned $LLM2_CODE (expected 409)"
+fi
+
+# Test 5: Multiple generic secrets allowed
+log "Test 5: Multiple generic secrets"
+RESP2=$(curl -s -X POST "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Alcove-Team: $TEAM_ID" \
+  -d '{"name":"another-secret","provider":"generic","auth_type":"secret","credential":"token-456"}')
+SECRET2_ID=$(echo "$RESP2" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+if [ "$SECRET2_ID" != "ERROR" ]; then
+  pass "Created second generic secret"
+else
+  fail "Second generic secret failed: $RESP2"
+fi
+
+GENERIC_COUNT=$(curl -s "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "X-Alcove-Team: $TEAM_ID" \
+  | python3 -c "import json,sys; print(len([c for c in json.load(sys.stdin).get('credentials',[]) if c.get('provider')=='generic']))")
+if [ "$GENERIC_COUNT" = "2" ]; then
+  pass "Two generic secrets coexist"
+else
+  fail "Generic count: $GENERIC_COUNT (expected 2)"
+fi
+
+# Test 6: Splunk credential alongside LLM (was broken, now fixed)
+log "Test 6: Splunk + LLM coexistence (bug fix)"
+SPLUNK_RESP=$(curl -s -X POST "$BRIDGE_URL/api/v1/credentials" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Alcove-Team: $TEAM_ID" \
+  -d '{"name":"splunk","provider":"splunk","auth_type":"api_key","credential":"splunk-token-fake"}')
+SPLUNK_ID=$(echo "$SPLUNK_RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','ERROR'))")
+if [ "$SPLUNK_ID" != "ERROR" ]; then
+  pass "Created Splunk credential alongside LLM (bug fixed)"
+else
+  fail "Splunk create failed: $SPLUNK_RESP"
+fi
+
+# Test 7: Delete generic secret
+log "Test 7: Delete generic secret"
+DEL_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+  "$BRIDGE_URL/api/v1/credentials/$SECRET_ID" \
+  -H "Authorization: Bearer $USER_TOKEN")
+if [ "$DEL_CODE" = "200" ]; then
+  pass "Deleted generic secret (HTTP 200)"
+else
+  fail "Delete returned $DEL_CODE"
+fi
+
+# Cleanup
+curl -s -X DELETE "$BRIDGE_URL/api/v1/credentials/$SECRET2_ID" -H "Authorization: Bearer $USER_TOKEN" > /dev/null 2>&1
+curl -s -X DELETE "$BRIDGE_URL/api/v1/credentials/$LLM_ID" -H "Authorization: Bearer $USER_TOKEN" > /dev/null 2>&1
+curl -s -X DELETE "$BRIDGE_URL/api/v1/credentials/$SPLUNK_ID" -H "Authorization: Bearer $USER_TOKEN" > /dev/null 2>&1
+
+# Summary
+echo ""
+log "=== Test Summary ==="
+echo "  Total: $((PASS+FAIL))  Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then exit 1; else echo "  All tests passed."; fi

--- a/web/index.html
+++ b/web/index.html
@@ -385,6 +385,16 @@
                             </table>
                         </div>
                     </div>
+
+                    <div id="credentials-section-generic" class="credentials-section" hidden>
+                        <div class="credentials-section-label">Secrets</div>
+                        <div class="table-container">
+                            <table class="data-table">
+                                <thead><tr><th>Name</th><th>Type</th><th>Created</th><th>Actions</th></tr></thead>
+                                <tbody id="credentials-tbody-generic"></tbody>
+                            </table>
+                        </div>
+                    </div>
                 </div>
             </div>
 
@@ -1115,6 +1125,7 @@ alcove list</pre>
                         <option value="gitlab">GitLab</option>
                         <option value="jira">Jira</option>
                         <option value="splunk">Splunk</option>
+                        <option value="generic">Generic Secret</option>
                     </select>
                 </div>
             </div>
@@ -1258,6 +1269,13 @@ cat ~/.config/gcloud/application_default_credentials.json   # or just cat and co
                     <label>API Host</label>
                     <input type="text" data-role="cred-splunk-host" class="input" placeholder="splunk.company.com:8089 (optional, for self-hosted instances)">
                     <small class="form-help">Leave empty for Splunk Cloud. For self-hosted Splunk, enter the hostname and port.</small>
+                </div>
+            </div>
+            <div data-role="cred-generic-fields" hidden>
+                <div class="form-group">
+                    <label>Secret Value <span class="required">*</span></label>
+                    <input type="password" data-role="cred-generic-value" class="input mono" placeholder="Enter secret value...">
+                    <small class="form-help">This value will be injected as an environment variable into agent containers.</small>
                 </div>
             </div>
             <div data-role="credential-form-error" class="error-message" role="alert" hidden></div>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1649,7 +1649,7 @@
             cachedCredentials = allCreds;
             // Only show LLM credentials in the provider dropdown
             const llmCreds = allCreds.filter(function (c) {
-                return c.provider !== 'github' && c.provider !== 'gitlab' && c.provider !== 'jira' && c.provider !== 'splunk';
+                return c.provider !== 'github' && c.provider !== 'gitlab' && c.provider !== 'jira' && c.provider !== 'splunk' && c.provider !== 'generic';
             });
             select.innerHTML = '<option value="">Select a provider</option>';
             llmCreds.forEach((c) => {
@@ -1687,7 +1687,7 @@
 
         // Block submission if no LLM credential
         var llmCreds = cachedCredentials.filter(function (c) {
-            return c.provider !== 'github' && c.provider !== 'gitlab' && c.provider !== 'jira' && c.provider !== 'splunk';
+            return c.provider !== 'github' && c.provider !== 'gitlab' && c.provider !== 'jira' && c.provider !== 'splunk' && c.provider !== 'generic';
         });
         if (llmCreds.length === 0) {
             errEl.textContent = 'No LLM provider configured. Add an LLM credential on the Credentials page before starting sessions.';
@@ -1758,15 +1758,19 @@
     async function loadCredentials() {
         const tbodyLlm = $('#credentials-tbody-llm');
         const tbodyScm = $('#credentials-tbody-scm');
+        const tbodyGeneric = $('#credentials-tbody-generic');
         const sectionLlm = $('#credentials-section-llm');
         const sectionScm = $('#credentials-section-scm');
+        const sectionGeneric = $('#credentials-section-generic');
         const loading = $('#credentials-loading');
         const empty = $('#credentials-empty');
 
         tbodyLlm.innerHTML = '';
         tbodyScm.innerHTML = '';
+        tbodyGeneric.innerHTML = '';
         hide(sectionLlm);
         hide(sectionScm);
+        hide(sectionGeneric);
         show(loading);
         hide(empty);
 
@@ -1781,11 +1785,14 @@
                 return;
             }
 
-            // Split credentials into LLM and SCM groups
+            // Split credentials into LLM, SCM, and generic groups
             var llmCreds = [];
             var scmCreds = [];
+            var genericCreds = [];
             credentials.forEach(function (c) {
-                if (c.provider === 'github' || c.provider === 'gitlab' || c.provider === 'jira' || c.provider === 'splunk') {
+                if (c.provider === 'generic') {
+                    genericCreds.push(c);
+                } else if (c.provider === 'github' || c.provider === 'gitlab' || c.provider === 'jira' || c.provider === 'splunk') {
                     scmCreds.push(c);
                 } else {
                     llmCreds.push(c);
@@ -1869,7 +1876,26 @@
                 tbodyScm.innerHTML = scmCreds.map(renderScmRow).join('');
             }
 
-            // Delete handlers for both sections
+            // Render generic secrets
+            if (genericCreds.length > 0) {
+                show(sectionGeneric);
+                tbodyGeneric.innerHTML = genericCreds.map(function(c) {
+                    var name = c.name || '-';
+                    var created = formatTime(c.created_at || c.created);
+                    var id = c.id || '';
+                    return '<tr>' +
+                        '<td>' + escapeHtml(name) + '</td>' +
+                        '<td><span class="badge">secret</span></td>' +
+                        '<td>' + escapeHtml(created) + '</td>' +
+                        '<td><button class="btn btn-small btn-outline delete-credential-btn" data-id="' + escapeHtml(id) + '" data-name="' + escapeHtml(name) + '" style="color:var(--status-error);border-color:var(--status-error);">Delete</button></td>' +
+                        '</tr>';
+                }).join('');
+            } else {
+                hide(sectionGeneric);
+                tbodyGeneric.innerHTML = '';
+            }
+
+            // Delete handlers for all sections
             var container = $('#credentials-grouped-container');
             container.querySelectorAll('.delete-credential-btn').forEach(function (btn) {
                 btn.addEventListener('click', async function () {
@@ -1931,6 +1957,7 @@
         var vertexFields = q('cred-vertex-fields');
         var scmFields = q('cred-scm-fields');
         var splunkFields = q('cred-splunk-fields');
+        var genericFields = q('cred-generic-fields');
         var gitlabHostGroup = q('cred-gitlab-host-group');
         var jiraHostGroup = q('jira-host-group');
         var jiraEmailGroup = q('jira-email-group');
@@ -1945,6 +1972,7 @@
             if (vertexFields) vertexFields.hidden = true;
             if (scmFields) scmFields.hidden = true;
             if (splunkFields) splunkFields.hidden = true;
+            if (genericFields) genericFields.hidden = true;
             if (jiraHostGroup) jiraHostGroup.hidden = true;
             if (jiraEmailGroup) jiraEmailGroup.hidden = true;
 
@@ -1956,6 +1984,8 @@
                 if (vertexFields) vertexFields.hidden = false;
             } else if (val === 'splunk') {
                 if (splunkFields) splunkFields.hidden = false;
+            } else if (val === 'generic') {
+                if (genericFields) genericFields.hidden = false;
             } else if (val === 'github' || val === 'gitlab' || val === 'jira') {
                 if (scmFields) scmFields.hidden = false;
                 // Show GitLab host field only for GitLab
@@ -2111,6 +2141,14 @@
                 if (splunkHost) {
                     payload.api_host = splunkHost;
                 }
+            } else if (provider === 'generic') {
+                var genericValue = (q('cred-generic-value') || {}).value;
+                if (!genericValue || !genericValue.trim()) {
+                    if (errorEl) { errorEl.textContent = 'Secret value is required.'; show(errorEl); }
+                    return;
+                }
+                payload.auth_type = 'secret';
+                payload.credential = genericValue.trim();
             }
 
             var btn = q('cred-submit');
@@ -5492,7 +5530,7 @@
         var warnings = [];
 
         var llmCreds = cachedCredentials.filter(function (c) {
-            return c.provider !== 'github' && c.provider !== 'gitlab' && c.provider !== 'jira' && c.provider !== 'splunk';
+            return c.provider !== 'github' && c.provider !== 'gitlab' && c.provider !== 'jira' && c.provider !== 'splunk' && c.provider !== 'generic';
         });
         var scmCreds = cachedCredentials.filter(function (c) {
             return c.provider === 'github' || c.provider === 'gitlab' || c.provider === 'jira' || c.provider === 'splunk';


### PR DESCRIPTION
## Summary

Adds a third credential category — **generic secrets** — alongside LLM and SCM. These are simple name/value pairs injected directly as env vars into Skiff containers.

- `provider: "generic"`, `auth_type: "secret"`
- Unlimited per team, no one-LLM limit
- Injected directly into Skiff (no Gate proxy)
- Also fixes splunk being incorrectly classified as LLM

## Test Results

- Go unit tests: all pass (including new TestProviderCategory)
- API tests: 9/9 pass (create, coexistence, limit, delete, splunk fix)
- E2E browser tests: 4/4 pass (dropdown, form, creation, display)

Fixes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)