### PR TITLE
Make `make up` fast by default (~12s vs ~8min)

### DIFF
--- a/.claude/skills/dev-up/SKILL.md
+++ b/.claude/skills/dev-up/SKILL.md
@@ -4,39 +4,37 @@ description: Tear down and bring up a fresh local dev environment with credentia
 user-invocable: true
 ---
 
-Tear down ALL containers (including database), rebuild images, start fresh, and configure default credentials.
+Tear down everything, build locally, start fresh (~12 seconds), and configure default credentials.
 
 ## Steps
 
 ### 1. Tear down everything
 ```bash
+pkill -f 'bin/bridge' 2>/dev/null
 for c in $(podman ps -a --format "{{.Names}}" | grep -E "alcove|gate-|skiff-"); do podman rm -f "$c" 2>/dev/null; done
 podman network rm alcove-internal alcove-external 2>/dev/null
 ```
 
 ### 2. Build and start
-Run `make up`. This builds all images and starts PostgreSQL, NATS, and Bridge.
+Run `make up`. This builds Go binaries locally, starts PostgreSQL + NATS containers, and runs Bridge as a local process (~12 seconds total).
+
+For the old container-based approach (builds all 3 images, ~8 min), use `make up-full` instead.
 
 ### 3. Ensure Bridge is running
-Bridge often fails to start due to a race with PostgreSQL. Check health within 10 seconds. If not healthy, restart Bridge manually:
+Check health within 10 seconds. The fast `make up` runs Bridge locally so it starts immediately.
+
+If using postgres auth backend, restart Bridge manually with the backend flag:
 ```bash
-VER=$(git describe --tags --always --dirty)
-podman run -d --replace --name alcove-bridge \
-  --network alcove-internal,alcove-external \
-  -p 8080:8080 --user 0 --security-opt label=disable \
-  -v ${XDG_RUNTIME_DIR}/podman/podman.sock:/run/podman/podman.sock \
-  -v $(pwd)/web:/web:ro,z \
-  -v $(pwd)/alcove.yaml:/etc/alcove/alcove.yaml:ro,z \
-  -e CONTAINER_HOST=unix:///run/podman/podman.sock \
-  -e LEDGER_DATABASE_URL=postgres://alcove:alcove@alcove-ledger:5432/alcove?sslmode=disable \
-  -e HAIL_URL=nats://alcove-hail:4222 \
-  -e RUNTIME=podman -e ALCOVE_WEB_DIR=/web \
-  -e ALCOVE_NETWORK=alcove-internal -e ALCOVE_EXTERNAL_NETWORK=alcove-external \
-  -e SKIFF_IMAGE=localhost/alcove-skiff-base:$VER \
-  -e GATE_IMAGE=localhost/alcove-gate:$VER \
-  localhost/alcove-bridge:$VER
+make down
+LEDGER_DATABASE_URL="postgres://alcove:alcove@localhost:5432/alcove?sslmode=disable" \
+HAIL_URL="nats://localhost:4222" \
+RUNTIME=podman \
+ALCOVE_NETWORK=alcove-internal \
+ALCOVE_EXTERNAL_NETWORK=alcove-external \
+AUTH_BACKEND=postgres \
+ADMIN_RESET_PASSWORD=admin \
+./bin/bridge
 ```
-Wait for health check to pass.
 
 ### 4. Configure admin Vertex AI credential
 Since the database is fresh, configure the Vertex AI user credential for admin:
@@ -65,9 +63,9 @@ curl -s -X POST http://localhost:8080/api/v1/credentials \
 ```
 
 ### 5. Configure admin GitHub credential
-Read the GitHub PAT from `~/.config/alcove-github-token` and POST it:
+Read the GitHub PAT from `~/.config/alcove-github-token` or fall back to `gh auth token`:
 ```bash
-GH_PAT=$(cat ~/.config/alcove-github-token)
+GH_PAT=$(cat ~/.config/alcove-github-token 2>/dev/null || gh auth token 2>/dev/null)
 curl -s -X POST http://localhost:8080/api/v1/credentials \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \

--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,35 @@ build-images: ## Build all container images with podman
 
 ##@ Easy Targets
 
-up: build-images dev-up ## Build images and start everything
+up: dev-config dev-infra build ## Build locally and start Bridge + infra (~20s)
+	@echo "Starting Bridge locally..."
+	@LEDGER_DATABASE_URL="postgres://alcove:alcove@localhost:5432/alcove?sslmode=disable" \
+	HAIL_URL="nats://localhost:4222" \
+	RUNTIME=podman \
+	ALCOVE_NETWORK=$(INTERNAL_NET) \
+	ALCOVE_EXTERNAL_NETWORK=$(EXTERNAL_NET) \
+	nohup $(BINDIR)/bridge > /tmp/alcove-bridge.log 2>&1 &
+	@sleep 2
+	@echo ""
+	@echo "Dashboard:   http://localhost:8080"
+	@echo "NATS:        nats://localhost:4222 (monitoring: http://localhost:8222)"
+	@echo "PostgreSQL:  postgres://alcove:alcove@localhost:5432/alcove"
+	@echo "Bridge logs: /tmp/alcove-bridge.log"
 
-down: dev-down ## Stop everything
+up-full: build-images dev-up ## Build container images and start everything in containers (~8min)
 
-logs: dev-logs ## Show logs from all containers
+down: ## Stop everything
+	-@pkill -f '$(BINDIR)/bridge' 2>/dev/null || true
+	-@$(PODMAN) stop alcove-bridge 2>/dev/null || true
+	-@$(PODMAN) stop alcove-hail 2>/dev/null || true
+	-@$(PODMAN) stop alcove-ledger 2>/dev/null || true
+	-@$(PODMAN) network rm $(INTERNAL_NET) 2>/dev/null || true
+	-@$(PODMAN) network rm $(EXTERNAL_NET) 2>/dev/null || true
+	@echo "Dev environment stopped."
+
+logs: ## Show Bridge logs
+	@if [ -f /tmp/alcove-bridge.log ]; then tail -50 /tmp/alcove-bridge.log; \
+	else $(PODMAN) logs --tail 50 alcove-bridge 2>/dev/null || echo "No logs found"; fi
 
 ##@ Development
 


### PR DESCRIPTION
## Summary

- `make up` now builds locally + runs Bridge as a process (~12 seconds)
- `make up-full` preserves the old container image build path (~8 minutes)
- `make down` handles both modes
- Updated dev-up skill to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)