### PR TITLE
Add debug-env: built-in diagnostic tool for Skiff environment variables

### DIFF
--- a/.claude/skills/dev-restart/SKILL.md
+++ b/.claude/skills/dev-restart/SKILL.md
@@ -19,6 +19,8 @@ Do NOT stop `alcove-ledger` (PostgreSQL).
 make build-images
 ```
 
+To rebuild only the Skiff image (e.g., after changing debug-env): `make build-skiff`
+
 ### 3. Ensure networks exist
 ```bash
 podman network create --internal alcove-internal 2>/dev/null || true

--- a/.claude/skills/dev-up/SKILL.md
+++ b/.claude/skills/dev-up/SKILL.md
@@ -20,6 +20,8 @@ Run `make up`. This builds Go binaries locally, starts PostgreSQL + NATS contain
 
 For the old container-based approach (builds all 3 images, ~8 min), use `make up-full` instead.
 
+To rebuild only the Skiff image (e.g., after changing debug-env): `make build-skiff`
+
 ### 3. Ensure Bridge is running
 Check health within 10 seconds. The fast `make up` runs Bridge locally so it starts immediately.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           done
 
           # Build server components for Linux AMD64 (existing pattern)
-          for cmd in bridge gate skiff-init; do
+          for cmd in bridge gate skiff-init debug-env; do
             echo "Building ${cmd}..."
             CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
               go build -ldflags="-s -w -X main.Version=${VERSION}" \
@@ -137,6 +137,7 @@ jobs:
             dist/alcove-bridge-linux-amd64
             dist/alcove-gate-linux-amd64
             dist/alcove-skiff-init-linux-amd64
+            dist/alcove-debug-env-linux-amd64
             dist/alcove-linux-amd64
             dist/alcove-linux-arm64
             dist/alcove-darwin-amd64

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ IMAGES       := bridge gate skiff-base
 GO       := go
 PODMAN   := podman
 
-CMDS     := bridge gate skiff-init alcove
+CMDS     := bridge gate skiff-init alcove debug-env
 
-.PHONY: all build build-cli-all build-images build-image-bridge build-image-gate build-image-skiff-base \
+.PHONY: all build build-cli-all build-images build-image-bridge build-image-gate build-image-skiff-base build-skiff \
         test test-network test-ledger test-isolation test-schedules test-credentials test-security-profiles test-yaml-security-profiles test-gate-real lint clean \
         up down logs watch dev-config dev-up dev-down dev-logs dev-reset dev-infra help \
         login-registry push pull up-pull build-tooling push-tooling
@@ -56,6 +56,9 @@ build-image-gate:
 	$(PODMAN) build --build-arg VERSION=$(VERSION) -f build/Containerfile.gate -t localhost/alcove-gate:$(VERSION) .
 
 build-image-skiff-base:
+	$(PODMAN) build --build-arg VERSION=$(VERSION) -f build/Containerfile.skiff-base -t localhost/alcove-skiff-base:$(VERSION) .
+
+build-skiff: build ## Rebuild only the Skiff base image (after changing debug-env or skiff-init)
 	$(PODMAN) build --build-arg VERSION=$(VERSION) -f build/Containerfile.skiff-base -t localhost/alcove-skiff-base:$(VERSION) .
 
 ##@ Easy Targets

--- a/build/Containerfile.skiff-base
+++ b/build/Containerfile.skiff-base
@@ -14,6 +14,9 @@ ARG VERSION=dev
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.Version=${VERSION}" -o /out/skiff-init ./cmd/skiff-init
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.Version=${VERSION}" -o /out/debug-env ./cmd/debug-env
 
 # Stage 2: Thin overlay on pre-built tooling base
 FROM localhost/alcove-skiff-tooling:latest
@@ -27,6 +30,7 @@ LABEL org.opencontainers.image.title="alcove-skiff-base" \
       org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=builder /out/skiff-init /usr/local/bin/skiff-init
+COPY --from=builder /out/debug-env /usr/local/bin/debug-env
 
 # Install the git credential helper for Gate integration
 COPY build/alcove-credential-helper /usr/local/bin/alcove-credential-helper

