### PR TITLE
Hide active team from team switcher dropdown

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5480,9 +5480,9 @@
         var html = '';
         for (var i = 0; i < teamsList.length; i++) {
             var t = teamsList[i];
+            if (t.id === activeTeamId) continue; // skip active team — already shown in toggle button
             var displayName = t.is_personal ? 'My Workspace' : escapeHtml(t.name);
-            var isActive = t.id === activeTeamId;
-            html += '<button class="team-switcher-item' + (isActive ? ' active' : '') + '" data-team-id="' + escapeHtml(t.id) + '">' + displayName + '</button>';
+            html += '<button class="team-switcher-item" data-team-id="' + escapeHtml(t.id) + '">' + displayName + '</button>';
         }
         html += '<button class="team-switcher-manage" id="team-switcher-manage-btn">Manage Teams</button>';
         listEl.innerHTML = html;


### PR DESCRIPTION
## Summary

Skip the active team in the team switcher dropdown. Its name is already shown in the toggle button — no need to offer a "switch" to the team you're already on.

Before: dropdown shows all teams including the active one (highlighted)
After: dropdown shows only teams you can switch TO

With a single team, the dropdown now shows just "Manage Teams" instead of a single highlighted item.

Fixes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)