### PR TITLE
Catalog redesign: 168 individual items with categories and search

### DIFF
--- a/cmd/alcove/catalog.go
+++ b/cmd/alcove/catalog.go
@@ -26,18 +26,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// catalogSourceEntry represents a source with item counts from GET /api/v1/teams/{team}/catalog.
-type catalogSourceEntry struct {
-	ID           string `json:"id"`
-	Name         string `json:"name"`
-	Category     string `json:"category"`
-	ItemCount    int    `json:"item_count"`
-	EnabledCount int    `json:"enabled_count"`
+// catalogEntry represents a catalog entry from GET /api/v1/teams/{team}/catalog.
+type catalogEntry struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Category    string   `json:"category"`
+	SourceType  string   `json:"source_type"`
+	Enabled     bool     `json:"enabled"`
+	Tags        []string `json:"tags"`
 }
 
-// catalogSourcesResponse is the response from GET /api/v1/teams/{team}/catalog.
-type catalogSourcesResponse struct {
-	Sources []catalogSourceEntry `json:"sources"`
+// catalogEntriesResponse is the response from GET /api/v1/teams/{team}/catalog.
+type catalogEntriesResponse struct {
+	Entries []catalogEntry `json:"entries"`
 }
 
 // catalogItem represents a single item within a source from GET /api/v1/teams/{team}/catalog/{source}.
@@ -51,6 +53,22 @@ type catalogItem struct {
 // catalogItemsResponse is the response from GET /api/v1/teams/{team}/catalog/{source}.
 type catalogItemsResponse struct {
 	Items []catalogItem `json:"items"`
+}
+
+// sourceTypeLabel maps source_type to a short display label.
+func sourceTypeLabel(sourceType string) string {
+	switch sourceType {
+	case "claude-plugins-official":
+		return "plugin"
+	case "agency-agents":
+		return "agent"
+	case "mcp-server":
+		return "mcp"
+	case "plugin-bundle":
+		return "bundle"
+	default:
+		return sourceType
+	}
 }
 
 // catalogAgent represents an enabled agent from GET /api/v1/teams/{team}/agents.
@@ -72,6 +90,7 @@ func newCatalogCmd() *cobra.Command {
 	}
 	cmd.AddCommand(
 		newCatalogListCmd(),
+		newCatalogSearchCmd(),
 		newCatalogItemsCmd(),
 		newCatalogEnableCmd(),
 		newCatalogDisableCmd(),
@@ -85,7 +104,7 @@ func newCatalogCmd() *cobra.Command {
 func newCatalogListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List catalog sources with item counts",
+		Short: "List catalog entries",
 		RunE:  runCatalogList,
 	}
 	cmd.Flags().String("category", "", "Filter by category")
@@ -93,58 +112,118 @@ func newCatalogListCmd() *cobra.Command {
 }
 
 func runCatalogList(cmd *cobra.Command, _ []string) error {
+	entries, err := fetchCatalogEntries(cmd)
+	if err != nil {
+		return err
+	}
+
+	categoryFilter, _ := cmd.Flags().GetString("category")
+	var filtered []catalogEntry
+	for _, e := range entries {
+		if categoryFilter != "" && !strings.EqualFold(e.Category, categoryFilter) {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+
+	return printCatalogEntries(cmd, filtered)
+}
+
+// fetchCatalogEntries retrieves all catalog entries from the API.
+func fetchCatalogEntries(cmd *cobra.Command) ([]catalogEntry, error) {
 	teamName := resolveTeamName(cmd)
 	if teamName == "" {
-		return fmt.Errorf("no active team; use 'alcove teams use <name>' or --team to set one")
+		return nil, fmt.Errorf("no active team; use 'alcove teams use <name>' or --team to set one")
 	}
 
 	teamID, err := resolveTeamID(cmd, teamName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	path := fmt.Sprintf("/api/v1/teams/%s/catalog", teamID)
 	resp, err := apiRequestRaw(cmd, http.MethodGet, path, nil, teamID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
 	}
 
-	var result catalogSourcesResponse
+	var result catalogEntriesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return fmt.Errorf("decoding catalog response: %w", err)
+		return nil, fmt.Errorf("decoding catalog response: %w", err)
 	}
 
-	categoryFilter, _ := cmd.Flags().GetString("category")
-	var filtered []catalogSourceEntry
-	for _, s := range result.Sources {
-		if categoryFilter != "" && s.Category != categoryFilter {
-			continue
-		}
-		filtered = append(filtered, s)
-	}
+	return result.Entries, nil
+}
 
+// printCatalogEntries renders catalog entries as a table or JSON.
+func printCatalogEntries(cmd *cobra.Command, entries []catalogEntry) error {
 	if isJSONOutput(cmd) {
-		return outputJSON(filtered)
+		return outputJSON(entries)
 	}
 
-	if len(filtered) == 0 {
-		fmt.Fprintln(os.Stderr, "No catalog sources found.")
+	if len(entries) == 0 {
+		fmt.Fprintln(os.Stderr, "No catalog entries found.")
 		return nil
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "SOURCE\tCATEGORY\tITEMS\tENABLED")
-	for _, s := range filtered {
-		enabled := fmt.Sprintf("%d/%d", s.EnabledCount, s.ItemCount)
-		fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", s.Name, s.Category, s.ItemCount, enabled)
+	fmt.Fprintln(w, "ID\tCATEGORY\tTYPE\tNAME\tENABLED\tDESCRIPTION")
+	for _, e := range entries {
+		enabled := "no"
+		if e.Enabled {
+			enabled = "yes"
+		}
+		desc := e.Description
+		if len(desc) > 50 {
+			desc = desc[:47] + "..."
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			e.ID, e.Category, sourceTypeLabel(e.SourceType), e.Name, enabled, desc)
 	}
 	return w.Flush()
+}
+
+// ---------- catalog search ----------
+
+func newCatalogSearchCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search catalog entries by name, description, or tags",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runCatalogSearch,
+	}
+}
+
+func runCatalogSearch(cmd *cobra.Command, args []string) error {
+	query := strings.ToLower(args[0])
+
+	entries, err := fetchCatalogEntries(cmd)
+	if err != nil {
+		return err
+	}
+
+	var matched []catalogEntry
+	for _, e := range entries {
+		if strings.Contains(strings.ToLower(e.Name), query) ||
+			strings.Contains(strings.ToLower(e.Description), query) {
+			matched = append(matched, e)
+			continue
+		}
+		for _, tag := range e.Tags {
+			if strings.Contains(strings.ToLower(tag), query) {
+				matched = append(matched, e)
+				break
+			}
+		}
+	}
+
+	return printCatalogEntries(cmd, matched)
 }
 
 // ---------- catalog items ----------

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -2683,9 +2683,25 @@ func (a *API) handleCatalog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	entries := LoadCatalog()
+
+	// Build category counts
+	categoryCounts := make(map[string]int)
+	for _, e := range entries {
+		categoryCounts[e.Category]++
+	}
+	type categoryInfo struct {
+		ID    string `json:"id"`
+		Count int    `json:"count"`
+	}
+	var categories []categoryInfo
+	for cat, count := range categoryCounts {
+		categories = append(categories, categoryInfo{ID: cat, Count: count})
+	}
+
 	respondJSON(w, http.StatusOK, map[string]any{
-		"entries": entries,
-		"count":   len(entries),
+		"entries":    entries,
+		"count":      len(entries),
+		"categories": categories,
 	})
 }
 

--- a/internal/bridge/catalog.go
+++ b/internal/bridge/catalog.go
@@ -19,12 +19,13 @@ type CatalogEntry struct {
 	ID          string   `json:"id"`
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
-	URL         string   `json:"url"`
-	Ref         string   `json:"ref,omitempty"`
-	Path        string   `json:"path,omitempty"`
 	Category    string   `json:"category"`
+	SourceType  string   `json:"source_type"`
+	SourceURL   string   `json:"source_url"`
+	SourcePath  string   `json:"source_path,omitempty"`
+	Ref         string   `json:"ref,omitempty"`
+	DocsURL     string   `json:"docs_url,omitempty"`
 	Tags        []string `json:"tags,omitempty"`
-	Source      string   `json:"source,omitempty"`
 }
 
 var (
@@ -45,7 +46,7 @@ func ResolveCatalogSkillRepos(catalog []CatalogEntry, enabledMap map[string]bool
 		if enabledMap[entry.ID] {
 			enabled := true
 			repos = append(repos, SkillRepo{
-				URL:     entry.URL,
+				URL:     entry.SourceURL,
 				Ref:     entry.Ref,
 				Name:    entry.Name,
 				Enabled: &enabled,

--- a/internal/bridge/catalog.json
+++ b/internal/bridge/catalog.json
@@ -1,11 +1,2413 @@
 [
-  {"id":"code-review","name":"Code Review","description":"Multi-agent PR review with confidence-based scoring and false-positive filtering","url":"https://github.com/anthropics/claude-plugins-official","ref":"main","path":"plugins/code-review","category":"plugins","tags":["github","pull-requests","code-quality"],"source":"claude-plugins-official"},
-  {"id":"feature-dev","name":"Feature Development","description":"Guided feature development workflow with codebase exploration and architecture design","url":"https://github.com/anthropics/claude-plugins-official","ref":"main","path":"plugins/feature-dev","category":"plugins","tags":["workflow","development"],"source":"claude-plugins-official"},
-  {"id":"security-guidance","name":"Security Guidance","description":"Security reminder hooks that warn about command injection, XSS, and unsafe patterns","url":"https://github.com/anthropics/claude-plugins-official","ref":"main","path":"plugins/security-guidance","category":"security","tags":["sast","hooks","vulnerabilities"],"source":"claude-plugins-official"},
-  {"id":"frontend-design","name":"Frontend Design","description":"Production-grade frontend interface generation for rapid UI development","url":"https://github.com/anthropics/claude-plugins-official","ref":"main","path":"plugins/frontend-design","category":"plugins","tags":["ui","frontend","design"],"source":"claude-plugins-official"},
-  {"id":"commit-commands","name":"Commit Commands","description":"Git commit workflow automation with custom slash commands","url":"https://github.com/anthropics/claude-plugins-official","ref":"main","path":"plugins/commit-commands","category":"plugins","tags":["git","workflow"],"source":"claude-plugins-official"},
-  {"id":"hookify","name":"Hookify","description":"Create custom Claude Code hooks from plain English rules","url":"https://github.com/anthropics/claude-plugins-official","ref":"main","path":"plugins/hookify","category":"plugins","tags":["hooks","automation"],"source":"claude-plugins-official"},
-  {"id":"typescript-lsp","name":"TypeScript Language Server","description":"Go-to-definition, find-references, and real-time error checking for TypeScript and JavaScript","url":"https://github.com/anthropics/claude-plugins-official","ref":"main","path":"plugins/typescript-lsp","category":"language-servers","tags":["typescript","javascript","lsp"],"source":"claude-plugins-official"},
-  {"id":"context7","name":"Context7","description":"Fetches up-to-date, version-specific library documentation to prevent API hallucinations","url":"https://github.com/upstash/context7","ref":"main","category":"integrations","tags":["documentation","libraries","mcp"]},
-  {"id":"agency-agents","name":"Agency Agents","description":"130+ pre-built agent personas for engineering, marketing, testing, design, and more","url":"https://github.com/msitarzewski/agency-agents","ref":"main","category":"agent-templates","tags":["personas","templates","multi-domain"]}
+  {
+    "id": "code-review",
+    "name": "Code Review",
+    "description": "Multi-agent PR review with confidence-based scoring and false-positive filtering.",
+    "category": "code-quality",
+    "source_type": "claude-plugins-official",
+    "source_url": "https://github.com/anthropics/claude-plugins-official",
+    "source_path": "plugins/code-review",
+    "docs_url": "https://github.com/anthropics/claude-plugins-official/blob/main/plugins/code-review",
+    "tags": [
+      "github",
+      "pull-requests",
+      "code-quality"
+    ]
+  },
+  {
+    "id": "feature-dev",
+    "name": "Feature Development",
+    "description": "Guided feature development workflow with codebase exploration and architecture design.",
+    "category": "developer-tools",
+    "source_type": "claude-plugins-official",
+    "source_url": "https://github.com/anthropics/claude-plugins-official",
+    "source_path": "plugins/feature-dev",
+    "docs_url": "https://github.com/anthropics/claude-plugins-official/blob/main/plugins/feature-dev",
+    "tags": [
+      "workflow",
+      "development"
+    ]
+  },
+  {
+    "id": "security-guidance",
+    "name": "Security Guidance",
+    "description": "Security reminder hooks that warn about command injection, XSS, and unsafe patterns.",
+    "category": "security",
+    "source_type": "claude-plugins-official",
+    "source_url": "https://github.com/anthropics/claude-plugins-official",
+    "source_path": "plugins/security-guidance",
+    "docs_url": "https://github.com/anthropics/claude-plugins-official/blob/main/plugins/security-guidance",
+    "tags": [
+      "sast",
+      "hooks",
+      "vulnerabilities"
+    ]
+  },
+  {
+    "id": "frontend-design",
+    "name": "Frontend Design",
+    "description": "Production-grade frontend interface generation for rapid UI development.",
+    "category": "frontend",
+    "source_type": "claude-plugins-official",
+    "source_url": "https://github.com/anthropics/claude-plugins-official",
+    "source_path": "plugins/frontend-design",
+    "docs_url": "https://github.com/anthropics/claude-plugins-official/blob/main/plugins/frontend-design",
+    "tags": [
+      "ui",
+      "frontend",
+      "design"
+    ]
+  },
+  {
+    "id": "commit-commands",
+    "name": "Commit Commands",
+    "description": "Git commit workflow automation with custom slash commands.",
+    "category": "developer-tools",
+    "source_type": "claude-plugins-official",
+    "source_url": "https://github.com/anthropics/claude-plugins-official",
+    "source_path": "plugins/commit-commands",
+    "docs_url": "https://github.com/anthropics/claude-plugins-official/blob/main/plugins/commit-commands",
+    "tags": [
+      "git",
+      "workflow"
+    ]
+  },
+  {
+    "id": "hookify",
+    "name": "Hookify",
+    "description": "Create custom Claude Code hooks from plain English rules.",
+    "category": "developer-tools",
+    "source_type": "claude-plugins-official",
+    "source_url": "https://github.com/anthropics/claude-plugins-official",
+    "source_path": "plugins/hookify",
+    "docs_url": "https://github.com/anthropics/claude-plugins-official/blob/main/plugins/hookify",
+    "tags": [
+      "hooks",
+      "automation"
+    ]
+  },
+  {
+    "id": "typescript-lsp",
+    "name": "TypeScript Language Server",
+    "description": "Go-to-definition, find-references, and real-time error checking for TypeScript and JavaScript.",
+    "category": "developer-tools",
+    "source_type": "claude-plugins-official",
+    "source_url": "https://github.com/anthropics/claude-plugins-official",
+    "source_path": "plugins/typescript-lsp",
+    "docs_url": "https://github.com/anthropics/claude-plugins-official/blob/main/plugins/typescript-lsp",
+    "tags": [
+      "typescript",
+      "javascript",
+      "lsp"
+    ]
+  },
+  {
+    "id": "sdlc-go",
+    "name": "SDLC Go",
+    "description": "Full software development lifecycle plugin bundle for Go projects.",
+    "category": "developer-tools",
+    "source_type": "plugin-bundle",
+    "source_url": "https://github.com/anthropics/claude-plugins-official",
+    "source_path": "bundles/sdlc-go",
+    "docs_url": "https://github.com/anthropics/claude-plugins-official/blob/main/bundles/sdlc-go",
+    "tags": [
+      "go",
+      "sdlc",
+      "bundle"
+    ]
+  },
+  {
+    "id": "sdlc-python",
+    "name": "SDLC Python",
+    "description": "Full software development lifecycle plugin bundle for Python projects.",
+    "category": "developer-tools",
+    "source_type": "plugin-bundle",
+    "source_url": "https://github.com/anthropics/claude-plugins-official",
+    "source_path": "bundles/sdlc-python",
+    "docs_url": "https://github.com/anthropics/claude-plugins-official/blob/main/bundles/sdlc-python",
+    "tags": [
+      "python",
+      "sdlc",
+      "bundle"
+    ]
+  },
+  {
+    "id": "sdlc-typescript",
+    "name": "SDLC TypeScript",
+    "description": "Full software development lifecycle plugin bundle for TypeScript projects.",
+    "category": "developer-tools",
+    "source_type": "plugin-bundle",
+    "source_url": "https://github.com/anthropics/claude-plugins-official",
+    "source_path": "bundles/sdlc-typescript",
+    "docs_url": "https://github.com/anthropics/claude-plugins-official/blob/main/bundles/sdlc-typescript",
+    "tags": [
+      "typescript",
+      "sdlc",
+      "bundle"
+    ]
+  },
+  {
+    "id": "content",
+    "name": "Content",
+    "description": "Content creation and marketing plugin bundle for writing and publishing workflows.",
+    "category": "marketing",
+    "source_type": "plugin-bundle",
+    "source_url": "https://github.com/anthropics/claude-plugins-official",
+    "source_path": "bundles/content",
+    "docs_url": "https://github.com/anthropics/claude-plugins-official/blob/main/bundles/content",
+    "tags": [
+      "content",
+      "marketing",
+      "bundle"
+    ]
+  },
+  {
+    "id": "context7",
+    "name": "Context7",
+    "description": "Fetches up-to-date, version-specific library documentation to prevent API hallucinations.",
+    "category": "developer-tools",
+    "source_type": "mcp-server",
+    "source_url": "https://github.com/upstash/context7",
+    "source_path": "",
+    "docs_url": "https://github.com/upstash/context7/blob/main/README.md",
+    "tags": [
+      "documentation",
+      "libraries",
+      "mcp"
+    ]
+  },
+  {
+    "id": "agency-anthropologist",
+    "name": "Anthropologist",
+    "description": "Expert in cultural systems, rituals, kinship, belief systems, and ethnographic method.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "academic/academic-anthropologist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/academic/academic-anthropologist.md",
+    "tags": [
+      "persona",
+      "academic",
+      "research"
+    ]
+  },
+  {
+    "id": "agency-geographer",
+    "name": "Geographer",
+    "description": "Expert in physical and human geography, climate systems, cartography, and spatial analysis.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "academic/academic-geographer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/academic/academic-geographer.md",
+    "tags": [
+      "persona",
+      "academic",
+      "research"
+    ]
+  },
+  {
+    "id": "agency-historian",
+    "name": "Historian",
+    "description": "Expert in historical analysis, periodization, material culture, and historiography.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "academic/academic-historian.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/academic/academic-historian.md",
+    "tags": [
+      "persona",
+      "academic",
+      "research"
+    ]
+  },
+  {
+    "id": "agency-narratologist",
+    "name": "Narratologist",
+    "description": "Expert in narrative theory, story structure, character arcs, and literary analysis.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "academic/academic-narratologist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/academic/academic-narratologist.md",
+    "tags": [
+      "persona",
+      "academic",
+      "research"
+    ]
+  },
+  {
+    "id": "agency-psychologist",
+    "name": "Psychologist",
+    "description": "Expert in human behavior, personality theory, motivation, and cognitive patterns.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "academic/academic-psychologist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/academic/academic-psychologist.md",
+    "tags": [
+      "persona",
+      "academic",
+      "research"
+    ]
+  },
+  {
+    "id": "agency-brand-guardian",
+    "name": "Brand Guardian",
+    "description": "Expert brand strategist and guardian specializing in brand identity development and consistency.",
+    "category": "frontend",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "design/design-brand-guardian.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/design/design-brand-guardian.md",
+    "tags": [
+      "persona",
+      "design",
+      "ui-ux"
+    ]
+  },
+  {
+    "id": "agency-image-prompt-engineer",
+    "name": "Image Prompt Engineer",
+    "description": "Expert photography prompt engineer specializing in crafting prompts for AI image generation.",
+    "category": "frontend",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "design/design-image-prompt-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/design/design-image-prompt-engineer.md",
+    "tags": [
+      "persona",
+      "design",
+      "ui-ux"
+    ]
+  },
+  {
+    "id": "agency-inclusive-visuals-specialist",
+    "name": "Inclusive Visuals Specialist",
+    "description": "Representation expert who defeats systemic AI biases to generate culturally accurate imagery.",
+    "category": "frontend",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "design/design-inclusive-visuals-specialist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/design/design-inclusive-visuals-specialist.md",
+    "tags": [
+      "persona",
+      "design",
+      "ui-ux"
+    ]
+  },
+  {
+    "id": "agency-ui-designer",
+    "name": "UI Designer",
+    "description": "Expert UI designer specializing in visual design systems, component libraries, and interfaces.",
+    "category": "frontend",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "design/design-ui-designer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/design/design-ui-designer.md",
+    "tags": [
+      "persona",
+      "design",
+      "ui-ux"
+    ]
+  },
+  {
+    "id": "agency-ux-architect",
+    "name": "UX Architect",
+    "description": "Technical architecture and UX specialist providing solid foundations and CSS systems.",
+    "category": "frontend",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "design/design-ux-architect.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/design/design-ux-architect.md",
+    "tags": [
+      "persona",
+      "design",
+      "ui-ux"
+    ]
+  },
+  {
+    "id": "agency-ux-researcher",
+    "name": "UX Researcher",
+    "description": "Expert user experience researcher specializing in user behavior analysis and usability testing.",
+    "category": "frontend",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "design/design-ux-researcher.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/design/design-ux-researcher.md",
+    "tags": [
+      "persona",
+      "design",
+      "ui-ux"
+    ]
+  },
+  {
+    "id": "agency-visual-storyteller",
+    "name": "Visual Storyteller",
+    "description": "Expert visual communication specialist focused on creating compelling visual narratives.",
+    "category": "frontend",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "design/design-visual-storyteller.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/design/design-visual-storyteller.md",
+    "tags": [
+      "persona",
+      "design",
+      "ui-ux"
+    ]
+  },
+  {
+    "id": "agency-whimsy-injector",
+    "name": "Whimsy Injector",
+    "description": "Expert creative specialist focused on adding personality, delight, and playful elements.",
+    "category": "frontend",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "design/design-whimsy-injector.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/design/design-whimsy-injector.md",
+    "tags": [
+      "persona",
+      "design",
+      "ui-ux"
+    ]
+  },
+  {
+    "id": "agency-ai-data-remediation-engineer",
+    "name": "AI Data Remediation Engineer",
+    "description": "Specialist in self-healing data pipelines using local SLMs to detect and fix data anomalies.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-ai-data-remediation-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-ai-data-remediation-engineer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-ai-engineer",
+    "name": "AI Engineer",
+    "description": "Expert AI/ML engineer specializing in machine learning model development and deployment.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-ai-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-ai-engineer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-autonomous-optimization-architect",
+    "name": "Autonomous Optimization Architect",
+    "description": "Intelligent system governor that shadow-tests APIs for performance with financial guardrails.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-autonomous-optimization-architect.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-autonomous-optimization-architect.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-backend-architect",
+    "name": "Backend Architect",
+    "description": "Senior backend architect specializing in scalable system design and database architecture.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-backend-architect.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-backend-architect.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-code-reviewer",
+    "name": "Code Reviewer",
+    "description": "Expert code reviewer providing constructive feedback on correctness, maintainability, and security.",
+    "category": "code-quality",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-code-reviewer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-code-reviewer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-database-optimizer",
+    "name": "Database Optimizer",
+    "description": "Expert database specialist focusing on schema design, query optimization, and indexing.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-database-optimizer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-database-optimizer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-data-engineer",
+    "name": "Data Engineer",
+    "description": "Expert data engineer specializing in building reliable data pipelines and lakehouse architectures.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-data-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-data-engineer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-devops-automator",
+    "name": "DevOps Automator",
+    "description": "Expert DevOps engineer specializing in infrastructure automation and CI/CD pipeline development.",
+    "category": "devops",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-devops-automator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-devops-automator.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-embedded-firmware-engineer",
+    "name": "Embedded Firmware Engineer",
+    "description": "Specialist in bare-metal and RTOS firmware for ESP32, ARM Cortex-M, STM32, and Nordic nRF.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-embedded-firmware-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-embedded-firmware-engineer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-feishu-integration-developer",
+    "name": "Feishu Integration Developer",
+    "description": "Full-stack integration expert specializing in the Feishu (Lark) Open Platform.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-feishu-integration-developer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-feishu-integration-developer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-frontend-developer",
+    "name": "Frontend Developer",
+    "description": "Expert frontend developer specializing in modern web technologies and React/Vue/Angular.",
+    "category": "frontend",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-frontend-developer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-frontend-developer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-git-workflow-master",
+    "name": "Git Workflow Master",
+    "description": "Expert in Git workflows, branching strategies, and version control best practices.",
+    "category": "developer-tools",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-git-workflow-master.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-git-workflow-master.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-incident-response-commander",
+    "name": "Incident Response Commander",
+    "description": "Expert incident commander specializing in production incident management and coordination.",
+    "category": "devops",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-incident-response-commander.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-incident-response-commander.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-mobile-app-builder",
+    "name": "Mobile App Builder",
+    "description": "Specialized mobile application developer with expertise in native iOS/Android and cross-platform.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-mobile-app-builder.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-mobile-app-builder.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-rapid-prototyper",
+    "name": "Rapid Prototyper",
+    "description": "Specialized in ultra-fast proof-of-concept development and MVP creation.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-rapid-prototyper.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-rapid-prototyper.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-security-engineer",
+    "name": "Security Engineer",
+    "description": "Expert application security engineer specializing in threat modeling and vulnerability assessment.",
+    "category": "security",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-security-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-security-engineer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-senior-developer",
+    "name": "Senior Developer",
+    "description": "Premium implementation specialist mastering Laravel/Livewire/FluxUI and advanced CSS.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-senior-developer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-senior-developer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-software-architect",
+    "name": "Software Architect",
+    "description": "Expert software architect specializing in system design and domain-driven design.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-software-architect.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-software-architect.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-solidity-smart-contract-engineer",
+    "name": "Solidity Smart Contract Engineer",
+    "description": "Expert Solidity developer specializing in EVM smart contract architecture and gas optimization.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-solidity-smart-contract-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-solidity-smart-contract-engineer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-sre",
+    "name": "SRE (Site Reliability Engineer)",
+    "description": "Expert site reliability engineer specializing in SLOs, error budgets, and observability.",
+    "category": "devops",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-sre.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-sre.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-technical-writer",
+    "name": "Technical Writer",
+    "description": "Expert technical writer specializing in developer documentation, API references, and tutorials.",
+    "category": "documentation",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-technical-writer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-technical-writer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-threat-detection-engineer",
+    "name": "Threat Detection Engineer",
+    "description": "Expert detection engineer specializing in SIEM rule development and MITRE ATT&CK coverage.",
+    "category": "security",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-threat-detection-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-threat-detection-engineer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-wechat-mini-program-developer",
+    "name": "WeChat Mini Program Developer",
+    "description": "Expert WeChat Mini Program developer specializing in WXML/WXSS/WXS and WeChat API integration.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "engineering/engineering-wechat-mini-program-developer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/engineering/engineering-wechat-mini-program-developer.md",
+    "tags": [
+      "persona",
+      "engineering"
+    ]
+  },
+  {
+    "id": "agency-blender-addon-engineer",
+    "name": "Blender Add-on Engineer",
+    "description": "Blender tooling specialist building Python add-ons, asset validators, and pipeline automations.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/blender/blender-addon-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/blender/blender-addon-engineer.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "blender",
+      "3d"
+    ]
+  },
+  {
+    "id": "agency-audio-engineer",
+    "name": "Game Audio Engineer",
+    "description": "Interactive audio specialist mastering FMOD/Wwise integration and adaptive music systems.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/game-audio-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/game-audio-engineer.md",
+    "tags": [
+      "persona",
+      "game-dev"
+    ]
+  },
+  {
+    "id": "agency-designer",
+    "name": "Game Designer",
+    "description": "Systems and mechanics architect mastering GDD authorship and gameplay loop design.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/game-designer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/game-designer.md",
+    "tags": [
+      "persona",
+      "game-dev"
+    ]
+  },
+  {
+    "id": "agency-godot-gameplay-scripter",
+    "name": "Godot Gameplay Scripter",
+    "description": "Composition and signal integrity specialist mastering GDScript 2.0 and C# for Godot 4.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/godot/godot-gameplay-scripter.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/godot/godot-gameplay-scripter.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "godot"
+    ]
+  },
+  {
+    "id": "agency-godot-multiplayer-engineer",
+    "name": "Godot Multiplayer Engineer",
+    "description": "Godot 4 networking specialist mastering the MultiplayerAPI and ENet/WebRTC transport.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/godot/godot-multiplayer-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/godot/godot-multiplayer-engineer.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "godot"
+    ]
+  },
+  {
+    "id": "agency-godot-shader-developer",
+    "name": "Godot Shader Developer",
+    "description": "Godot 4 visual effects specialist mastering the Godot Shading Language and VisualShader.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/godot/godot-shader-developer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/godot/godot-shader-developer.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "godot"
+    ]
+  },
+  {
+    "id": "agency-level-designer",
+    "name": "Level Designer",
+    "description": "Spatial storytelling and flow specialist mastering layout theory and pacing architecture.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/level-designer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/level-designer.md",
+    "tags": [
+      "persona",
+      "game-dev"
+    ]
+  },
+  {
+    "id": "agency-narrative-designer",
+    "name": "Narrative Designer",
+    "description": "Story systems and dialogue architect mastering branching dialogue and lore architecture.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/narrative-designer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/narrative-designer.md",
+    "tags": [
+      "persona",
+      "game-dev"
+    ]
+  },
+  {
+    "id": "agency-roblox-avatar-creator",
+    "name": "Roblox Avatar Creator",
+    "description": "Roblox UGC and avatar pipeline specialist mastering avatar systems and Creator Marketplace.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/roblox-studio/roblox-avatar-creator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/roblox-studio/roblox-avatar-creator.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "roblox"
+    ]
+  },
+  {
+    "id": "agency-roblox-experience-designer",
+    "name": "Roblox Experience Designer",
+    "description": "Roblox platform UX and monetization specialist mastering engagement loop design.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/roblox-studio/roblox-experience-designer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/roblox-studio/roblox-experience-designer.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "roblox"
+    ]
+  },
+  {
+    "id": "agency-roblox-systems-scripter",
+    "name": "Roblox Systems Scripter",
+    "description": "Roblox platform engineering specialist mastering Luau and client-server security.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/roblox-studio/roblox-systems-scripter.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/roblox-studio/roblox-systems-scripter.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "roblox"
+    ]
+  },
+  {
+    "id": "agency-technical-artist",
+    "name": "Technical Artist",
+    "description": "Art-to-engine pipeline specialist mastering shaders, VFX systems, and LOD pipelines.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/technical-artist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/technical-artist.md",
+    "tags": [
+      "persona",
+      "game-dev"
+    ]
+  },
+  {
+    "id": "agency-unity-architect",
+    "name": "Unity Architect",
+    "description": "Data-driven modularity specialist mastering ScriptableObjects and decoupled Unity systems.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/unity/unity-architect.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/unity/unity-architect.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "unity"
+    ]
+  },
+  {
+    "id": "agency-unity-editor-tool-developer",
+    "name": "Unity Editor Tool Developer",
+    "description": "Unity editor automation specialist mastering custom EditorWindows and PropertyDrawers.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/unity/unity-editor-tool-developer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/unity/unity-editor-tool-developer.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "unity"
+    ]
+  },
+  {
+    "id": "agency-unity-multiplayer-engineer",
+    "name": "Unity Multiplayer Engineer",
+    "description": "Networked gameplay specialist mastering Netcode for GameObjects and Unity Gaming Services.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/unity/unity-multiplayer-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/unity/unity-multiplayer-engineer.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "unity"
+    ]
+  },
+  {
+    "id": "agency-unity-shader-graph-artist",
+    "name": "Unity Shader Graph Artist",
+    "description": "Visual effects and material specialist mastering Unity Shader Graph and HLSL.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/unity/unity-shader-graph-artist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/unity/unity-shader-graph-artist.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "unity"
+    ]
+  },
+  {
+    "id": "agency-unreal-multiplayer-architect",
+    "name": "Unreal Multiplayer Architect",
+    "description": "Unreal Engine networking specialist mastering Actor replication and server-authoritative gameplay.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/unreal-engine/unreal-multiplayer-architect.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/unreal-engine/unreal-multiplayer-architect.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "unreal"
+    ]
+  },
+  {
+    "id": "agency-unreal-systems-engineer",
+    "name": "Unreal Systems Engineer",
+    "description": "Performance and hybrid architecture specialist mastering C++/Blueprint for Unreal Engine.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/unreal-engine/unreal-systems-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/unreal-engine/unreal-systems-engineer.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "unreal"
+    ]
+  },
+  {
+    "id": "agency-unreal-technical-artist",
+    "name": "Unreal Technical Artist",
+    "description": "Unreal Engine visual pipeline specialist mastering Material Editor and Niagara VFX.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/unreal-engine/unreal-technical-artist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/unreal-engine/unreal-technical-artist.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "unreal"
+    ]
+  },
+  {
+    "id": "agency-unreal-world-builder",
+    "name": "Unreal World Builder",
+    "description": "Open-world and environment specialist mastering UE5 World Partition and Landscape.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "game-development/unreal-engine/unreal-world-builder.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/game-development/unreal-engine/unreal-world-builder.md",
+    "tags": [
+      "persona",
+      "game-dev",
+      "unreal"
+    ]
+  },
+  {
+    "id": "agency-ai-citation-strategist",
+    "name": "AI Citation Strategist",
+    "description": "Expert in AI recommendation engine optimization for ChatGPT, Claude, Gemini, and Perplexity.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-ai-citation-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-ai-citation-strategist.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-app-store-optimizer",
+    "name": "App Store Optimizer",
+    "description": "Expert app store marketing specialist focused on ASO and conversion rate optimization.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-app-store-optimizer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-app-store-optimizer.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-baidu-seo-specialist",
+    "name": "Baidu SEO Specialist",
+    "description": "Expert Baidu search optimization specialist focused on Chinese search engine ranking.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-baidu-seo-specialist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-baidu-seo-specialist.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-bilibili-content-strategist",
+    "name": "Bilibili Content Strategist",
+    "description": "Expert Bilibili marketing specialist focused on UP master growth and danmaku culture.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-bilibili-content-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-bilibili-content-strategist.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-book-co-author",
+    "name": "Book Co-Author",
+    "description": "Strategic thought-leadership book collaborator for founders and experts.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-book-co-author.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-book-co-author.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-carousel-growth-engine",
+    "name": "Carousel Growth Engine",
+    "description": "Autonomous TikTok and Instagram carousel generation specialist.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-carousel-growth-engine.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-carousel-growth-engine.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-china-ecommerce-operator",
+    "name": "China E-Commerce Operator",
+    "description": "Expert China e-commerce operations specialist covering Taobao, Tmall, Pinduoduo, and JD.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-china-ecommerce-operator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-china-ecommerce-operator.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-content-creator",
+    "name": "Content Creator",
+    "description": "Expert content strategist and creator for multi-platform campaigns.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-content-creator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-content-creator.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-cross-border-ecommerce",
+    "name": "Cross-Border E-Commerce Specialist",
+    "description": "Full-funnel cross-border e-commerce strategist covering Amazon, Shopee, Lazada, and more.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-cross-border-ecommerce.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-cross-border-ecommerce.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-douyin-strategist",
+    "name": "Douyin Strategist",
+    "description": "Short-video marketing expert specializing in the Douyin platform and algorithm mechanics.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-douyin-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-douyin-strategist.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-growth-hacker",
+    "name": "Growth Hacker",
+    "description": "Expert growth strategist specializing in rapid user acquisition through data-driven experimentation.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-growth-hacker.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-growth-hacker.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-instagram-curator",
+    "name": "Instagram Curator",
+    "description": "Expert Instagram marketing specialist focused on visual storytelling and community building.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-instagram-curator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-instagram-curator.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-kuaishou-strategist",
+    "name": "Kuaishou Strategist",
+    "description": "Expert Kuaishou marketing strategist specializing in short-video content for China.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-kuaishou-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-kuaishou-strategist.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-linkedin-content-creator",
+    "name": "LinkedIn Content Creator",
+    "description": "Expert LinkedIn content strategist focused on thought leadership and personal brand building.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-linkedin-content-creator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-linkedin-content-creator.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-livestream-commerce-coach",
+    "name": "Livestream Commerce Coach",
+    "description": "Veteran livestream e-commerce coach specializing in host training and live room operations.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-livestream-commerce-coach.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-livestream-commerce-coach.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-podcast-strategist",
+    "name": "Podcast Strategist",
+    "description": "Content strategy and operations expert for the Chinese podcast market.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-podcast-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-podcast-strategist.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-private-domain-operator",
+    "name": "Private Domain Operator",
+    "description": "Expert in building enterprise WeChat private domain ecosystems with SCRM systems.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-private-domain-operator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-private-domain-operator.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-reddit-community-builder",
+    "name": "Reddit Community Builder",
+    "description": "Expert Reddit marketing specialist focused on authentic community engagement.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-reddit-community-builder.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-reddit-community-builder.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-seo-specialist",
+    "name": "SEO Specialist",
+    "description": "Expert search engine optimization strategist specializing in technical SEO and content.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-seo-specialist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-seo-specialist.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-short-video-editing-coach",
+    "name": "Short-Video Editing Coach",
+    "description": "Hands-on short-video editing coach covering the full post-production pipeline.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-short-video-editing-coach.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-short-video-editing-coach.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-social-media-strategist",
+    "name": "Social Media Strategist",
+    "description": "Expert social media strategist for LinkedIn, Twitter, and professional platforms.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-social-media-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-social-media-strategist.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-tiktok-strategist",
+    "name": "TikTok Strategist",
+    "description": "Expert TikTok marketing specialist focused on viral content creation and algorithm optimization.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-tiktok-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-tiktok-strategist.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-twitter-engager",
+    "name": "Twitter Engager",
+    "description": "Expert Twitter marketing specialist focused on real-time engagement and thought leadership.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-twitter-engager.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-twitter-engager.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-wechat-official-account",
+    "name": "WeChat Official Account Manager",
+    "description": "Expert WeChat Official Account strategist specializing in content marketing.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-wechat-official-account.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-wechat-official-account.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-weibo-strategist",
+    "name": "Weibo Strategist",
+    "description": "Full-spectrum operations expert for Sina Weibo with trending topic expertise.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-weibo-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-weibo-strategist.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-xiaohongshu-specialist",
+    "name": "Xiaohongshu Specialist",
+    "description": "Expert Xiaohongshu marketing specialist focused on lifestyle content and trends.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-xiaohongshu-specialist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-xiaohongshu-specialist.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-zhihu-strategist",
+    "name": "Zhihu Strategist",
+    "description": "Expert Zhihu marketing specialist focused on thought leadership and knowledge engagement.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "marketing/marketing-zhihu-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/marketing/marketing-zhihu-strategist.md",
+    "tags": [
+      "persona",
+      "marketing"
+    ]
+  },
+  {
+    "id": "agency-auditor",
+    "name": "Paid Media Auditor",
+    "description": "Comprehensive paid media auditor evaluating Google Ads, Microsoft Ads, and Meta accounts.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "paid-media/paid-media-auditor.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/paid-media/paid-media-auditor.md",
+    "tags": [
+      "persona",
+      "paid-media",
+      "advertising"
+    ]
+  },
+  {
+    "id": "agency-creative-strategist",
+    "name": "Ad Creative Strategist",
+    "description": "Paid media creative specialist focused on ad copywriting and RSA optimization.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "paid-media/paid-media-creative-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/paid-media/paid-media-creative-strategist.md",
+    "tags": [
+      "persona",
+      "paid-media",
+      "advertising"
+    ]
+  },
+  {
+    "id": "agency-paid-social-strategist",
+    "name": "Paid Social Strategist",
+    "description": "Cross-platform paid social advertising specialist covering Meta, LinkedIn, and TikTok.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "paid-media/paid-media-paid-social-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/paid-media/paid-media-paid-social-strategist.md",
+    "tags": [
+      "persona",
+      "paid-media",
+      "advertising"
+    ]
+  },
+  {
+    "id": "agency-ppc-strategist",
+    "name": "PPC Campaign Strategist",
+    "description": "Senior paid media strategist specializing in large-scale search and shopping campaigns.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "paid-media/paid-media-ppc-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/paid-media/paid-media-ppc-strategist.md",
+    "tags": [
+      "persona",
+      "paid-media",
+      "advertising"
+    ]
+  },
+  {
+    "id": "agency-programmatic-buyer",
+    "name": "Programmatic & Display Buyer",
+    "description": "Display advertising and programmatic media buying specialist covering managed placements.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "paid-media/paid-media-programmatic-buyer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/paid-media/paid-media-programmatic-buyer.md",
+    "tags": [
+      "persona",
+      "paid-media",
+      "advertising"
+    ]
+  },
+  {
+    "id": "agency-search-query-analyst",
+    "name": "Search Query Analyst",
+    "description": "Specialist in search term analysis, negative keyword architecture, and query-to-intent mapping.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "paid-media/paid-media-search-query-analyst.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/paid-media/paid-media-search-query-analyst.md",
+    "tags": [
+      "persona",
+      "paid-media",
+      "advertising"
+    ]
+  },
+  {
+    "id": "agency-tracking-specialist",
+    "name": "Tracking & Measurement Specialist",
+    "description": "Expert in conversion tracking architecture, tag management, and attribution modeling.",
+    "category": "marketing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "paid-media/paid-media-tracking-specialist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/paid-media/paid-media-tracking-specialist.md",
+    "tags": [
+      "persona",
+      "paid-media",
+      "advertising"
+    ]
+  },
+  {
+    "id": "agency-behavioral-nudge-engine",
+    "name": "Behavioral Nudge Engine",
+    "description": "Behavioral psychology specialist that adapts software interaction cadences and styles.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "product/product-behavioral-nudge-engine.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/product/product-behavioral-nudge-engine.md",
+    "tags": [
+      "persona",
+      "product"
+    ]
+  },
+  {
+    "id": "agency-feedback-synthesizer",
+    "name": "Feedback Synthesizer",
+    "description": "Expert in collecting, analyzing, and synthesizing user feedback from multiple channels.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "product/product-feedback-synthesizer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/product/product-feedback-synthesizer.md",
+    "tags": [
+      "persona",
+      "product"
+    ]
+  },
+  {
+    "id": "agency-manager",
+    "name": "Product Manager",
+    "description": "Holistic product leader who owns the full product lifecycle from discovery to measurement.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "product/product-manager.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/product/product-manager.md",
+    "tags": [
+      "persona",
+      "product"
+    ]
+  },
+  {
+    "id": "agency-sprint-prioritizer",
+    "name": "Sprint Prioritizer",
+    "description": "Expert product manager specializing in agile sprint planning and feature prioritization.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "product/product-sprint-prioritizer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/product/product-sprint-prioritizer.md",
+    "tags": [
+      "persona",
+      "product"
+    ]
+  },
+  {
+    "id": "agency-trend-researcher",
+    "name": "Trend Researcher",
+    "description": "Expert market intelligence analyst specializing in identifying emerging trends.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "product/product-trend-researcher.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/product/product-trend-researcher.md",
+    "tags": [
+      "persona",
+      "product"
+    ]
+  },
+  {
+    "id": "agency-experiment-tracker",
+    "name": "Experiment Tracker",
+    "description": "Expert project manager specializing in experiment design and data-driven decision making.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "project-management/project-management-experiment-tracker.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/project-management/project-management-experiment-tracker.md",
+    "tags": [
+      "persona",
+      "project-management"
+    ]
+  },
+  {
+    "id": "agency-jira-workflow-steward",
+    "name": "Jira Workflow Steward",
+    "description": "Expert delivery operations specialist enforcing Jira-linked Git workflows.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "project-management/project-management-jira-workflow-steward.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/project-management/project-management-jira-workflow-steward.md",
+    "tags": [
+      "persona",
+      "project-management"
+    ]
+  },
+  {
+    "id": "agency-project-shepherd",
+    "name": "Project Shepherd",
+    "description": "Expert project manager specializing in cross-functional project coordination.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "project-management/project-management-project-shepherd.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/project-management/project-management-project-shepherd.md",
+    "tags": [
+      "persona",
+      "project-management"
+    ]
+  },
+  {
+    "id": "agency-studio-operations",
+    "name": "Studio Operations",
+    "description": "Expert operations manager specializing in day-to-day studio efficiency.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "project-management/project-management-studio-operations.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/project-management/project-management-studio-operations.md",
+    "tags": [
+      "persona",
+      "project-management"
+    ]
+  },
+  {
+    "id": "agency-studio-producer",
+    "name": "Studio Producer",
+    "description": "Senior strategic leader specializing in creative and technical project orchestration.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "project-management/project-management-studio-producer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/project-management/project-management-studio-producer.md",
+    "tags": [
+      "persona",
+      "project-management"
+    ]
+  },
+  {
+    "id": "agency-senior",
+    "name": "Senior Project Manager",
+    "description": "Converts specs to tasks and remembers previous projects with realistic scope.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "project-management/project-manager-senior.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/project-management/project-manager-senior.md",
+    "tags": [
+      "persona",
+      "project-management"
+    ]
+  },
+  {
+    "id": "agency-account-strategist",
+    "name": "Account Strategist",
+    "description": "Expert post-sale account strategist specializing in land-and-expand execution.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "sales/sales-account-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/sales/sales-account-strategist.md",
+    "tags": [
+      "persona",
+      "sales"
+    ]
+  },
+  {
+    "id": "agency-coach",
+    "name": "Sales Coach",
+    "description": "Expert sales coaching specialist focused on rep development and pipeline review.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "sales/sales-coach.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/sales/sales-coach.md",
+    "tags": [
+      "persona",
+      "sales"
+    ]
+  },
+  {
+    "id": "agency-deal-strategist",
+    "name": "Deal Strategist",
+    "description": "Senior deal strategist specializing in MEDDPICC qualification and competitive positioning.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "sales/sales-deal-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/sales/sales-deal-strategist.md",
+    "tags": [
+      "persona",
+      "sales"
+    ]
+  },
+  {
+    "id": "agency-discovery-coach",
+    "name": "Discovery Coach",
+    "description": "Coaches sales teams on elite discovery methodology and question design.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "sales/sales-discovery-coach.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/sales/sales-discovery-coach.md",
+    "tags": [
+      "persona",
+      "sales"
+    ]
+  },
+  {
+    "id": "agency-engineer",
+    "name": "Sales Engineer",
+    "description": "Senior pre-sales engineer specializing in technical discovery and demo engineering.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "sales/sales-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/sales/sales-engineer.md",
+    "tags": [
+      "persona",
+      "sales"
+    ]
+  },
+  {
+    "id": "agency-outbound-strategist",
+    "name": "Outbound Strategist",
+    "description": "Signal-based outbound specialist designing multi-channel prospecting sequences.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "sales/sales-outbound-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/sales/sales-outbound-strategist.md",
+    "tags": [
+      "persona",
+      "sales"
+    ]
+  },
+  {
+    "id": "agency-pipeline-analyst",
+    "name": "Pipeline Analyst",
+    "description": "Revenue operations analyst specializing in pipeline health diagnostics and deal velocity.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "sales/sales-pipeline-analyst.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/sales/sales-pipeline-analyst.md",
+    "tags": [
+      "persona",
+      "sales"
+    ]
+  },
+  {
+    "id": "agency-proposal-strategist",
+    "name": "Proposal Strategist",
+    "description": "Strategic proposal architect who transforms RFPs into compelling win narratives.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "sales/sales-proposal-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/sales/sales-proposal-strategist.md",
+    "tags": [
+      "persona",
+      "sales"
+    ]
+  },
+  {
+    "id": "agency-macos-spatial-metal-engineer",
+    "name": "macOS Spatial/Metal Engineer",
+    "description": "Native Swift and Metal specialist building high-performance 3D rendering systems.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "spatial-computing/macos-spatial-metal-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/spatial-computing/macos-spatial-metal-engineer.md",
+    "tags": [
+      "persona",
+      "spatial",
+      "xr"
+    ]
+  },
+  {
+    "id": "agency-terminal-integration-specialist",
+    "name": "Terminal Integration Specialist",
+    "description": "Terminal emulation, text rendering optimization, and SwiftTerm integration specialist.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "spatial-computing/terminal-integration-specialist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/spatial-computing/terminal-integration-specialist.md",
+    "tags": [
+      "persona",
+      "spatial",
+      "xr"
+    ]
+  },
+  {
+    "id": "agency-visionos-spatial-engineer",
+    "name": "visionOS Spatial Engineer",
+    "description": "Native visionOS spatial computing and SwiftUI volumetric interface specialist.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "spatial-computing/visionos-spatial-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/spatial-computing/visionos-spatial-engineer.md",
+    "tags": [
+      "persona",
+      "spatial",
+      "xr"
+    ]
+  },
+  {
+    "id": "agency-xr-cockpit-interaction-specialist",
+    "name": "XR Cockpit Interaction Specialist",
+    "description": "Specialist in designing immersive cockpit-based control systems for XR environments.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "spatial-computing/xr-cockpit-interaction-specialist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/spatial-computing/xr-cockpit-interaction-specialist.md",
+    "tags": [
+      "persona",
+      "spatial",
+      "xr"
+    ]
+  },
+  {
+    "id": "agency-xr-immersive-developer",
+    "name": "XR Immersive Developer",
+    "description": "Expert WebXR and immersive technology developer for browser-based AR/VR/XR applications.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "spatial-computing/xr-immersive-developer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/spatial-computing/xr-immersive-developer.md",
+    "tags": [
+      "persona",
+      "spatial",
+      "xr"
+    ]
+  },
+  {
+    "id": "agency-xr-interface-architect",
+    "name": "XR Interface Architect",
+    "description": "Spatial interaction designer and interface strategist for immersive AR/VR/XR environments.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "spatial-computing/xr-interface-architect.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/spatial-computing/xr-interface-architect.md",
+    "tags": [
+      "persona",
+      "spatial",
+      "xr"
+    ]
+  },
+  {
+    "id": "agency-accounts-payable-agent",
+    "name": "Accounts Payable Agent",
+    "description": "Autonomous payment processing specialist that executes vendor payments across any rail.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/accounts-payable-agent.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/accounts-payable-agent.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-agentic-identity-trust",
+    "name": "Agentic Identity & Trust Architect",
+    "description": "Designs identity, authentication, and trust verification systems for autonomous AI agents.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/agentic-identity-trust.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/agentic-identity-trust.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-agents-orchestrator",
+    "name": "Agents Orchestrator",
+    "description": "Autonomous pipeline manager that orchestrates the entire development workflow.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/agents-orchestrator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/agents-orchestrator.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-automation-governance-architect",
+    "name": "Automation Governance Architect",
+    "description": "Governance-first architect for business automations who audits value, risk, and maintainability.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/automation-governance-architect.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/automation-governance-architect.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-blockchain-security-auditor",
+    "name": "Blockchain Security Auditor",
+    "description": "Expert smart contract security auditor specializing in vulnerability detection and formal verification.",
+    "category": "security",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/blockchain-security-auditor.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/blockchain-security-auditor.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-compliance-auditor",
+    "name": "Compliance Auditor",
+    "description": "Expert technical compliance auditor specializing in SOC 2, ISO 27001, HIPAA, and PCI-DSS.",
+    "category": "security",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/compliance-auditor.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/compliance-auditor.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-corporate-training-designer",
+    "name": "Corporate Training Designer",
+    "description": "Expert in enterprise training system design and curriculum development.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/corporate-training-designer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/corporate-training-designer.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-data-consolidation-agent",
+    "name": "Data Consolidation Agent",
+    "description": "AI agent that consolidates extracted sales data into live reporting dashboards.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/data-consolidation-agent.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/data-consolidation-agent.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-government-digital-presales-consultant",
+    "name": "Government Digital Presales Consultant",
+    "description": "Presales expert for China's government digital transformation market.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/government-digital-presales-consultant.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/government-digital-presales-consultant.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-healthcare-marketing-compliance",
+    "name": "Healthcare Marketing Compliance Specialist",
+    "description": "Expert in healthcare marketing compliance in China covering pharmaceuticals and devices.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/healthcare-marketing-compliance.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/healthcare-marketing-compliance.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-identity-graph-operator",
+    "name": "Identity Graph Operator",
+    "description": "Operates a shared identity graph that multiple AI agents resolve against.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/identity-graph-operator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/identity-graph-operator.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-lsp-index-engineer",
+    "name": "LSP/Index Engineer",
+    "description": "Language Server Protocol specialist building unified code intelligence systems.",
+    "category": "developer-tools",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/lsp-index-engineer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/lsp-index-engineer.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-recruitment-specialist",
+    "name": "Recruitment Specialist",
+    "description": "Expert recruitment operations and talent acquisition specialist for China's hiring platforms.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/recruitment-specialist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/recruitment-specialist.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-report-distribution-agent",
+    "name": "Report Distribution Agent",
+    "description": "AI agent that automates distribution of consolidated sales reports to representatives.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/report-distribution-agent.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/report-distribution-agent.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-data-extraction-agent",
+    "name": "Sales Data Extraction Agent",
+    "description": "AI agent specialized in monitoring Excel files and extracting key sales metrics.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/sales-data-extraction-agent.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/sales-data-extraction-agent.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-cultural-intelligence-strategist",
+    "name": "Cultural Intelligence Strategist",
+    "description": "CQ specialist that detects invisible exclusion and ensures software resonates across cultures.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/specialized-cultural-intelligence-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/specialized-cultural-intelligence-strategist.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-developer-advocate",
+    "name": "Developer Advocate",
+    "description": "Expert developer advocate specializing in building developer communities and technical content.",
+    "category": "documentation",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/specialized-developer-advocate.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/specialized-developer-advocate.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-document-generator",
+    "name": "Document Generator",
+    "description": "Expert document creation specialist generating professional PDF, PPTX, DOCX, and XLSX files.",
+    "category": "documentation",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/specialized-document-generator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/specialized-document-generator.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-french-consulting-market",
+    "name": "French Consulting Market Navigator",
+    "description": "Navigate the French ESN/SI freelance ecosystem with margin models and platform mechanics.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/specialized-french-consulting-market.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/specialized-french-consulting-market.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-korean-business-navigator",
+    "name": "Korean Business Navigator",
+    "description": "Korean business culture specialist for foreign professionals navigating hierarchy and etiquette.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/specialized-korean-business-navigator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/specialized-korean-business-navigator.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-mcp-builder",
+    "name": "MCP Builder",
+    "description": "Expert Model Context Protocol developer who designs, builds, and tests MCP servers.",
+    "category": "developer-tools",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/specialized-mcp-builder.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/specialized-mcp-builder.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-model-qa",
+    "name": "Model QA Specialist",
+    "description": "Independent model QA expert who audits ML and statistical models end-to-end.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/specialized-model-qa.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/specialized-model-qa.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-salesforce-architect",
+    "name": "Salesforce Architect",
+    "description": "Solution architecture for Salesforce platform covering multi-cloud design and integration.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/specialized-salesforce-architect.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/specialized-salesforce-architect.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-workflow-architect",
+    "name": "Workflow Architect",
+    "description": "Workflow design specialist who maps complete workflow trees for every system interaction.",
+    "category": "devops",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/specialized-workflow-architect.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/specialized-workflow-architect.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-study-abroad-advisor",
+    "name": "Study Abroad Advisor",
+    "description": "Full-spectrum study abroad planning expert covering the US, UK, Canada, Australia, and Europe.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/study-abroad-advisor.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/study-abroad-advisor.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-supply-chain-strategist",
+    "name": "Supply Chain Strategist",
+    "description": "Expert supply chain management and procurement strategy specialist.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/supply-chain-strategist.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/supply-chain-strategist.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-zk-steward",
+    "name": "ZK Steward",
+    "description": "Knowledge-base steward in the spirit of Niklas Luhmann's Zettelkasten.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "specialized/zk-steward.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/specialized/zk-steward.md",
+    "tags": [
+      "persona",
+      "specialist"
+    ]
+  },
+  {
+    "id": "agency-analytics-reporter",
+    "name": "Analytics Reporter",
+    "description": "Expert data analyst transforming raw data into actionable business insights and dashboards.",
+    "category": "engineering",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "support/support-analytics-reporter.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/support/support-analytics-reporter.md",
+    "tags": [
+      "persona",
+      "support"
+    ]
+  },
+  {
+    "id": "agency-executive-summary-generator",
+    "name": "Executive Summary Generator",
+    "description": "Consultant-grade AI specialist transforming complex inputs into executive summaries.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "support/support-executive-summary-generator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/support/support-executive-summary-generator.md",
+    "tags": [
+      "persona",
+      "support"
+    ]
+  },
+  {
+    "id": "agency-finance-tracker",
+    "name": "Finance Tracker",
+    "description": "Expert financial analyst specializing in financial planning and budget management.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "support/support-finance-tracker.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/support/support-finance-tracker.md",
+    "tags": [
+      "persona",
+      "support"
+    ]
+  },
+  {
+    "id": "agency-infrastructure-maintainer",
+    "name": "Infrastructure Maintainer",
+    "description": "Expert infrastructure specialist focused on system reliability and performance optimization.",
+    "category": "devops",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "support/support-infrastructure-maintainer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/support/support-infrastructure-maintainer.md",
+    "tags": [
+      "persona",
+      "support"
+    ]
+  },
+  {
+    "id": "agency-legal-compliance-checker",
+    "name": "Legal Compliance Checker",
+    "description": "Expert legal and compliance specialist ensuring operations comply with laws and regulations.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "support/support-legal-compliance-checker.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/support/support-legal-compliance-checker.md",
+    "tags": [
+      "persona",
+      "support"
+    ]
+  },
+  {
+    "id": "agency-support-responder",
+    "name": "Support Responder",
+    "description": "Expert customer support specialist delivering exceptional service and issue resolution.",
+    "category": "specialized",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "support/support-support-responder.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/support/support-support-responder.md",
+    "tags": [
+      "persona",
+      "support"
+    ]
+  },
+  {
+    "id": "agency-accessibility-auditor",
+    "name": "Accessibility Auditor",
+    "description": "Expert accessibility specialist who audits interfaces against WCAG standards.",
+    "category": "testing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "testing/testing-accessibility-auditor.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/testing/testing-accessibility-auditor.md",
+    "tags": [
+      "persona",
+      "testing",
+      "qa"
+    ]
+  },
+  {
+    "id": "agency-api-tester",
+    "name": "API Tester",
+    "description": "Expert API testing specialist focused on comprehensive API validation and performance testing.",
+    "category": "testing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "testing/testing-api-tester.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/testing/testing-api-tester.md",
+    "tags": [
+      "persona",
+      "testing",
+      "qa"
+    ]
+  },
+  {
+    "id": "agency-evidence-collector",
+    "name": "Evidence Collector",
+    "description": "Screenshot-obsessed QA specialist that requires visual proof for everything.",
+    "category": "testing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "testing/testing-evidence-collector.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/testing/testing-evidence-collector.md",
+    "tags": [
+      "persona",
+      "testing",
+      "qa"
+    ]
+  },
+  {
+    "id": "agency-performance-benchmarker",
+    "name": "Performance Benchmarker",
+    "description": "Expert performance testing specialist focused on measuring and improving system performance.",
+    "category": "testing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "testing/testing-performance-benchmarker.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/testing/testing-performance-benchmarker.md",
+    "tags": [
+      "persona",
+      "testing",
+      "qa"
+    ]
+  },
+  {
+    "id": "agency-reality-checker",
+    "name": "Reality Checker",
+    "description": "Evidence-based certification specialist that defaults to NEEDS WORK.",
+    "category": "testing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "testing/testing-reality-checker.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/testing/testing-reality-checker.md",
+    "tags": [
+      "persona",
+      "testing",
+      "qa"
+    ]
+  },
+  {
+    "id": "agency-test-results-analyzer",
+    "name": "Test Results Analyzer",
+    "description": "Expert test analysis specialist focused on comprehensive test result evaluation.",
+    "category": "testing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "testing/testing-test-results-analyzer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/testing/testing-test-results-analyzer.md",
+    "tags": [
+      "persona",
+      "testing",
+      "qa"
+    ]
+  },
+  {
+    "id": "agency-tool-evaluator",
+    "name": "Tool Evaluator",
+    "description": "Expert technology assessment specialist focused on evaluating tools and platforms.",
+    "category": "testing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "testing/testing-tool-evaluator.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/testing/testing-tool-evaluator.md",
+    "tags": [
+      "persona",
+      "testing",
+      "qa"
+    ]
+  },
+  {
+    "id": "agency-workflow-optimizer",
+    "name": "Workflow Optimizer",
+    "description": "Expert process improvement specialist focused on analyzing and optimizing workflows.",
+    "category": "testing",
+    "source_type": "agency-agents",
+    "source_url": "https://github.com/msitarzewski/agency-agents",
+    "source_path": "testing/testing-workflow-optimizer.md",
+    "docs_url": "https://github.com/msitarzewski/agency-agents/blob/main/testing/testing-workflow-optimizer.md",
+    "tags": [
+      "persona",
+      "testing",
+      "qa"
+    ]
+  }
 ]

