### PR TITLE
Fix tools endpoint returning 500 for NULL team_id

### DIFF
--- a/internal/bridge/tools.go
+++ b/internal/bridge/tools.go
@@ -94,12 +94,22 @@ func (ts *ToolStore) CreateTool(ctx context.Context, tool *ToolDefinition, teamI
 
 // ListTools returns ALL builtin tools plus the given owner's custom tools.
 func (ts *ToolStore) ListTools(ctx context.Context, teamID string) ([]ToolDefinition, error) {
-	query := `SELECT id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, team_id, created_at
-		FROM mcp_tools
-		WHERE tool_type = 'builtin' OR team_id = $1
-		ORDER BY tool_type ASC, name ASC`
+	var query string
+	var args []any
+	if teamID != "" {
+		query = `SELECT id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, team_id, created_at
+			FROM mcp_tools
+			WHERE tool_type = 'builtin' OR team_id = $1
+			ORDER BY tool_type ASC, name ASC`
+		args = []any{teamID}
+	} else {
+		query = `SELECT id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, team_id, created_at
+			FROM mcp_tools
+			WHERE tool_type = 'builtin'
+			ORDER BY tool_type ASC, name ASC`
+	}
 
-	rows, err := ts.db.Query(ctx, query, teamID)
+	rows, err := ts.db.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying tools: %w", err)
 	}
@@ -108,15 +118,18 @@ func (ts *ToolStore) ListTools(ctx context.Context, teamID string) ([]ToolDefini
 	var tools []ToolDefinition
 	for rows.Next() {
 		var t ToolDefinition
-		var mcpCommand, apiHost, authHeader, authFormat *string
+		var mcpCommand, apiHost, authHeader, authFormat, teamID *string
 		var mcpArgs, operations string
 
 		if err := rows.Scan(&t.ID, &t.Name, &t.DisplayName, &t.ToolType,
 			&mcpCommand, &mcpArgs, &apiHost, &authHeader, &authFormat,
-			&operations, &t.TeamID, &t.CreatedAt); err != nil {
+			&operations, &teamID, &t.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scanning tool: %w", err)
 		}
 
+		if teamID != nil {
+			t.TeamID = *teamID
+		}
 		if mcpCommand != nil {
 			t.MCPCommand = *mcpCommand
 		}


### PR DESCRIPTION
## Summary

Fix GET /api/v1/tools returning 500 (the "flaky test" failure).

## Root Cause (two bugs)

1. **Empty team header → UUID parse error**: `ListTools` passed an empty string to `WHERE team_id = $1` which PostgreSQL rejected as invalid UUID
2. **NULL team_id → scan error**: Builtin tools have `team_id = NULL` but the scan target was `string` (not `*string`), causing "cannot scan NULL into *string"

## Fix

- Skip team_id filter when teamID is empty (return only builtin tools)
- Use `*string` pointer for scanning team_id, set after null check

## Verified

- Local dev: `GET /api/v1/tools` returns 200 with and without team header
- No errors in Bridge logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)