### PR TITLE
Fix release workflow: build skiff-tooling before skiff-base

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,13 +115,24 @@ jobs:
             ${{ env.REGISTRY }}/alcove-gate:latest
             ${{ env.REGISTRY }}/alcove-gate:sha-${{ steps.version.outputs.sha_short }}
 
+      - name: Build and push skiff-tooling image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: build/Containerfile.skiff-tooling
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/alcove-skiff-tooling:latest
+
       - name: Build and push skiff-base image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: build/Containerfile.skiff-base
           push: true
-          build-args: VERSION=${{ steps.version.outputs.version }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            SKIFF_TOOLING_BASE=${{ env.REGISTRY }}/alcove-skiff-tooling:latest
           tags: |
             ${{ env.REGISTRY }}/alcove-skiff-base:${{ steps.version.outputs.version }}
             ${{ env.REGISTRY }}/alcove-skiff-base:latest

--- a/build/Containerfile.skiff-base
+++ b/build/Containerfile.skiff-base
@@ -19,7 +19,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.Version=${VERSION}" -o /out/debug-env ./cmd/debug-env
 
 # Stage 2: Thin overlay on pre-built tooling base
-FROM localhost/alcove-skiff-tooling:latest
+# SKIFF_TOOLING_BASE can be overridden for CI (localhost/) vs release (ghcr.io/)
+ARG SKIFF_TOOLING_BASE=localhost/alcove-skiff-tooling:latest
+FROM ${SKIFF_TOOLING_BASE}
 
 ARG VERSION=dev
 LABEL org.opencontainers.image.title="alcove-skiff-base" \


### PR DESCRIPTION
Release failed because Containerfile.skiff-base uses localhost/ which Docker Buildx can't resolve. Use build arg SKIFF_TOOLING_BASE.