--- a/internal/bridge/catalog_test.go
+++ b/internal/bridge/catalog_test.go
@@ -6,10 +6,10 @@ import (
 
 func TestLoadCatalog(t *testing.T) {
 	entries := LoadCatalog()
-	if len(entries) == 0 {
-		t.Fatal("LoadCatalog returned 0 entries")
+	if len(entries) < 100 {
+		t.Fatalf("LoadCatalog returned %d entries, expected 100+", len(entries))
 	}
-	// Check first entry has required fields
+	// Check first entry has required fields including new ones
 	first := entries[0]
 	if first.ID == "" {
 		t.Error("first entry has empty ID")
@@ -20,8 +20,11 @@ func TestLoadCatalog(t *testing.T) {
 	if first.Category == "" {
 		t.Error("first entry has empty Category")
 	}
-	if first.URL == "" {
-		t.Error("first entry has empty URL")
+	if first.SourceType == "" {
+		t.Error("first entry has empty SourceType")
+	}
+	if first.SourceURL == "" {
+		t.Error("first entry has empty SourceURL")
 	}
 
 	// Check no duplicate IDs

--- a/internal/bridge/tasksync.go
+++ b/internal/bridge/tasksync.go
@@ -262,7 +262,7 @@ func (s *AgentRepoSyncer) SyncAll(ctx context.Context) error {
 func (s *AgentRepoSyncer) syncCatalogSources(ctx context.Context) {
 	catalog := LoadCatalog()
 	for _, entry := range catalog {
-		if entry.URL == "" {
+		if entry.SourceURL == "" {
 			continue
 		}
 
@@ -281,7 +281,7 @@ func (s *AgentRepoSyncer) syncCatalogSources(ctx context.Context) {
 				log.Printf("agent-repo-syncer: error creating catalog source dir for %s: %v", entry.ID, err)
 				continue
 			}
-			cmd := exec.CommandContext(ctx, "git", "clone", "--depth=1", "--branch", ref, entry.URL, cloneDir)
+			cmd := exec.CommandContext(ctx, "git", "clone", "--depth=1", "--branch", ref, entry.SourceURL, cloneDir)
 			cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 			if out, err := cmd.CombinedOutput(); err != nil {
 				log.Printf("agent-repo-syncer: error cloning catalog source %s: %s: %v", entry.ID, string(out), err)
@@ -315,16 +315,16 @@ func (s *AgentRepoSyncer) syncCatalogSources(ctx context.Context) {
 func (s *AgentRepoSyncer) introspectCatalogSource(ctx context.Context, entry CatalogEntry, repoDir string) error {
 	var items []CatalogItem
 
-	// If the source has a path field (e.g., claude-plugins-official entries),
+	// If the source has a source_path field (e.g., claude-plugins-official entries),
 	// treat the catalog entry itself as a single item.
-	if entry.Path != "" {
+	if entry.SourcePath != "" {
 		items = append(items, CatalogItem{
 			SourceID:    entry.ID,
 			Slug:        entry.ID,
 			Name:        entry.Name,
 			Description: entry.Description,
 			ItemType:    categoryToItemType(entry.Category),
-			SourceFile:  entry.Path,
+			SourceFile:  entry.SourcePath,
 		})
 	} else {
 		// Scan for .alcove/tasks/*.yml and .alcove/tasks/*.yaml → agent items

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -2897,160 +2897,146 @@ details[open] > .tx-tool-expand-toggle::before {
     background: rgba(231, 76, 60, 0.15);
 }
 
-/* Catalog page — two-level collapsible list */
+/* Catalog page — flat card grid with category pills */
 .catalog-sources-list {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 16px;
     margin-bottom: 16px;
 }
-.catalog-source {
+
+/* Category pills */
+.catalog-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 4px;
+}
+.catalog-pill {
+    padding: 5px 14px;
+    border-radius: 16px;
+    border: 1px solid var(--border);
+    background: var(--bg-card);
+    color: var(--text-muted);
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+}
+.catalog-pill:hover {
+    border-color: var(--text-muted);
+    color: var(--text);
+}
+.catalog-pill.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+}
+
+/* Search bar */
+.catalog-search-bar {
+    margin-bottom: 4px;
+}
+.catalog-search {
+    width: 100%;
+    max-width: 400px;
+    padding: 8px 14px;
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    font-size: 14px;
+}
+.catalog-search::placeholder { color: var(--text-muted); }
+.catalog-search:focus {
+    outline: 2px solid var(--accent);
+    outline-offset: -1px;
+    border-color: var(--accent);
+}
+
+/* Card grid */
+.catalog-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 8px;
+}
+
+/* Individual card */
+.catalog-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 16px;
     background: var(--bg-card);
     border: 1px solid var(--border);
     border-radius: var(--radius);
     transition: border-color 0.15s;
 }
-.catalog-source:hover { border-color: var(--text-muted); }
-.catalog-source-header {
+.catalog-card:hover {
+    border-color: var(--text-muted);
+}
+.catalog-card-info {
+    flex: 1;
+    min-width: 0;
+}
+.catalog-card-header {
     display: flex;
     align-items: center;
-    gap: 12px;
-    padding: 14px 16px;
-    cursor: pointer;
-    user-select: none;
+    gap: 4px;
+    margin-bottom: 4px;
 }
-.catalog-source-arrow {
-    font-size: 12px;
-    color: var(--text-muted);
-    width: 16px;
-    text-align: center;
-    flex-shrink: 0;
-    transition: transform 0.15s;
-}
-.catalog-source-expanded .catalog-source-arrow {
-    transform: rotate(90deg);
-}
-.catalog-source-name {
+.catalog-card-name {
     font-weight: 600;
     font-size: 14px;
     color: var(--text);
-    flex: 1;
-    min-width: 0;
 }
-.catalog-source-badge {
-    font-size: 11px;
-    padding: 2px 10px;
-    border-radius: 10px;
-    font-weight: 500;
-    flex-shrink: 0;
-}
-.catalog-badge-plugins { background: rgba(52, 152, 219, 0.15); color: #3498db; }
-.catalog-badge-language-servers { background: rgba(46, 204, 113, 0.15); color: #2ecc71; }
-.catalog-badge-integrations { background: rgba(155, 89, 182, 0.15); color: #9b59b6; }
-.catalog-badge-agent-templates { background: rgba(230, 126, 34, 0.15); color: #e67e22; }
-.catalog-badge-security { background: rgba(231, 76, 60, 0.15); color: #e74c3c; }
-.catalog-source-stats {
+.catalog-card-desc {
     font-size: 12px;
     color: var(--text-muted);
-    flex-shrink: 0;
-    white-space: nowrap;
-}
-.catalog-source-counts {
-    font-size: 12px;
-    color: var(--text-muted);
-    flex-shrink: 0;
-    min-width: 50px;
-    text-align: right;
-}
-.catalog-source-inline-toggle {
-    flex-shrink: 0;
-}
-.catalog-items-container {
-    display: none;
-    border-top: 1px solid var(--border);
-    padding: 12px 16px 16px 44px;
-}
-.catalog-source-expanded .catalog-items-container {
-    display: block;
-}
-.catalog-item-search {
-    width: 100%;
-    max-width: 300px;
-    padding: 6px 12px;
-    background: var(--bg-input);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    color: var(--text);
-    font-size: 13px;
-    margin-bottom: 10px;
-}
-.catalog-item-search::placeholder { color: var(--text-muted); }
-.catalog-item-search:focus {
-    outline: 2px solid var(--accent);
-    outline-offset: -1px;
-    border-color: var(--accent);
-}
-.catalog-items-list {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-}
-.catalog-item {
-    display: flex;
-    align-items: flex-start;
-    gap: 10px;
-    padding: 8px 12px;
-    border-radius: var(--radius);
-    transition: background 0.1s;
-}
-.catalog-item:hover {
-    background: rgba(255, 255, 255, 0.03);
-}
-.catalog-item input[type="checkbox"] {
-    margin-top: 3px;
-    flex-shrink: 0;
-    cursor: pointer;
-    accent-color: var(--accent);
-    width: 16px;
-    height: 16px;
-}
-.catalog-item-info {
-    flex: 1;
-    min-width: 0;
-}
-.catalog-item-name {
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--text);
-}
-.catalog-item-desc {
-    font-size: 12px;
-    color: var(--text-muted);
-    margin-top: 2px;
     line-height: 1.3;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    margin-bottom: 6px;
 }
-.catalog-item-type {
+.catalog-card-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+.catalog-card-tag {
     font-size: 11px;
     padding: 1px 8px;
     border-radius: 10px;
-    background: rgba(255, 255, 255, 0.06);
-    color: var(--text-muted);
+    font-weight: 500;
+    white-space: nowrap;
+}
+.catalog-card-toggle {
     flex-shrink: 0;
-    margin-top: 2px;
+    padding-top: 2px;
 }
-.catalog-show-all {
-    background: none;
-    border: none;
-    color: var(--accent-light);
-    cursor: pointer;
-    font-size: 13px;
-    padding: 8px 12px;
-    text-align: left;
-}
-.catalog-show-all:hover { color: var(--text); text-decoration: underline; }
+
+/* Category badge colors */
+.catalog-badge-code-quality { background: rgba(52, 152, 219, 0.15); color: #3498db; }
+.catalog-badge-security { background: rgba(231, 76, 60, 0.15); color: #e74c3c; }
+.catalog-badge-frontend { background: rgba(241, 196, 15, 0.15); color: #f1c40f; }
+.catalog-badge-devops { background: rgba(46, 204, 113, 0.15); color: #2ecc71; }
+.catalog-badge-testing { background: rgba(155, 89, 182, 0.15); color: #9b59b6; }
+.catalog-badge-developer-tools { background: rgba(230, 126, 34, 0.15); color: #e67e22; }
+.catalog-badge-engineering { background: rgba(52, 73, 94, 0.2); color: #95a5a6; }
+.catalog-badge-documentation { background: rgba(26, 188, 156, 0.15); color: #1abc9c; }
+.catalog-badge-marketing { background: rgba(243, 156, 18, 0.15); color: #f39c12; }
+.catalog-badge-specialized { background: rgba(142, 68, 173, 0.15); color: #8e44ad; }
+
+/* Source type badge colors */
+.catalog-card-tag.source-claude-plugins-official { background: rgba(52,152,219,0.2); color: #3498db; }
+.catalog-card-tag.source-agency-agents { background: rgba(230,126,34,0.2); color: #e67e22; }
+.catalog-card-tag.source-mcp-server { background: rgba(155,89,182,0.2); color: #9b59b6; }
+.catalog-card-tag.source-plugin-bundle { background: rgba(46,204,113,0.2); color: #2ecc71; }
+
+/* Docs link */
+.catalog-docs-link { text-decoration: none; font-size: 12px; opacity: 0.5; margin-left: 4px; }
+.catalog-docs-link:hover { opacity: 1; }
 .catalog-custom-section { border-top: 1px solid var(--border); padding-top: 24px; }
 .catalog-custom-item {
     display: flex;

--- a/web/index.html
+++ b/web/index.html
@@ -522,7 +522,7 @@
                 </div>
                 <div id="catalog-sources-list" class="catalog-sources-list"></div>
                 <div id="catalog-empty" class="empty-state" hidden>
-                    <p>No catalog sources available.</p>
+                    <p>No catalog entries available.</p>
                 </div>
                 <div id="catalog-loading" class="loading-state" hidden>
                     <div class="spinner"></div><p>Loading catalog...</p>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -7042,22 +7042,31 @@
     // Catalog
     // ---------------------
 
-    var catalogSources = [];
+    var catalogEntries = [];
     var catalogCustomPlugins = [];
-    var catalogSourceItems = {};   // sourceId -> {items: [...], loaded: bool}
-    var catalogExpandedSources = {};
-    var catalogShowAllSources = {};
-    var catalogItemSearchFilters = {};
+    var catalogEnabledMap = {};       // entryId -> bool
+    var catalogItemSlugs = {};        // entryId -> slug (lazy-loaded)
+    var catalogActiveCategory = '';   // '' = all
+    var catalogSearchQuery = '';
 
     var categoryLabels = {
-        'plugins': 'Plugins',
-        'language-servers': 'Language Servers',
-        'integrations': 'Integrations',
-        'agent-templates': 'Agent Templates',
+        'code-quality': 'Code Quality',
         'security': 'Security',
-        'testing': 'Testing',
-        'content': 'Content',
-        'documentation': 'Documentation'
+        'frontend': 'Frontend & UI',
+        'devops': 'DevOps & Infra',
+        'testing': 'Testing & QA',
+        'developer-tools': 'Developer Tools',
+        'engineering': 'Engineering',
+        'documentation': 'Documentation',
+        'marketing': 'Marketing & Content',
+        'specialized': 'Specialized'
+    };
+
+    var sourceLabels = {
+        'claude-plugins-official': 'plugin',
+        'agency-agents': 'agent',
+        'mcp-server': 'mcp',
+        'plugin-bundle': 'bundle'
     };
 
     async function loadCatalogPage() {
@@ -7074,270 +7083,169 @@
                 show(empty);
                 return;
             }
-            var resp = await api('GET', '/api/v1/teams/' + activeTeamId + '/catalog');
-            if (resp && resp.ok) {
-                var data = await resp.json();
-                catalogSources = data.sources || [];
-                catalogCustomPlugins = data.custom_plugins || [];
+
+            // Fetch catalog entries and team enablement in parallel
+            var catalogResp = api('GET', '/api/v1/catalog');
+            var teamResp = api('GET', '/api/v1/teams/' + activeTeamId + '/catalog');
+            var customResp = catalogResp; // custom plugins come from team catalog
+
+            var results = await Promise.all([catalogResp, teamResp]);
+
+            // Parse catalog entries
+            if (results[0] && results[0].ok) {
+                var data = await results[0].json();
+                catalogEntries = data.entries || [];
             } else {
-                catalogSources = [];
-                catalogCustomPlugins = [];
+                catalogEntries = [];
+            }
+
+            // Parse team enabled state
+            catalogEnabledMap = {};
+            catalogCustomPlugins = [];
+            if (results[1] && results[1].ok) {
+                var teamData = await results[1].json();
+                var sources = teamData.sources || [];
+                sources.forEach(function(src) {
+                    catalogEnabledMap[src.source_id] = (src.enabled_items || 0) > 0;
+                });
+                catalogCustomPlugins = teamData.custom_plugins || [];
             }
         } catch (err) {
             if (err.message === 'unauthorized') { hide(loading); return; }
-            catalogSources = [];
+            catalogEntries = [];
+            catalogEnabledMap = {};
             catalogCustomPlugins = [];
         }
 
         hide(loading);
-        catalogSourceItems = {};
-        renderCatalogSources();
+        renderCatalogCategoryPills();
+        renderCatalogGrid();
         renderCatalogCustomPlugins();
     }
 
-    function renderCatalogSources() {
+    function renderCatalogCategoryPills() {
         var listEl = $('#catalog-sources-list');
-        var empty = $('#catalog-empty');
 
-        if (catalogSources.length === 0) {
-            listEl.innerHTML = '';
-            show(empty);
-            return;
-        }
-        hide(empty);
-        listEl.innerHTML = '';
-
-        catalogSources.forEach(function(source) {
-            var sourceEl = renderCatalogSourceRow(source);
-            listEl.appendChild(sourceEl);
-        });
-    }
-
-    function renderCatalogSourceRow(source) {
-        var sourceId = source.source_id;
-        var isExpanded = catalogExpandedSources[sourceId] || false;
-        var isSingleItem = source.total_items === 1;
-        var badgeClass = 'catalog-badge-' + (source.category || '').replace(/\s+/g, '-');
-        var categoryLabel = categoryLabels[source.category] || source.category || '';
-
-        var div = document.createElement('div');
-        div.className = 'catalog-source' + (isExpanded ? ' catalog-source-expanded' : '');
-        div.setAttribute('data-source-id', sourceId);
-
-        // Build header
-        var headerHtml =
-            '<div class="catalog-source-header">' +
-                (isSingleItem ? '<span class="catalog-source-arrow" style="visibility:hidden;">&#9654;</span>' :
-                    '<span class="catalog-source-arrow">&#9654;</span>') +
-                '<span class="catalog-source-name">' + escapeHtml(source.name) + '</span>' +
-                '<span class="catalog-source-badge ' + badgeClass + '">' + escapeHtml(categoryLabel) + '</span>' +
-                '<span class="catalog-source-stats">' + source.total_items + ' item' + (source.total_items === 1 ? '' : 's') + '</span>' +
-                '<span class="catalog-source-counts">' + (source.enabled_items || 0) + '/' + source.total_items + '</span>';
-
-        // For single-item sources, show inline toggle
-        if (isSingleItem) {
-            var singleEnabled = (source.enabled_items || 0) > 0;
-            headerHtml +=
-                '<span class="catalog-source-inline-toggle">' +
-                    '<label class="toggle-switch" title="' + (singleEnabled ? 'Disable' : 'Enable') + '">' +
-                        '<input type="checkbox" class="catalog-single-toggle" data-source-id="' + escapeHtml(sourceId) + '"' + (singleEnabled ? ' checked' : '') + '>' +
-                        '<span class="toggle-slider"></span>' +
-                    '</label>' +
-                '</span>';
-        }
-
-        headerHtml += '</div>';
-
-        // Build items container (for multi-item sources)
-        var itemsHtml = '';
-        if (!isSingleItem) {
-            itemsHtml = '<div class="catalog-items-container">' +
-                '<div class="catalog-items-inner" data-source-id="' + escapeHtml(sourceId) + '">' +
-                    '<div class="loading-state" style="padding:8px 0;"><div class="spinner"></div></div>' +
-                '</div>' +
-            '</div>';
-        }
-
-        div.innerHTML = headerHtml + itemsHtml;
-
-        // Wire header click to expand/collapse (only for multi-item)
-        var header = div.querySelector('.catalog-source-header');
-        if (!isSingleItem) {
-            header.addEventListener('click', function(e) {
-                // Don't toggle when clicking a toggle switch
-                if (e.target.closest('.catalog-source-inline-toggle') || e.target.closest('.toggle-switch')) return;
-                catalogExpandedSources[sourceId] = !catalogExpandedSources[sourceId];
-                div.classList.toggle('catalog-source-expanded');
-                if (catalogExpandedSources[sourceId] && !catalogSourceItems[sourceId]) {
-                    loadCatalogSourceItems(sourceId);
-                }
-            });
-        }
-
-        // Wire single-item toggle
-        var singleToggle = div.querySelector('.catalog-single-toggle');
-        if (singleToggle) {
-            singleToggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-            });
-            singleToggle.addEventListener('change', async function() {
-                var enabled = singleToggle.checked;
-                try {
-                    // For single-item sources, we need to fetch the item slug first, then toggle
-                    if (!catalogSourceItems[sourceId]) {
-                        await loadCatalogSourceItems(sourceId);
-                    }
-                    var items = (catalogSourceItems[sourceId] || {}).items || [];
-                    if (items.length > 0) {
-                        var item = items[0];
-                        var resp = await api('PUT', '/api/v1/teams/' + activeTeamId + '/catalog/' + encodeURIComponent(sourceId) + '/' + encodeURIComponent(item.slug), { enabled: enabled });
-                        if (resp.ok) {
-                            item.enabled = enabled;
-                            source.enabled_items = enabled ? 1 : 0;
-                            updateSourceCounts(sourceId, source);
-                        } else {
-                            singleToggle.checked = !enabled;
-                        }
-                    }
-                } catch (e) {
-                    singleToggle.checked = !enabled;
-                }
-            });
-        }
-
-        // If already expanded, load items
-        if (isExpanded && !isSingleItem && !catalogSourceItems[sourceId]) {
-            loadCatalogSourceItems(sourceId);
-        } else if (isExpanded && !isSingleItem && catalogSourceItems[sourceId]) {
-            renderCatalogItems(sourceId);
-        }
-
-        return div;
-    }
-
-    async function loadCatalogSourceItems(sourceId) {
-        var searchQuery = catalogItemSearchFilters[sourceId] || '';
-        try {
-            var url = '/api/v1/teams/' + activeTeamId + '/catalog/' + encodeURIComponent(sourceId);
-            if (searchQuery) url += '?search=' + encodeURIComponent(searchQuery);
-            var resp = await api('GET', url);
-            if (resp.ok) {
-                var data = await resp.json();
-                catalogSourceItems[sourceId] = { items: data.items || [], loaded: true };
-                renderCatalogItems(sourceId);
-            }
-        } catch (e) {
-            var innerEl = document.querySelector('.catalog-items-inner[data-source-id="' + sourceId + '"]');
-            if (innerEl) innerEl.innerHTML = '<p style="color:var(--status-error);font-size:13px;">Failed to load items.</p>';
-        }
-    }
-
-    function renderCatalogItems(sourceId) {
-        var innerEl = document.querySelector('.catalog-items-inner[data-source-id="' + sourceId + '"]');
-        if (!innerEl) return;
-
-        var cached = catalogSourceItems[sourceId];
-        if (!cached || !cached.items) {
-            innerEl.innerHTML = '<div class="loading-state" style="padding:8px 0;"><div class="spinner"></div></div>';
-            return;
-        }
-
-        var items = cached.items.slice();
-        var showAll = catalogShowAllSources[sourceId] || false;
-        var searchFilter = catalogItemSearchFilters[sourceId] || '';
-
-        // Sort: enabled items first
-        items.sort(function(a, b) {
-            if (a.enabled && !b.enabled) return -1;
-            if (!a.enabled && b.enabled) return 1;
-            return (a.name || '').localeCompare(b.name || '');
+        // Count entries per category
+        var counts = {};
+        catalogEntries.forEach(function(e) {
+            counts[e.category] = (counts[e.category] || 0) + 1;
         });
 
-        // Filter by local search
-        if (searchFilter) {
-            var q = searchFilter.toLowerCase();
-            items = items.filter(function(item) {
-                return (item.name + ' ' + (item.description || '') + ' ' + (item.slug || '')).toLowerCase().indexOf(q) !== -1;
-            });
-        }
-
-        var totalCount = items.length;
-        var displayLimit = 10;
-        var displayItems = showAll ? items : items.slice(0, displayLimit);
-        var hasMore = !showAll && totalCount > displayLimit;
-
-        var html = '';
-
-        // Search box (show for sources with >10 items)
-        if (totalCount > displayLimit || searchFilter) {
-            html += '<input type="text" class="catalog-item-search" placeholder="Filter items..." value="' + escapeHtml(searchFilter) + '" data-source-id="' + escapeHtml(sourceId) + '">';
-        }
-
-        html += '<div class="catalog-items-list">';
-        displayItems.forEach(function(item) {
-            html += '<div class="catalog-item">' +
-                '<input type="checkbox" class="catalog-item-toggle" data-source-id="' + escapeHtml(sourceId) + '" data-item-slug="' + escapeHtml(item.slug) + '"' + (item.enabled ? ' checked' : '') + '>' +
-                '<div class="catalog-item-info">' +
-                    '<div class="catalog-item-name">' + escapeHtml(item.name) + '</div>' +
-                    (item.description ? '<div class="catalog-item-desc">' + escapeHtml(item.description) + '</div>' : '') +
-                '</div>' +
-                (item.item_type ? '<span class="catalog-item-type">' + escapeHtml(item.item_type) + '</span>' : '') +
-            '</div>';
+        var html = '<div class="catalog-pills">';
+        html += '<button class="catalog-pill' + (!catalogActiveCategory ? ' active' : '') + '" data-category="">All (' + catalogEntries.length + ')</button>';
+        Object.keys(categoryLabels).forEach(function(cat) {
+            if (!counts[cat]) return;
+            html += '<button class="catalog-pill' + (catalogActiveCategory === cat ? ' active' : '') + '" data-category="' + escapeHtml(cat) + '">' +
+                escapeHtml(categoryLabels[cat] || cat) + ' (' + counts[cat] + ')</button>';
         });
         html += '</div>';
 
-        if (hasMore) {
-            var remaining = totalCount - displayLimit;
-            html += '<button class="catalog-show-all" data-source-id="' + escapeHtml(sourceId) + '">Show all (' + remaining + ' more)</button>';
-        }
+        // Search bar
+        html += '<div class="catalog-search-bar">' +
+            '<input type="text" class="catalog-search" placeholder="Search catalog..." value="' + escapeHtml(catalogSearchQuery) + '">' +
+        '</div>';
 
-        innerEl.innerHTML = html;
+        html += '<div id="catalog-grid" class="catalog-grid"></div>';
+        listEl.innerHTML = html;
+
+        // Wire pills
+        listEl.querySelectorAll('.catalog-pill').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                catalogActiveCategory = btn.getAttribute('data-category');
+                listEl.querySelectorAll('.catalog-pill').forEach(function(p) { p.classList.remove('active'); });
+                btn.classList.add('active');
+                renderCatalogGrid();
+            });
+        });
 
         // Wire search
-        var searchInput = innerEl.querySelector('.catalog-item-search');
+        var searchInput = listEl.querySelector('.catalog-search');
         if (searchInput) {
             searchInput.addEventListener('input', debounce(function() {
-                catalogItemSearchFilters[sourceId] = searchInput.value;
-                renderCatalogItems(sourceId);
+                catalogSearchQuery = searchInput.value;
+                renderCatalogGrid();
             }, 200));
-            // Prevent header click when clicking in search
-            searchInput.addEventListener('click', function(e) { e.stopPropagation(); });
+        }
+    }
+
+    function renderCatalogGrid() {
+        var gridEl = document.getElementById('catalog-grid');
+        var empty = $('#catalog-empty');
+        if (!gridEl) return;
+
+        var entries = catalogEntries.slice();
+
+        // Filter by category
+        if (catalogActiveCategory) {
+            entries = entries.filter(function(e) { return e.category === catalogActiveCategory; });
         }
 
-        // Wire show-all
-        var showAllBtn = innerEl.querySelector('.catalog-show-all');
-        if (showAllBtn) {
-            showAllBtn.addEventListener('click', function(e) {
-                e.stopPropagation();
-                catalogShowAllSources[sourceId] = true;
-                renderCatalogItems(sourceId);
+        // Filter by search
+        if (catalogSearchQuery) {
+            var q = catalogSearchQuery.toLowerCase();
+            entries = entries.filter(function(e) {
+                var searchable = (e.name + ' ' + (e.description || '') + ' ' + (e.tags || []).join(' ')).toLowerCase();
+                return searchable.indexOf(q) !== -1;
             });
         }
 
-        // Wire item toggles
-        innerEl.querySelectorAll('.catalog-item-toggle').forEach(function(cb) {
-            cb.addEventListener('click', function(e) { e.stopPropagation(); });
+        // Sort: enabled first, then alphabetical
+        entries.sort(function(a, b) {
+            var aEnabled = catalogEnabledMap[a.id] || false;
+            var bEnabled = catalogEnabledMap[b.id] || false;
+            if (aEnabled && !bEnabled) return -1;
+            if (!aEnabled && bEnabled) return 1;
+            return (a.name || '').localeCompare(b.name || '');
+        });
+
+        if (entries.length === 0) {
+            gridEl.innerHTML = '<p class="form-help" style="color:var(--text-muted);padding:16px 0;">No matching catalog entries.</p>';
+            hide(empty);
+            return;
+        }
+        hide(empty);
+
+        var html = '';
+        entries.forEach(function(entry) {
+            var enabled = catalogEnabledMap[entry.id] || false;
+            var sourceLabel = sourceLabels[entry.source_type] || entry.source_type;
+            var badgeClass = 'catalog-badge-' + (entry.category || '').replace(/\s+/g, '-');
+            var catLabel = categoryLabels[entry.category] || entry.category || '';
+
+            var tagsHtml = '<span class="catalog-card-tag ' + badgeClass + '">' + escapeHtml(catLabel) + '</span>';
+
+            html += '<div class="catalog-card">' +
+                '<div class="catalog-card-info">' +
+                    '<div class="catalog-card-header">' +
+                        '<span class="catalog-card-name">' + escapeHtml(entry.name) + '</span>' +
+                        (entry.docs_url ? ' <a href="' + escapeHtml(entry.docs_url) + '" target="_blank" class="catalog-docs-link" title="Documentation">&#128279;</a>' : '') +
+                    '</div>' +
+                    '<div class="catalog-card-desc">' + escapeHtml(entry.description) + '</div>' +
+                    '<div class="catalog-card-tags">' +
+                        '<span class="catalog-card-tag source-' + escapeHtml(entry.source_type || 'unknown') + '">' + escapeHtml(sourceLabel) + '</span>' +
+                        tagsHtml +
+                    '</div>' +
+                '</div>' +
+                '<div class="catalog-card-toggle">' +
+                    '<label class="toggle-switch" title="' + (enabled ? 'Disable' : 'Enable') + '">' +
+                        '<input type="checkbox" class="catalog-toggle" data-entry-id="' + escapeHtml(entry.id) + '"' + (enabled ? ' checked' : '') + '>' +
+                        '<span class="toggle-slider"></span>' +
+                    '</label>' +
+                '</div>' +
+            '</div>';
+        });
+        gridEl.innerHTML = html;
+
+        // Wire toggles
+        gridEl.querySelectorAll('.catalog-toggle').forEach(function(cb) {
             cb.addEventListener('change', async function() {
-                var itemSlug = cb.getAttribute('data-item-slug');
-                var sid = cb.getAttribute('data-source-id');
+                var entryId = cb.getAttribute('data-entry-id');
                 var enabled = cb.checked;
                 try {
-                    var resp = await api('PUT', '/api/v1/teams/' + activeTeamId + '/catalog/' + encodeURIComponent(sid) + '/' + encodeURIComponent(itemSlug), { enabled: enabled });
+                    var resp = await api('PUT', '/api/v1/teams/' + activeTeamId + '/catalog/' + encodeURIComponent(entryId), { enabled: enabled });
                     if (resp.ok) {
-                        // Update local cache
-                        var cached = catalogSourceItems[sid];
-                        if (cached) {
-                            cached.items.forEach(function(it) {
-                                if (it.slug === itemSlug) it.enabled = enabled;
-                            });
-                        }
-                        // Update source counts
-                        var src = catalogSources.find(function(s) { return s.source_id === sid; });
-                        if (src) {
-                            src.enabled_items = (src.enabled_items || 0) + (enabled ? 1 : -1);
-                            if (src.enabled_items < 0) src.enabled_items = 0;
-                            updateSourceCounts(sid, src);
-                        }
+                        catalogEnabledMap[entryId] = enabled;
                     } else {
                         cb.checked = !enabled;
                     }
@@ -7346,15 +7254,6 @@
                 }
             });
         });
-    }
-
-    function updateSourceCounts(sourceId, source) {
-        var sourceEl = document.querySelector('.catalog-source[data-source-id="' + sourceId + '"]');
-        if (!sourceEl) return;
-        var countsEl = sourceEl.querySelector('.catalog-source-counts');
-        if (countsEl) {
-            countsEl.textContent = (source.enabled_items || 0) + '/' + source.total_items;
-        }
     }
 
     function renderCatalogCustomPlugins() {


### PR DESCRIPTION
## Summary

Replaces the 9 source-level catalog entries with 168 individual items. Each card is one agent/plugin/tool organized by function, not source.

**168 items**: 156 agency-agents personas, 7 Anthropic plugins, 4 plugin bundles, 1 MCP server

**10 categories**: code-quality, security, frontend, devops, testing, developer-tools, engineering, documentation, marketing, specialized

## Changes

- **catalog.json**: 9 → 168 entries with new schema (source_type, source_url, source_path, docs_url)
- **API**: category summary in catalog response
- **Frontend**: category pill filter, card grid with source type badges, docs links, simplified toggles
- **CLI**: TYPE column, `catalog search` subcommand

## Test Results

- Go unit tests: all pass
- E2E browser: 8/8 (168 cards, category filter, search, toggle PUT, source badges, docs links)
- API: catalog returns 168 entries with 10 categories

Fixes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)