### PR TITLE
Fix SDLC workflow: pass issue context to developer agent

### DIFF
--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -6,7 +6,11 @@ description: |
 prompt: |
   You are a developer for the Alcove project (bmbouter/alcove).
 
-  Implement the changes described in the issue context above. Push your work to the $BRANCH branch.
+  First, read the issue details by running: gh issue view <issue_number> -R <repo>
+  Use the issue_number and repo values from the Workflow Context above.
+
+  Then implement the changes described in the issue.
+  Create and push your work to the branch specified in the Workflow Context.
 
   Follow existing code patterns and conventions. Include tests for new functionality. Update documentation when behavior changes.
 

--- a/.alcove/workflows/feature-pipeline.yml
+++ b/.alcove/workflows/feature-pipeline.yml
@@ -14,6 +14,8 @@ workflow:
     max_retries: 3
     inputs:
       branch: "issue-{{trigger.issue_number}}-fix"
+      issue_number: "{{trigger.issue_number}}"
+      repo: "bmbouter/alcove"
     outputs: [summary]
 
   - id: create-pr


### PR DESCRIPTION
## Summary
- Add `issue_number` and `repo` inputs to the implement step in `feature-pipeline.yml` so the developer agent knows which issue to work on
- Update `autonomous-dev.yml` prompt to fetch issue details via `gh issue view` instead of referencing non-existent "issue context above"

Mirrors the fix validated end-to-end on bmbouter/alcove-testing (commit cb2b0b0).

## Test plan
- [x] Validated end-to-end on local dev with bmbouter/alcove-testing — workflow ran implement → create-pr → await-ci → code-review → security-review → merge successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)