### PR TITLE
Allow workflow steps to declare credentials

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -768,6 +768,7 @@ review/revision patterns.
 | `max_iterations` | int | no | `1` | Maximum times this step can execute (1 = no revisiting) |
 | `max_retries` | int | no | `0` | Maximum retry count on failure |
 | `inputs` | map | no | — | Key-value inputs passed to the step |
+| `credentials` | map[string]string | no | — | Env var to credential provider mappings; merges with agent credentials (step overrides agent) |
 
 ### Bridge Actions
 

--- a/docs/workflow-authoring.md
+++ b/docs/workflow-authoring.md
@@ -172,6 +172,38 @@ Other steps reference this as `{{steps.code-review.outputs.comments}}`.
 Bridge actions produce outputs automatically (see the reference above for
 each action's output fields).
 
+## Step Credentials
+
+Steps can declare credentials that override or augment the referenced agent's
+credentials. This is useful when different steps need different API keys or when
+a step needs additional secrets not defined in the agent.
+
+```yaml
+workflow:
+  steps:
+    - id: analyze
+      type: agent
+      agent: Log Analyzer
+      credentials:
+        SPLUNK_TOKEN: splunk-prod        # Override agent's default credential
+        CUSTOM_WEBHOOK: slack-webhook    # Additional credential for this step
+```
+
+**Merge behavior:** Step credentials merge with agent credentials. Step values
+override agent values for the same environment variable name. Agent credentials
+not overridden are preserved.
+
+```
+Agent credentials:  {GITHUB_TOKEN: github, SPLUNK_TOKEN: splunk-staging}
+Step credentials:   {SPLUNK_TOKEN: splunk-prod, CUSTOM_KEY: my-secret}
+Result:             {GITHUB_TOKEN: github, SPLUNK_TOKEN: splunk-prod, CUSTOM_KEY: my-secret}
+```
+
+The `credentials` field uses the same format as agent-level credentials: keys
+are environment variable names, values are credential provider names from the
+credential store. See [Configuration Reference](configuration.md#credentials)
+for details on creating and managing credentials.
+
 ## Triggers
 
 Workflows run in response to events or on a schedule.

--- a/internal/bridge/workflow.go
+++ b/internal/bridge/workflow.go
@@ -58,6 +58,7 @@ type WorkflowStep struct {
 	RouteMap      map[string]string      `json:"route_map,omitempty" yaml:"route_map,omitempty"`           // Value -> next step mapping
 	MaxIterations int                    `json:"max_iterations,omitempty" yaml:"max_iterations,omitempty"` // Max times this step can execute (default 1)
 	MaxRetries    int                    `json:"max_retries,omitempty" yaml:"max_retries,omitempty"`       // Max retries on failure within one iteration
+	Credentials   map[string]string      `json:"credentials,omitempty" yaml:"credentials,omitempty"`
 }
 
 // WorkflowTrigger defines when a workflow should be triggered.

--- a/internal/bridge/workflow_engine.go
+++ b/internal/bridge/workflow_engine.go
@@ -79,6 +79,13 @@ type WorkflowRunStep struct {
 	Iteration  int                    `json:"iteration"`
 	StartedAt  *time.Time             `json:"started_at,omitempty"`
 	FinishedAt *time.Time             `json:"finished_at,omitempty"`
+
+	// Fields enriched from the workflow definition (not stored in DB).
+	Type          string            `json:"type,omitempty"`
+	Action        string            `json:"action,omitempty"`
+	Depends       string            `json:"depends,omitempty"`
+	MaxIterations int               `json:"max_iterations,omitempty"`
+	Credentials   map[string]string `json:"credentials,omitempty"`
 }
 
 // StartWorkflowRun creates a new workflow run and dispatches initial steps.
@@ -230,6 +237,16 @@ func (we *WorkflowEngine) dispatchStep(ctx context.Context, run *WorkflowRun, st
 	taskReq.TaskName = step.Agent
 	taskReq.TriggerType = run.TriggerType
 	taskReq.TriggerRef = run.TriggerRef
+
+	// Merge step-level credentials (override/augment agent credentials).
+	if len(step.Credentials) > 0 {
+		if taskReq.Credentials == nil {
+			taskReq.Credentials = make(map[string]string)
+		}
+		for envVar, credName := range step.Credentials {
+			taskReq.Credentials[envVar] = credName
+		}
+	}
 
 	// If step has a repo specified, override the agent's repo
 	if step.Repo != "" {
@@ -1085,7 +1102,8 @@ func (we *WorkflowEngine) ListWorkflowRuns(ctx context.Context, status, teamID s
 	return runs, nil
 }
 
-// GetWorkflowRunDetail retrieves a workflow run with all its steps.
+// GetWorkflowRunDetail retrieves a workflow run with all its steps, enriched
+// with definition data (type, action, depends, max_iterations, credentials).
 func (we *WorkflowEngine) GetWorkflowRunDetail(ctx context.Context, runID string) (*WorkflowRun, []WorkflowRunStep, error) {
 	run, err := we.GetWorkflowRun(ctx, runID)
 	if err != nil {
@@ -1095,6 +1113,24 @@ func (we *WorkflowEngine) GetWorkflowRunDetail(ctx context.Context, runID string
 	steps, err := we.getWorkflowRunSteps(ctx, runID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting workflow run steps: %w", err)
+	}
+
+	// Enrich run steps with fields from the workflow definition.
+	workflow, err := we.getWorkflowByID(ctx, run.WorkflowID)
+	if err == nil && workflow != nil {
+		defByID := make(map[string]*WorkflowStep, len(workflow.Workflow))
+		for i := range workflow.Workflow {
+			defByID[workflow.Workflow[i].ID] = &workflow.Workflow[i]
+		}
+		for i := range steps {
+			if def, ok := defByID[steps[i].StepID]; ok {
+				steps[i].Type = def.Type
+				steps[i].Action = def.Action
+				steps[i].Depends = def.Depends
+				steps[i].MaxIterations = def.MaxIterations
+				steps[i].Credentials = def.Credentials
+			}
+		}
 	}
 
 	return run, steps, nil

--- a/internal/bridge/workflow_test.go
+++ b/internal/bridge/workflow_test.go
@@ -764,6 +764,52 @@ func TestIsValidIdentifier(t *testing.T) {
 	}
 }
 
+func TestParseWorkflowWithStepCredentials(t *testing.T) {
+	yamlData := `
+name: Test Workflow
+workflow:
+  - id: step1
+    agent: Test Agent
+    credentials:
+      API_KEY: my-secret
+      DB_PASSWORD: db-cred
+`
+	wd, err := ParseWorkflowDefinition([]byte(yamlData))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(wd.Workflow) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(wd.Workflow))
+	}
+	step := wd.Workflow[0]
+	if len(step.Credentials) != 2 {
+		t.Errorf("expected 2 credentials, got %d", len(step.Credentials))
+	}
+	if step.Credentials["API_KEY"] != "my-secret" {
+		t.Errorf("API_KEY: got %q, want %q", step.Credentials["API_KEY"], "my-secret")
+	}
+	if step.Credentials["DB_PASSWORD"] != "db-cred" {
+		t.Errorf("DB_PASSWORD: got %q, want %q", step.Credentials["DB_PASSWORD"], "db-cred")
+	}
+}
+
+func TestParseWorkflowWithoutStepCredentials(t *testing.T) {
+	yamlData := `
+name: Test Workflow
+workflow:
+  - id: step1
+    agent: Test Agent
+`
+	wd, err := ParseWorkflowDefinition([]byte(yamlData))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	step := wd.Workflow[0]
+	if len(step.Credentials) != 0 {
+		t.Errorf("expected 0 credentials, got %d", len(step.Credentials))
+	}
+}
+
 func TestValidateConditionSyntax_Enhanced(t *testing.T) {
 	tests := []struct {
 		condition string

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2667,6 +2667,29 @@ details[open] > .tx-tool-expand-toggle::before {
     color: var(--text-muted);
 }
 
+/* Step credentials display in run detail */
+.step-credentials {
+    display: block;
+    margin-top: 4px;
+    font-size: 11px;
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+}
+
+.step-credentials-label {
+    font-family: var(--font-sans);
+    font-weight: 500;
+    color: var(--text-muted);
+}
+
+/* Credential icon in mini DAG */
+.step-cred-icon {
+    font-size: 10px;
+    margin-left: 3px;
+    cursor: help;
+    opacity: 0.7;
+}
+
 /* Max iterations exceeded status dot */
 .workflow-step-dot-max_iterations_exceeded {
     background: var(--status-error);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6326,8 +6326,18 @@
             var bridgeBadge = isBridge ? '<span class="bridge-badge">bridge</span>' : '';
             var stepTypeIcon = isBridge ? '<span class="step-type-icon-mini">&#9881;</span>' : '';
 
+            // Credential indicator with tooltip
+            var credBadge = '';
+            if (step.credentials && Object.keys(step.credentials).length > 0) {
+                var credParts = [];
+                for (var envVar in step.credentials) {
+                    credParts.push(escapeHtml(envVar) + '=' + escapeHtml(step.credentials[envVar]));
+                }
+                credBadge = '<span class="step-cred-icon" title="Credentials: ' + credParts.join(', ') + '">&#128273;</span>';
+            }
+
             dagHtml += '<span class="workflow-dag-step' + (hasApproval ? ' has-approval' : '') + (isBridge ? ' dag-step-bridge' : '') + '">' +
-                       stepTypeIcon + escapeHtml(stepName) + approvalIcon + bridgeBadge + '</span>';
+                       stepTypeIcon + escapeHtml(stepName) + approvalIcon + bridgeBadge + credBadge + '</span>';
 
             if (index < executionOrder.length - 1) {
                 dagHtml += '<span class="workflow-dag-arrow">→</span>';
@@ -6456,6 +6466,19 @@
                     dependsHtml = '<span class="workflow-step-depends">' + escapeHtml(step.depends) + '</span>';
                 }
 
+                // Step credentials
+                var credentialsHtml = '';
+                if (step.credentials && Object.keys(step.credentials).length > 0) {
+                    var credParts = [];
+                    for (var envVar in step.credentials) {
+                        credParts.push(escapeHtml(envVar) + '=' + escapeHtml(step.credentials[envVar]));
+                    }
+                    credentialsHtml = '<div class="step-credentials">' +
+                        '<span class="step-credentials-label">credentials:</span> ' +
+                        credParts.join(', ') +
+                        '</div>';
+                }
+
                 item.innerHTML =
                     '<div class="' + dotClass + '"></div>' +
                     typeIcon +
@@ -6466,6 +6489,7 @@
                             sessionLink +
                         '</div>' +
                         dependsHtml +
+                        credentialsHtml +
                     '</div>' +
                     actionsHtml;
 


### PR DESCRIPTION
## Summary

Steps can declare a `credentials:` map that merges with the agent's credentials. Step values override agent values for the same env var.

```yaml
workflow:
  - id: analyze
    agent: Log Analyzer
    credentials:
      SPLUNK_TOKEN: splunk-prod     # Override agent default
      CUSTOM_KEY: my-secret         # Additional credential
```

## Changes

- Backend: `Credentials` field on `WorkflowStep`, merge in `dispatchStep()`
- Frontend: key icon tooltip in DAG, credential display in run detail
- Docs: workflow-authoring.md, configuration.md
- Tests: 2 unit tests for YAML parsing with/without credentials

## Test Results

- Go unit tests: all pass (including 2 new step credential tests)
- Full test suite: all packages pass, no regressions
- Generic secrets API tests: 9/9 pass

Fixes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)