--- a/cmd/debug-env/main.go
+++ b/cmd/debug-env/main.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+var Version = "dev"
+
+type EnvEntry struct {
+	Key            string `json:"key"`
+	Value          string `json:"value,omitempty"`
+	MaskedValue    string `json:"masked_value"`
+	Classification string `json:"classification"` // dummy, sensitive, safe, gate-proxy
+	Category       string `json:"category"`
+}
+
+var categoryOrder = []string{
+	"Infrastructure",
+	"LLM Provider",
+	"SCM Tokens",
+	"SCM Gateway URLs",
+	"Network Proxy",
+	"Plugins & Catalog",
+	"Git Config",
+	"Generic Secrets",
+	"Runtime",
+	"Other",
+}
+
+var infraVars = map[string]bool{
+	"TASK_ID": true, "SESSION_ID": true, "SESSION_TOKEN": true,
+	"HAIL_URL": true, "LEDGER_URL": true, "TASK_TIMEOUT": true,
+	"TASK_BUDGET": true, "PROMPT": true,
+}
+
+var llmVars = map[string]bool{
+	"ANTHROPIC_BASE_URL": true, "ANTHROPIC_API_KEY": true,
+	"ANTHROPIC_AUTH_TOKEN": true, "CLAUDE_MODEL": true,
+	"PROVIDER": true,
+}
+
+var scmTokenVars = map[string]bool{
+	"GITHUB_TOKEN": true, "GH_TOKEN": true, "GITHUB_PERSONAL_ACCESS_TOKEN": true,
+	"GITLAB_TOKEN": true, "GITLAB_PERSONAL_ACCESS_TOKEN": true,
+	"JIRA_TOKEN": true, "SPLUNK_TOKEN": true,
+}
+
+var scmURLVars = map[string]bool{
+	"GITHUB_API_URL": true, "GH_HOST": true, "GH_PROTOCOL": true,
+	"GH_PROMPT_DISABLED": true, "GH_NO_UPDATE_NOTIFIER": true,
+	"GITLAB_API_URL": true, "GLAB_HOST": true,
+	"JIRA_API_URL": true, "SPLUNK_URL": true,
+}
+
+var proxyVars = map[string]bool{
+	"HTTP_PROXY": true, "HTTPS_PROXY": true, "NO_PROXY": true,
+	"http_proxy": true, "https_proxy": true, "no_proxy": true,
+}
+
+var pluginVars = map[string]bool{
+	"ALCOVE_PLUGINS": true, "ALCOVE_SKILL_REPOS": true,
+	"ALCOVE_MCP_CONFIG": true, "ALCOVE_EXECUTABLE": true,
+}
+
+var gitVars = map[string]bool{
+	"GIT_AUTHOR_NAME": true, "GIT_AUTHOR_EMAIL": true,
+	"GIT_COMMITTER_NAME": true, "GIT_COMMITTER_EMAIL": true,
+	"GIT_TERMINAL_PROMPT": true, "GIT_SSH_COMMAND": true,
+	"GATE_CREDENTIAL_URL": true, "REPO": true, "BRANCH": true,
+}
+
+var runtimeVars = map[string]bool{
+	"HOME": true, "PATH": true, "USER": true, "SHELL": true,
+	"GOPATH": true, "GOBIN": true, "GOROOT": true, "LANG": true,
+	"TERM": true, "HOSTNAME": true, "PWD": true, "OLDPWD": true,
+	"SHLVL": true, "LC_ALL": true, "TMPDIR": true,
+}
+
+func categorize(key string) string {
+	switch {
+	case infraVars[key]:
+		return "Infrastructure"
+	case llmVars[key]:
+		return "LLM Provider"
+	case scmTokenVars[key]:
+		return "SCM Tokens"
+	case scmURLVars[key]:
+		return "SCM Gateway URLs"
+	case proxyVars[key]:
+		return "Network Proxy"
+	case pluginVars[key]:
+		return "Plugins & Catalog"
+	case gitVars[key]:
+		return "Git Config"
+	case runtimeVars[key]:
+		return "Runtime"
+	default:
+		// Check if it looks like a secret/credential
+		upper := strings.ToUpper(key)
+		for _, word := range []string{"TOKEN", "KEY", "SECRET", "PASSWORD", "CREDENTIAL", "AUTH"} {
+			if strings.Contains(upper, word) {
+				return "Generic Secrets"
+			}
+		}
+		return "Other"
+	}
+}
+
+func isDummy(value string) bool {
+	return strings.HasPrefix(value, "alcove-session-") ||
+		value == "sk-placeholder-routed-through-gate"
+}
+
+func isGateProxy(value string) bool {
+	return strings.Contains(value, "gate-") && strings.Contains(value, ":8443")
+}
+
+func classify(key, value string) string {
+	if isDummy(value) {
+		return "dummy"
+	}
+	if isGateProxy(value) {
+		return "gate-proxy"
+	}
+	cat := categorize(key)
+	if cat == "Generic Secrets" {
+		return "sensitive"
+	}
+	if key == "SESSION_TOKEN" || key == "ANTHROPIC_AUTH_TOKEN" {
+		return "sensitive"
+	}
+	return "safe"
+}
+
+func mask(value string) string {
+	if len(value) <= 8 {
+		return "***"
+	}
+	return value[:8] + "..."
+}
+
+func main() {
+	showSecrets := flag.Bool("show-secrets", false, "Show full values of sensitive environment variables")
+	jsonOutput := flag.Bool("json", false, "Output as JSON")
+	version := flag.Bool("version", false, "Print version")
+	flag.Parse()
+
+	if *version {
+		fmt.Printf("debug-env %s\n", Version)
+		os.Exit(0)
+	}
+
+	// Collect and categorize
+	categories := make(map[string][]EnvEntry)
+	for _, env := range os.Environ() {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key, value := parts[0], parts[1]
+		cat := categorize(key)
+		cls := classify(key, value)
+
+		entry := EnvEntry{
+			Key:            key,
+			Classification: cls,
+			Category:       cat,
+		}
+
+		if cls == "sensitive" && !*showSecrets {
+			entry.MaskedValue = mask(value)
+		} else {
+			entry.Value = value
+			entry.MaskedValue = value
+		}
+
+		categories[cat] = append(categories[cat], entry)
+	}
+
+	// Sort entries within each category
+	for cat := range categories {
+		sort.Slice(categories[cat], func(i, j int) bool {
+			return categories[cat][i].Key < categories[cat][j].Key
+		})
+	}
+
+	if *jsonOutput {
+		type CategoryGroup struct {
+			Name    string     `json:"name"`
+			Entries []EnvEntry `json:"entries"`
+		}
+		var groups []CategoryGroup
+		for _, cat := range categoryOrder {
+			if entries, ok := categories[cat]; ok && len(entries) > 0 {
+				groups = append(groups, CategoryGroup{Name: cat, Entries: entries})
+			}
+		}
+		out := map[string]any{
+			"version":    Version,
+			"categories": groups,
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(out)
+		return
+	}
+
+	// Human-readable output
+	for _, cat := range categoryOrder {
+		entries, ok := categories[cat]
+		if !ok || len(entries) == 0 {
+			continue
+		}
+		fmt.Printf("\n=== %s ===\n", cat)
+		for _, e := range entries {
+			display := e.MaskedValue
+			if e.Value != "" {
+				display = e.Value
+			}
+
+			// Truncate very long values (like JSON configs)
+			if len(display) > 120 {
+				display = display[:120] + "..."
+			}
+
+			annotation := ""
+			switch e.Classification {
+			case "dummy":
+				annotation = " [DUMMY]"
+			case "sensitive":
+				annotation = " [MASKED]"
+			case "gate-proxy":
+				annotation = " [GATE-PROXY]"
+			}
+
+			fmt.Printf("  %-30s = %s%s\n", e.Key, display, annotation)
+		}
+	}
+	fmt.Println()
+}

--- a/cmd/debug-env/main_test.go
+++ b/cmd/debug-env/main_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestCategorize(t *testing.T) {
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"TASK_ID", "Infrastructure"},
+		{"SESSION_ID", "Infrastructure"},
+		{"ANTHROPIC_API_KEY", "LLM Provider"},
+		{"CLAUDE_MODEL", "LLM Provider"},
+		{"GITHUB_TOKEN", "SCM Tokens"},
+		{"JIRA_TOKEN", "SCM Tokens"},
+		{"GITHUB_API_URL", "SCM Gateway URLs"},
+		{"HTTP_PROXY", "Network Proxy"},
+		{"ALCOVE_PLUGINS", "Plugins & Catalog"},
+		{"GIT_AUTHOR_NAME", "Git Config"},
+		{"HOME", "Runtime"},
+		{"PATH", "Runtime"},
+		{"MY_API_KEY", "Generic Secrets"},
+		{"CUSTOM_SECRET", "Generic Secrets"},
+		{"DB_PASSWORD", "Generic Secrets"},
+		{"SOME_RANDOM_VAR", "Other"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got := categorize(tt.key)
+			if got != tt.want {
+				t.Errorf("categorize(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDummy(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"alcove-session-abc123", true},
+		{"alcove-session-f8a3b2c1-1234-5678-9abc-def012345678", true},
+		{"sk-placeholder-routed-through-gate", true},
+		{"sk-ant-real-token", false},
+		{"ghp_realtoken123", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			got := isDummy(tt.value)
+			if got != tt.want {
+				t.Errorf("isDummy(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsGateProxy(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"http://gate-abc123:8443", true},
+		{"http://gate-abc123:8443/github", true},
+		{"http://localhost:8080", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			got := isGateProxy(tt.value)
+			if got != tt.want {
+				t.Errorf("isGateProxy(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		key, value string
+		want       string
+	}{
+		{"GITHUB_TOKEN", "alcove-session-abc", "dummy"},
+		{"ANTHROPIC_API_KEY", "sk-placeholder-routed-through-gate", "dummy"},
+		{"ANTHROPIC_BASE_URL", "http://gate-abc:8443", "gate-proxy"},
+		{"MY_API_KEY", "sk-real-secret", "sensitive"},
+		{"CUSTOM_SECRET", "real-value", "sensitive"},
+		{"SESSION_TOKEN", "real-session-token", "sensitive"},
+		{"TASK_ID", "abc-123", "safe"},
+		{"HOME", "/home/skiff", "safe"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got := classify(tt.key, tt.value)
+			if got != tt.want {
+				t.Errorf("classify(%q, %q) = %q, want %q", tt.key, tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{"sk-ant-real-long-token-here", "sk-ant-r..."},
+		{"short", "***"},
+		{"12345678", "***"},
+		{"123456789", "12345678..."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			got := mask(tt.value)
+			if got != tt.want {
+				t.Errorf("mask(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -30,6 +30,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -216,20 +217,29 @@ func runExecutable(
 		return 1, "error", nil, nil
 	}
 
-	log.Printf("downloading executable from %s", execSpec.URL)
-
-	// Download the executable
+	// Resolve the executable path: local file or remote download
 	agentPath := "/tmp/agent"
-	downloadCmd := exec.CommandContext(ctx, "curl", "-sL", execSpec.URL, "-o", agentPath)
-	if err := downloadCmd.Run(); err != nil {
-		log.Printf("error downloading executable: %v", err)
-		return 1, "error", nil, nil
-	}
+	if strings.HasPrefix(execSpec.URL, "file://") {
+		agentPath = strings.TrimPrefix(execSpec.URL, "file://")
+		log.Printf("using local executable at %s", agentPath)
+	} else if strings.HasPrefix(execSpec.URL, "/") {
+		agentPath = execSpec.URL
+		log.Printf("using local executable at %s", agentPath)
+	} else {
+		log.Printf("downloading executable from %s", execSpec.URL)
 
-	// Make it executable
-	if err := os.Chmod(agentPath, 0755); err != nil {
-		log.Printf("error making executable: %v", err)
-		return 1, "error", nil, nil
+		// Download the executable
+		downloadCmd := exec.CommandContext(ctx, "curl", "-sL", execSpec.URL, "-o", agentPath)
+		if err := downloadCmd.Run(); err != nil {
+			log.Printf("error downloading executable: %v", err)
+			return 1, "error", nil, nil
+		}
+
+		// Make it executable (only needed for downloaded files)
+		if err := os.Chmod(agentPath, 0755); err != nil {
+			log.Printf("error making executable: %v", err)
+			return 1, "error", nil, nil
+		}
 	}
 
 	log.Printf("running executable: %s %v", agentPath, execSpec.Args)

--- a/docs/debug-env.md
+++ b/docs/debug-env.md
@@ -1,0 +1,74 @@
+# Debug Environment Inspector
+
+The `debug-env` utility is built into every Skiff container and prints all
+environment variables with categorization, dummy token detection, and
+secret masking.
+
+## Usage
+
+```bash
+debug-env                  # Human-readable categorized output
+debug-env --json           # Structured JSON output
+debug-env --show-secrets   # Reveal masked sensitive values
+debug-env --version        # Print version
+```
+
+## Running as an Agent
+
+Create an agent definition in your repo (`.alcove/tasks/debug-env.yml`)
+with the same `credentials:` block as the agent you're debugging:
+
+```yaml
+name: Debug Environment Inspector
+description: Prints all Skiff environment variables with dummy token detection
+executable:
+  url: file:///usr/local/bin/debug-env
+timeout: 60
+credentials:
+  SPLUNK_TOKEN: splunk
+  JIRA_TOKEN: jira
+  MY_API_KEY: my-secret
+```
+
+The `credentials:` block is the key — copy it from whatever agent isn't
+working. The debug-env binary prints exactly what the Skiff sees, showing
+which values are real, dummy, or missing.
+
+This shows up on the Schedules page with a "Run Now" button. Runs in
+~5 seconds.
+
+## Categories
+
+| Category | Variables | Notes |
+|----------|-----------|-------|
+| Infrastructure | TASK_ID, SESSION_ID, HAIL_URL, etc. | Always set, safe values |
+| LLM Provider | ANTHROPIC_BASE_URL, ANTHROPIC_API_KEY | API_KEY is a dummy placeholder |
+| SCM Tokens | GITHUB_TOKEN, GITLAB_TOKEN, JIRA_TOKEN | All dummy — Gate swaps for real |
+| SCM Gateway URLs | GITHUB_API_URL, GITLAB_API_URL | Gate proxy endpoints |
+| Network Proxy | HTTP_PROXY, HTTPS_PROXY, NO_PROXY | Gate proxy settings |
+| Plugins & Catalog | ALCOVE_PLUGINS, ALCOVE_SKILL_REPOS | Plugin/skill configuration |
+| Git Config | GIT_AUTHOR_NAME, REPO, etc. | Git identity and repo settings |
+| Generic Secrets | User-defined via credentials: map | Real values — masked by default |
+| Runtime | HOME, PATH, USER, etc. | System environment |
+
+## Annotations
+
+- `[DUMMY]` — Fake token that Gate swaps for a real credential at proxy time
+- `[MASKED]` — Real sensitive value, hidden by default (use `--show-secrets`)
+- `[GATE-PROXY]` — URL pointing to the Gate sidecar proxy
+
+## Dummy Token Patterns
+
+- `alcove-session-*` prefix — dummy SCM tokens
+- `sk-placeholder-routed-through-gate` — dummy LLM API key
+- `http://gate-*:8443/*` — Gate proxy URLs
+
+## Rebuilding
+
+If you modify `cmd/debug-env/main.go`, rebuild the Skiff image:
+
+```bash
+make build-skiff    # Rebuilds only the Skiff base image (~2-3 min)
+```
+
+The next dispatched session will use the updated binary.


### PR DESCRIPTION
## Summary

Bakes a `debug-env` binary into every Skiff container that prints all env vars categorized, with dummy token detection and secret masking.

Users debug credential issues by creating an agent definition with the same `credentials:` block as the agent they're troubleshooting:

```yaml
name: Debug Environment Inspector
executable:
  url: file:///usr/local/bin/debug-env
timeout: 60
credentials:
  SPLUNK_TOKEN: splunk
  MY_API_KEY: my-secret
```

## Changes (+479 lines)

- `cmd/debug-env/main.go` — the binary (10 categories, dummy detection, masking)
- `cmd/debug-env/main_test.go` — 16 unit tests
- `build/Containerfile.skiff-base` — bake into Skiff image
- `.github/workflows/release.yml` — release artifact
- `cmd/skiff-init/main.go` — support `file://` URLs for baked-in executables
- `Makefile` — add to CMDS + `make build-skiff` target
- `docs/debug-env.md` — usage docs
- Dev skills updated with `make build-skiff` info

## Test Results

- Go tests: all pass (including 16 new debug-env tests)
- Manual test: binary correctly marks dummy tokens, masks secrets, categorizes vars

Fixes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)