### PR TITLE
Fix workflow provider resolution: treat 'workflow' as empty

### DIFF
--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -121,8 +121,9 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 	taskID := uuid.New().String()
 
 	// Resolve provider: use explicit name or first available credential.
+	// "workflow" is a placeholder used by workflow schedule entries, not a real provider.
 	provider := req.Provider
-	if provider == "" {
+	if provider == "" || provider == "workflow" {
 		if firstCred, err := d.credStore.FirstAvailableProvider(ctx); err == nil {
 			provider = firstCred.Name
 		} else {


### PR DESCRIPTION
## Summary

Treat `provider='workflow'` as empty so the dispatcher falls back to the first available LLM credential.

## Root Cause

Workflow schedule entries are inserted with `provider='workflow'` as a placeholder (tasksync.go:1059). When the poller dispatched these sessions, the dispatcher used `'workflow'` as the LLM provider name. Claude Code then tried to authenticate with a provider called "workflow", which doesn't exist, returning "Invalid API key".

The credentials were fine — manual sessions from the same team with the same Vertex AI credential worked. Only poller-dispatched workflow sessions failed.

## Fix

One-line change: `if provider == "" || provider == "workflow"` — falls back to `FirstAvailableProvider()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)