### PR TITLE
Fix workspace switch navigating to sessions list

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5496,8 +5496,8 @@
                     localStorage.setItem('alcove_active_team', teamId);
                     renderTeamSwitcher();
                     hide($('#team-switcher-menu'));
-                    // Reload the current view with new team context
-                    handleRoute();
+                    // Navigate to sessions list — don't stay on a detail page from the old team
+                    navigate('sessions');
                 } else {
                     hide($('#team-switcher-menu'));
                 }


### PR DESCRIPTION
Closes #311. One-line fix: navigate('sessions') instead of handleRoute() on workspace switch.