### PR TITLE
Fix Claude Pro/Max (OAuth) credential flow end-to-end

### DIFF
--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -703,10 +703,9 @@ func setupEnv(task internal.Task) {
 	// Force HTTPS for git operations (SSH bypasses Gate credential helper).
 	setEnvIfMissing("GIT_SSH_COMMAND", "echo 'SSH disabled — use HTTPS' && exit 1")
 
-	// Configure MCP servers for Claude Code if specified.
-	if mcpConfig := os.Getenv("ALCOVE_MCP_CONFIG"); mcpConfig != "" {
-		configureMCPServers(mcpConfig)
-	}
+	// Configure Claude Code: skip onboarding (prevents startup API key validation
+	// that bypasses ANTHROPIC_BASE_URL) and set up MCP servers if specified.
+	configureClaude(os.Getenv("ALCOVE_MCP_CONFIG"))
 
 	// Load skill/agent repos if specified.
 	loadSkillRepos()
@@ -720,20 +719,24 @@ func setupEnv(task internal.Task) {
 	}
 }
 
-// configureMCPServers writes MCP server configuration for Claude Code.
-// The config is a JSON object mapping server names to their configurations.
-// Claude Code reads MCP servers from ~/.claude.json.
-func configureMCPServers(configJSON string) {
-	// Parse the MCP config
-	var mcpServers map[string]any
-	if err := json.Unmarshal([]byte(configJSON), &mcpServers); err != nil {
-		log.Printf("warning: invalid ALCOVE_MCP_CONFIG: %v", err)
-		return
-	}
-
+// configureClaude writes ~/.claude.json with onboarding flag and optional MCP servers.
+// hasCompletedOnboarding prevents Claude Code from validating the API key at startup
+// via a direct CONNECT tunnel to api.anthropic.com, which bypasses Gate's credential
+// injection.
+func configureClaude(mcpConfigJSON string) {
 	// Build the Claude Code config structure
 	claudeConfig := map[string]any{
-		"mcpServers": mcpServers,
+		"hasCompletedOnboarding": true,
+	}
+
+	// Add MCP servers if configured
+	if mcpConfigJSON != "" {
+		var mcpServers map[string]any
+		if err := json.Unmarshal([]byte(mcpConfigJSON), &mcpServers); err != nil {
+			log.Printf("warning: invalid ALCOVE_MCP_CONFIG: %v", err)
+		} else {
+			claudeConfig["mcpServers"] = mcpServers
+		}
 	}
 
 	// Determine home directory
@@ -755,7 +758,7 @@ func configureMCPServers(configJSON string) {
 		return
 	}
 
-	log.Printf("configured %d MCP server(s) at %s", len(mcpServers), configPath)
+	log.Printf("configured claude at %s (onboarding=true)", configPath)
 
 	// Also write settings to auto-approve MCP servers
 	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -313,7 +313,17 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		"CLAUDE_MODEL":       model,
 		"TASK_TIMEOUT":       fmt.Sprintf("%d", timeout),
 		"ANTHROPIC_BASE_URL": fmt.Sprintf("http://%s:8443", gateName),
-		"ANTHROPIC_API_KEY":  "sk-placeholder-routed-through-gate",
+	}
+
+	// For claude-oauth (Pro/Max), pass the real OAuth token as
+	// ANTHROPIC_AUTH_TOKEN which Claude Code sends as Authorization: Bearer.
+	// This works in --bare mode (unlike CLAUDE_CODE_OAUTH_TOKEN) and the
+	// Anthropic API accepts OAuth tokens via Bearer auth.
+	// For all other providers, use a placeholder API key that Gate replaces.
+	if llmTokenType == "oauth_token" {
+		skiffEnv["ANTHROPIC_AUTH_TOKEN"] = llmToken
+	} else {
+		skiffEnv["ANTHROPIC_API_KEY"] = "sk-placeholder-routed-through-gate"
 	}
 
 	// Pass executable configuration to Skiff via environment variable

--- a/internal/bridge/llm.go
+++ b/internal/bridge/llm.go
@@ -117,11 +117,13 @@ func (l *BridgeLLM) completeAnthropic(ctx context.Context, systemPrompt, userPro
 		return "", fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", l.apiKey)
-	req.Header.Set("anthropic-version", "2023-06-01")
 	if l.provider == "claude-oauth" {
+		req.Header.Set("Authorization", "Bearer "+l.apiKey)
 		req.Header.Set("anthropic-beta", "oauth-2025-04-20,claude-code-20250219")
+	} else {
+		req.Header.Set("x-api-key", l.apiKey)
 	}
+	req.Header.Set("anthropic-version", "2023-06-01")
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)

--- a/internal/gate/proxy.go
+++ b/internal/gate/proxy.go
@@ -232,10 +232,28 @@ func (p *Proxy) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 func (p *Proxy) handleLLMRequest(w http.ResponseWriter, r *http.Request) {
 	var targetURL string
 	switch p.config.LLMProvider {
-	case "anthropic":
+	case "anthropic", "claude-oauth":
 		targetURL = "https://api.anthropic.com" + r.URL.Path
 		if r.URL.RawQuery != "" {
 			targetURL += "?" + r.URL.RawQuery
+		}
+
+		// For OAuth (Pro/Max), strip fields not supported by the subscription API.
+		if p.config.LLMProvider == "claude-oauth" {
+			bodyBytes, err := io.ReadAll(r.Body)
+			if err == nil {
+				var bodyMap map[string]any
+				if json.Unmarshal(bodyBytes, &bodyMap) == nil {
+					if _, has := bodyMap["context_management"]; has {
+						delete(bodyMap, "context_management")
+						if newBody, err := json.Marshal(bodyMap); err == nil {
+							bodyBytes = newBody
+						}
+					}
+				}
+				r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+				r.ContentLength = int64(len(bodyBytes))
+			}
 		}
 	case "google-vertex":
 		region := p.config.VertexRegion
@@ -313,13 +331,13 @@ func (p *Proxy) handleLLMRequest(w http.ResponseWriter, r *http.Request) {
 			// Inject credential based on token type
 			switch p.config.LLMTokenType {
 			case "oauth_token":
-				req.Header.Set("x-api-key", p.config.LLMToken)
+				req.Header.Set("Authorization", "Bearer "+p.config.LLMToken)
 				req.Header.Set("anthropic-version", "2023-06-01")
 				req.Header.Set("anthropic-beta", "oauth-2025-04-20,claude-code-20250219")
 			case "bearer":
 				req.Header.Set("Authorization", "Bearer "+p.config.LLMToken)
 			case "api_key":
-				if p.config.LLMProvider == "anthropic" {
+				if p.config.LLMProvider == "anthropic" || p.config.LLMProvider == "claude-oauth" {
 					req.Header.Set("x-api-key", p.config.LLMToken)
 					req.Header.Set("anthropic-version", "2023-06-01")
 				} else {
@@ -368,13 +386,13 @@ func (p *Proxy) handleLLMForward(w http.ResponseWriter, r *http.Request) {
 			// Inject credential based on token type
 			switch p.config.LLMTokenType {
 			case "oauth_token":
-				req.Header.Set("x-api-key", p.config.LLMToken)
+				req.Header.Set("Authorization", "Bearer "+p.config.LLMToken)
 				req.Header.Set("anthropic-version", "2023-06-01")
 				req.Header.Set("anthropic-beta", "oauth-2025-04-20,claude-code-20250219")
 			case "bearer":
 				req.Header.Set("Authorization", "Bearer "+p.config.LLMToken)
 			case "api_key":
-				if p.config.LLMProvider == "anthropic" {
+				if p.config.LLMProvider == "anthropic" || p.config.LLMProvider == "claude-oauth" {
 					req.Header.Set("x-api-key", p.config.LLMToken)
 					req.Header.Set("anthropic-version", "2023-06-01")
 				} else {


### PR DESCRIPTION
## Summary

Fixes five issues that prevented Claude Pro/Max (OAuth) tokens from working:

1. **Gate routing**: `handleLLMRequest()` had no case for `"claude-oauth"` — caused 500 errors
2. **Auth header**: OAuth tokens must use `Authorization: Bearer`, not `x-api-key`
3. **Dispatcher**: Pass token as `ANTHROPIC_AUTH_TOKEN` (Bearer, precedence #2) instead of `ANTHROPIC_API_KEY`
4. **Request body**: Strip `context_management` field — Pro/Max subscriptions reject this beta feature
5. **Skiff-init**: Write `hasCompletedOnboarding: true` to `~/.claude.json` to skip startup validation

Also fixes system LLM (`llm.go`) to use Bearer auth for claude-oauth.

## Test plan

- [x] `go build/vet/test` all pass
- [x] Vertex AI session: completed, exit 0
- [x] Pro/Max OAuth session: completed, exit 0
- [x] Pro/Max OAuth token validated via direct curl (Bearer auth returns rate_limit, not auth_error)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)