### PR TITLE
Extend debug-env with installation status: requested vs installed

### DIFF
--- a/cmd/debug-env/main.go
+++ b/cmd/debug-env/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -144,6 +145,218 @@ func mask(value string) string {
 	return value[:8] + "..."
 }
 
+// PluginSpec describes a plugin requested via ALCOVE_PLUGINS.
+type PluginSpec struct {
+	Name   string `json:"name"`
+	Source string `json:"source,omitempty"`
+	Ref    string `json:"ref,omitempty"`
+}
+
+// SkillRepo describes a skill repo requested via ALCOVE_SKILL_REPOS.
+type SkillRepo struct {
+	URL     string `json:"url"`
+	Ref     string `json:"ref,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Enabled *bool  `json:"enabled,omitempty"`
+}
+
+// InstallationReport summarizes what was requested and what is actually installed.
+type InstallationReport struct {
+	Plugins     []InstallEntry `json:"plugins,omitempty"`
+	SkillRepos  []InstallEntry `json:"skill_repos,omitempty"`
+	MCPServers  []InstallEntry `json:"mcp_servers,omitempty"`
+	Credentials []InstallEntry `json:"credentials,omitempty"`
+}
+
+// InstallEntry is a single item in the installation report.
+type InstallEntry struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Source string `json:"source,omitempty"`
+	Status string `json:"status"` // installed, missing, configured, requested, dummy, sensitive
+	Detail string `json:"detail,omitempty"`
+}
+
+func checkInstallation() *InstallationReport {
+	// Skip if not inside a Skiff container
+	if os.Getenv("TASK_ID") == "" {
+		return nil
+	}
+
+	report := &InstallationReport{}
+
+	// Parse and check plugins
+	if raw := os.Getenv("ALCOVE_PLUGINS"); raw != "" {
+		var plugins []PluginSpec
+		json.Unmarshal([]byte(raw), &plugins)
+		for _, p := range plugins {
+			entry := InstallEntry{Name: p.Name, Source: p.Source, Type: "plugin"}
+			// Check /tmp/alcove-plugins/{name}
+			dir := "/tmp/alcove-plugins/" + p.Name
+			if _, err := os.Stat(dir); err == nil {
+				entry.Status = "installed"
+			} else if p.Source == "claude-plugins-official" || p.Source == "" {
+				// Marketplace/official plugins installed differently
+				entry.Status = "requested" // Can't easily verify marketplace installs
+			} else {
+				entry.Status = "missing"
+			}
+			report.Plugins = append(report.Plugins, entry)
+		}
+	}
+
+	// Parse and check skill repos
+	if raw := os.Getenv("ALCOVE_SKILL_REPOS"); raw != "" {
+		var repos []SkillRepo
+		json.Unmarshal([]byte(raw), &repos)
+		for _, r := range repos {
+			name := r.Name
+			if name == "" {
+				name = filepath.Base(strings.TrimSuffix(r.URL, ".git"))
+			}
+			entry := InstallEntry{Name: name, Source: r.URL, Type: "skill_repo"}
+			dir := "/tmp/alcove-skills/" + name
+			if info, err := os.Stat(dir); err == nil && info.IsDir() {
+				// Check if it's a lola module or plugin dir
+				for _, sub := range []string{"module", "skills", "agents"} {
+					if _, err := os.Stat(filepath.Join(dir, sub)); err == nil {
+						entry.Detail = "lola module"
+						break
+					}
+				}
+				if entry.Detail == "" {
+					entry.Detail = "plugin dir"
+				}
+				entry.Status = "installed"
+			} else {
+				entry.Status = "missing"
+			}
+			report.SkillRepos = append(report.SkillRepos, entry)
+		}
+	}
+
+	// Parse MCP config
+	if raw := os.Getenv("ALCOVE_MCP_CONFIG"); raw != "" {
+		var mcpConfig map[string]json.RawMessage
+		json.Unmarshal([]byte(raw), &mcpConfig)
+		for name := range mcpConfig {
+			entry := InstallEntry{Name: name, Type: "mcp_server", Status: "configured"}
+			report.MCPServers = append(report.MCPServers, entry)
+		}
+	}
+
+	// Also check ~/.claude.json for MCP servers
+	if data, err := os.ReadFile(filepath.Join(os.Getenv("HOME"), ".claude.json")); err == nil {
+		var claudeConfig map[string]json.RawMessage
+		json.Unmarshal(data, &claudeConfig)
+		if servers, ok := claudeConfig["mcpServers"]; ok {
+			var serverMap map[string]json.RawMessage
+			json.Unmarshal(servers, &serverMap)
+			for name := range serverMap {
+				// Only add if not already in MCP list
+				found := false
+				for _, s := range report.MCPServers {
+					if s.Name == name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					report.MCPServers = append(report.MCPServers, InstallEntry{Name: name, Type: "mcp_server", Status: "configured", Detail: "from claude.json"})
+				}
+			}
+		}
+	}
+
+	// Credential summary
+	for _, env := range os.Environ() {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key, value := parts[0], parts[1]
+		cls := classify(key, value)
+		if cls == "dummy" || cls == "sensitive" {
+			detail := "real value"
+			if isDummy(value) {
+				detail = "gate-proxied"
+			}
+			report.Credentials = append(report.Credentials, InstallEntry{
+				Name:   key,
+				Status: cls,
+				Type:   "credential",
+				Detail: detail,
+			})
+		}
+	}
+
+	sort.Slice(report.Credentials, func(i, j int) bool { return report.Credentials[i].Name < report.Credentials[j].Name })
+
+	return report
+}
+
+func printInstallationReport(r *InstallationReport) {
+	fmt.Println("\n=== Installation Status ===")
+
+	if len(r.Plugins) > 0 {
+		fmt.Printf("\n  Plugins (requested: %d):\n", len(r.Plugins))
+		for _, p := range r.Plugins {
+			icon := "[OK]  "
+			if p.Status == "missing" {
+				icon = "[MISS]"
+			}
+			source := p.Source
+			if source == "" {
+				source = "marketplace"
+			}
+			fmt.Printf("    %s %-25s (%s)\n", icon, p.Name, source)
+		}
+	}
+
+	if len(r.SkillRepos) > 0 {
+		fmt.Printf("\n  Skill Repos (requested: %d):\n", len(r.SkillRepos))
+		for _, s := range r.SkillRepos {
+			icon := "[OK]  "
+			if s.Status == "missing" {
+				icon = "[MISS]"
+			}
+			detail := ""
+			if s.Detail != "" {
+				detail = " (" + s.Detail + ")"
+			}
+			fmt.Printf("    %s %-25s%s\n", icon, s.Name, detail)
+		}
+	}
+
+	if len(r.MCPServers) > 0 {
+		fmt.Printf("\n  MCP Servers (configured: %d):\n", len(r.MCPServers))
+		for _, m := range r.MCPServers {
+			detail := ""
+			if m.Detail != "" {
+				detail = " — " + m.Detail
+			}
+			fmt.Printf("    [OK]   %-25s%s\n", m.Name, detail)
+		}
+	}
+
+	if len(r.Credentials) > 0 {
+		fmt.Printf("\n  Credentials (%d):\n", len(r.Credentials))
+		for _, c := range r.Credentials {
+			badge := "[REAL] "
+			if c.Status == "dummy" {
+				badge = "[DUMMY]"
+			}
+			detail := ""
+			if c.Detail != "" {
+				detail = " " + c.Detail
+			}
+			fmt.Printf("    %-30s %s%s\n", c.Name, badge, detail)
+		}
+	}
+
+	fmt.Println()
+}
+
 func main() {
 	showSecrets := flag.Bool("show-secrets", false, "Show full values of sensitive environment variables")
 	jsonOutput := flag.Bool("json", false, "Output as JSON")
@@ -189,6 +402,9 @@ func main() {
 		})
 	}
 
+	// Installation status (only inside Skiff)
+	report := checkInstallation()
+
 	if *jsonOutput {
 		type CategoryGroup struct {
 			Name    string     `json:"name"`
@@ -203,6 +419,9 @@ func main() {
 		out := map[string]any{
 			"version":    Version,
 			"categories": groups,
+		}
+		if report != nil {
+			out["installation"] = report
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -241,5 +460,10 @@ func main() {
 			fmt.Printf("  %-30s = %s%s\n", e.Key, display, annotation)
 		}
 	}
-	fmt.Println()
+
+	if report != nil {
+		printInstallationReport(report)
+	} else {
+		fmt.Println()
+	}
 }

--- a/cmd/debug-env/main_test.go
+++ b/cmd/debug-env/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 )
 
@@ -119,5 +120,41 @@ func TestMask(t *testing.T) {
 				t.Errorf("mask(%q) = %q, want %q", tt.value, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCheckInstallationOutsideSkiff(t *testing.T) {
+	// Ensure TASK_ID is unset
+	t.Setenv("TASK_ID", "")
+	os.Unsetenv("TASK_ID")
+	report := checkInstallation()
+	if report != nil {
+		t.Error("expected nil report outside Skiff")
+	}
+}
+
+func TestCheckInstallationInsideSkiff(t *testing.T) {
+	t.Setenv("TASK_ID", "test-123")
+	t.Setenv("ALCOVE_PLUGINS", `[{"name":"code-review","source":"claude-plugins-official"}]`)
+	t.Setenv("ALCOVE_SKILL_REPOS", `[{"url":"https://github.com/org/skills","name":"my-skills"}]`)
+	t.Setenv("ALCOVE_MCP_CONFIG", `{"github":{"command":"npx"}}`)
+	// Use a temp dir as HOME so we don't pick up the real ~/.claude.json
+	t.Setenv("HOME", t.TempDir())
+
+	report := checkInstallation()
+	if report == nil {
+		t.Fatal("expected non-nil report inside Skiff")
+	}
+	if len(report.Plugins) != 1 {
+		t.Errorf("expected 1 plugin, got %d", len(report.Plugins))
+	}
+	if report.Plugins[0].Name != "code-review" {
+		t.Errorf("expected plugin name 'code-review', got %q", report.Plugins[0].Name)
+	}
+	if len(report.SkillRepos) != 1 {
+		t.Errorf("expected 1 skill repo, got %d", len(report.SkillRepos))
+	}
+	if len(report.MCPServers) != 1 {
+		t.Errorf("expected 1 MCP server, got %d", len(report.MCPServers))
 	}
 }

--- a/docs/debug-env.md
+++ b/docs/debug-env.md
@@ -63,6 +63,52 @@ This shows up on the Schedules page with a "Run Now" button. Runs in
 - `sk-placeholder-routed-through-gate` — dummy LLM API key
 - `http://gate-*:8443/*` — Gate proxy URLs
 
+## Installation Status
+
+When running inside a Skiff container (detected via `TASK_ID`), debug-env
+reports what plugins, skill repos, MCP servers, and credentials were
+requested versus what is actually installed on disk.
+
+### Sections
+
+| Section | Source | Checks |
+|---------|--------|--------|
+| Plugins | `ALCOVE_PLUGINS` env var (JSON) | `/tmp/alcove-plugins/{name}` exists |
+| Skill Repos | `ALCOVE_SKILL_REPOS` env var (JSON) | `/tmp/alcove-skills/{name}` exists and is a directory |
+| MCP Servers | `ALCOVE_MCP_CONFIG` env var + `~/.claude.json` | Listed as configured |
+| Credentials | All env vars | Classified as dummy (gate-proxied) or real |
+
+### Status Values
+
+- `[OK]` / `installed` — found on disk at expected path
+- `[MISS]` / `missing` — requested but not found on disk
+- `requested` — marketplace/official plugin, cannot verify filesystem install
+- `configured` — MCP server declared in config
+- `[DUMMY]` / `dummy` — credential is a placeholder swapped by Gate at proxy time
+- `[REAL]` / `sensitive` — credential has a real value
+
+### Example Output
+
+```
+=== Installation Status ===
+
+  Plugins (requested: 2):
+    [OK]   code-review               (claude-plugins-official)
+    [MISS] custom-lint                (https://github.com/org/lint)
+
+  Skill Repos (requested: 1):
+    [OK]   my-skills                  (lola module)
+
+  MCP Servers (configured: 1):
+    [OK]   github
+
+  Credentials (2):
+    ANTHROPIC_API_KEY              [DUMMY] gate-proxied
+    GITHUB_TOKEN                   [DUMMY] gate-proxied
+```
+
+In JSON mode (`--json`), the report appears under the `"installation"` key.
+
 ## Rebuilding
 
 If you modify `cmd/debug-env/main.go`, rebuild the Skiff image:


### PR DESCRIPTION
## Summary

debug-env now shows what was requested vs what was actually installed on the Skiff.

```
=== Installation Status ===

  Plugins (requested: 2):
    [OK]   code-review               (claude-plugins-official)
    [MISS] my-plugin                 (https://github.com/org/plugin)

  Skill Repos (requested: 2):
    [OK]   my-skills                 (lola module)
    [MISS] prompts

  MCP Servers (configured: 2):
    [OK]   github
    [OK]   google-drive               — from claude.json

  Credentials (3):
    GITHUB_TOKEN                   [DUMMY] gate-proxied
    MY_API_KEY                     [REAL]  real value
```

Only activates inside Skiff containers (TASK_ID set). JSON output includes `installation` key.

## Test Results

- Go tests: 18/18 pass (including 2 new installation tests)
- Manual: verified with simulated env vars

Fixes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)