### PR TITLE
Fix SDLC workflow engine: end-to-end pipeline execution

### DIFF
--- a/build/Containerfile.skiff-base
+++ b/build/Containerfile.skiff-base
@@ -47,6 +47,8 @@ RUN git config --system credential.helper '/usr/local/bin/alcove-credential-help
     git config --system url."https://gitlab.com/".insteadOf "git@gitlab.com:" && \
     git config --system url."https://gitlab.com/".insteadOf "ssh://git@gitlab.com/"
 
+RUN mkdir -p /workspace && chmod 777 /workspace
+
 USER 1001
 WORKDIR /home/skiff
 ENTRYPOINT ["/usr/local/bin/skiff-init"]

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -213,6 +213,7 @@ func main() {
 
 	// Create and start the scheduler.
 	scheduler := bridge.NewScheduler(dbpool, dispatcher, cfg, credStore, defStore, settingsStore)
+	scheduler.SetWorkflowEngine(workflowEngine)
 	scheduler.Start(context.Background())
 	defer scheduler.Stop()
 

--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -993,6 +993,11 @@ func installPlugins() {
 
 // cloneRepo performs a shallow clone of the given repo.
 func cloneRepo(repo, branch string) error {
+	// Mark /workspace as safe to avoid "dubious ownership" errors when the
+	// directory is owned by a different UID (e.g., root-created in the image).
+	safeDir := exec.Command("git", "config", "--global", "--add", "safe.directory", "/workspace")
+	safeDir.Run()
+
 	args := []string{"clone", "--depth=1"}
 	if branch != "" {
 		args = append(args, "--branch", branch)

--- a/internal/bridge/bridge_actions.go
+++ b/internal/bridge/bridge_actions.go
@@ -280,6 +280,18 @@ func bridgeActionAwaitCI(ctx context.Context, inputs map[string]interface{}, cre
 		}
 
 		if len(checks.CheckRuns) == 0 {
+			// If no checks after 90s, treat as passed (repo has no CI configured).
+			if time.Since(deadline.Add(-time.Duration(timeout)*time.Second)) > 90*time.Second {
+				log.Printf("bridge-action await-ci: no check runs found after 90s for %s#%d, treating as passed", repo, pr)
+				return &BridgeActionResult{
+					Status: "succeeded",
+					Outputs: map[string]interface{}{
+						"status":        "passed",
+						"failure_logs":  "",
+						"failed_checks": []string{},
+					},
+				}, nil
+			}
 			time.Sleep(pollInterval)
 			continue
 		}

--- a/internal/bridge/poller.go
+++ b/internal/bridge/poller.go
@@ -50,11 +50,12 @@ var githubEventTypeMap = map[string]string{
 // GitHubPoller polls the GitHub Events API for repos referenced by
 // polling-mode event schedules and dispatches matching tasks.
 type GitHubPoller struct {
-	db         *pgxpool.Pool
-	dispatcher *Dispatcher
-	credStore  *CredentialStore
-	defStore   *AgentDefStore
-	client     *http.Client
+	db             *pgxpool.Pool
+	dispatcher     *Dispatcher
+	credStore      *CredentialStore
+	defStore       *AgentDefStore
+	workflowEngine *WorkflowEngine
+	client         *http.Client
 }
 
 // pollSchedule holds the fields needed from a schedule for polling and dispatch.
@@ -500,10 +501,29 @@ func (p *GitHubPoller) pollRepo(ctx context.Context, repo, teamID string, schedu
 			metaJSON, _ := json.Marshal(meta)
 			taskReq.Prompt = taskReq.Prompt + "\n\n" + enrichedContext + "\n\n[event: " + string(metaJSON) + "]"
 
-			_, err := p.dispatcher.DispatchTask(ctx, taskReq, "poller", sched.TeamID)
-			if err != nil {
-				log.Printf("poller: error dispatching schedule %s for %s: %v", sched.Name, eventRepo, err)
-				continue
+			// Route workflow schedules through the workflow engine.
+			if sched.Provider == "workflow" && p.workflowEngine != nil && sched.SourceKey != "" {
+				// Look up the workflow by source_key to get its ID.
+				var workflowID string
+				err := p.db.QueryRow(ctx,
+					`SELECT id FROM workflows WHERE source_key = $1 AND team_id = $2`,
+					sched.SourceKey, sched.TeamID,
+				).Scan(&workflowID)
+				if err != nil {
+					log.Printf("poller: error looking up workflow for schedule %s: %v", sched.Name, err)
+					continue
+				}
+				_, err = p.workflowEngine.StartWorkflowRun(ctx, workflowID, "event", taskReq.TriggerRef, sched.TeamID)
+				if err != nil {
+					log.Printf("poller: error starting workflow run for %s: %v", sched.Name, err)
+					continue
+				}
+			} else {
+				_, err := p.dispatcher.DispatchTask(ctx, taskReq, "poller", sched.TeamID)
+				if err != nil {
+					log.Printf("poller: error dispatching schedule %s for %s: %v", sched.Name, eventRepo, err)
+					continue
+				}
 			}
 
 			// Mark this task as dispatched for this issue/PR in this poll cycle.

--- a/internal/bridge/scheduler.go
+++ b/internal/bridge/scheduler.go
@@ -242,6 +242,12 @@ type Scheduler struct {
 	wg            sync.WaitGroup
 }
 
+// SetWorkflowEngine attaches a WorkflowEngine to the scheduler's poller so that
+// workflow-type schedules are dispatched through the workflow engine.
+func (s *Scheduler) SetWorkflowEngine(we *WorkflowEngine) {
+	s.poller.workflowEngine = we
+}
+
 // NewScheduler creates a Scheduler with the given dependencies.
 func NewScheduler(db *pgxpool.Pool, dispatcher *Dispatcher, cfg *Config, credStore *CredentialStore, defStore *AgentDefStore, settingsStore *SettingsStore) *Scheduler {
 	return &Scheduler{

--- a/internal/bridge/taskdef.go
+++ b/internal/bridge/taskdef.go
@@ -235,7 +235,7 @@ func (s *AgentDefStore) GetAgentDefinition(ctx context.Context, id, teamID strin
 		       s.next_run, s.last_run
 		FROM agent_definitions td
 		LEFT JOIN schedules s ON s.source_key = td.source_key AND s.source = 'yaml'
-		WHERE td.id = $1 AND td.team_id = $2
+		WHERE (td.id = $1 OR td.name = $1) AND td.team_id = $2
 	`, id, teamID).Scan(
 		&td.ID, &td.Name, &td.Description, &td.SourceRepo, &td.SourceFile,
 		&td.SourceKey, &td.RawYAML, &parsedJSON, &hasSchedule, &syncError,

--- a/internal/bridge/workflow_engine.go
+++ b/internal/bridge/workflow_engine.go
@@ -309,8 +309,21 @@ func (we *WorkflowEngine) dispatchStep(ctx context.Context, run *WorkflowRun, st
 	}
 
 	// Inject step inputs into the task request
-	if err := we.injectStepInputs(ctx, run.ID, step, &taskReq); err != nil {
+	if err := we.injectStepInputs(ctx, run.ID, step, &taskReq, run.TriggerRef); err != nil {
 		return fmt.Errorf("injecting inputs for step %s: %w", step.ID, err)
+	}
+
+	// Store resolved inputs in step outputs so later steps can reference them via
+	// {{steps.X.inputs.Y}} templates (e.g., create-pr needs implement's branch input).
+	if len(step.Inputs) > 0 {
+		stepOutputs, _ := we.getRunStepOutputs(ctx, run.ID)
+		ref := run.TriggerRef
+		resolvedInputs := make(map[string]interface{})
+		for key, value := range step.Inputs {
+			resolved, _ := we.processInputValue(value, stepOutputs, ref)
+			resolvedInputs["_input_"+key] = resolved
+		}
+		we.updateRunStepOutputs(ctx, run.ID, step.ID, resolvedInputs)
 	}
 
 	// Dispatch the task
@@ -339,7 +352,7 @@ func (we *WorkflowEngine) executeBridgeAction(ctx context.Context, run *Workflow
 	}
 
 	// Resolve inputs (expand templates).
-	resolvedInputs, err := we.resolveStepInputs(ctx, run.ID, step)
+	resolvedInputs, err := we.resolveStepInputs(ctx, run.ID, step, run.TriggerRef)
 	if err != nil {
 		return fmt.Errorf("resolving inputs for bridge step %s: %w", step.ID, err)
 	}
@@ -399,7 +412,7 @@ func (we *WorkflowEngine) executeBridgeAction(ctx context.Context, run *Workflow
 }
 
 // resolveStepInputs resolves template references in step inputs.
-func (we *WorkflowEngine) resolveStepInputs(ctx context.Context, runID string, step *WorkflowStep) (map[string]interface{}, error) {
+func (we *WorkflowEngine) resolveStepInputs(ctx context.Context, runID string, step *WorkflowStep, triggerRef ...string) (map[string]interface{}, error) {
 	if len(step.Inputs) == 0 {
 		return make(map[string]interface{}), nil
 	}
@@ -409,9 +422,14 @@ func (we *WorkflowEngine) resolveStepInputs(ctx context.Context, runID string, s
 		return nil, fmt.Errorf("getting step outputs: %w", err)
 	}
 
+	ref := ""
+	if len(triggerRef) > 0 {
+		ref = triggerRef[0]
+	}
+
 	resolved := make(map[string]interface{})
 	for key, value := range step.Inputs {
-		processedValue, err := we.processInputValue(value, stepOutputs)
+		processedValue, err := we.processInputValue(value, stepOutputs, ref)
 		if err != nil {
 			return nil, fmt.Errorf("processing input %s: %w", key, err)
 		}
@@ -628,6 +646,47 @@ func (we *WorkflowEngine) checkWorkflowCompletion(ctx context.Context, run *Work
 		return fmt.Errorf("getting workflow run steps: %w", err)
 	}
 
+	// Get the workflow definition and step statuses for dependency evaluation.
+	workflow, _ := we.getWorkflowByID(ctx, run.WorkflowID)
+	stepStatuses, _ := we.getAllStepStatuses(ctx, run.ID)
+
+	// Mark unreachable pending steps as skipped: if all referenced steps are
+	// terminal (completed/failed/skipped) and the depends expression is false,
+	// the step can never be triggered.
+	if workflow != nil && stepStatuses != nil {
+		for _, step := range steps {
+			if step.Status != "pending" {
+				continue
+			}
+			stepDef := workflow.GetStepByID(step.StepID)
+			if stepDef == nil || stepDef.Depends == "" {
+				continue
+			}
+			referencedIDs := ExtractDependsStepIDs(stepDef.Depends)
+			allTerminal := true
+			for _, refID := range referencedIDs {
+				status, ok := stepStatuses[refID]
+				if !ok || (status != "completed" && status != "failed" && status != "skipped") {
+					allTerminal = false
+					break
+				}
+			}
+			if !allTerminal {
+				continue
+			}
+			result, err := EvaluateDepends(stepDef.Depends, stepStatuses)
+			if err == nil && !result {
+				log.Printf("marking unreachable step %s as skipped", step.StepID)
+				we.updateStepStatus(ctx, run.ID, step.StepID, "skipped", nil, nil)
+			}
+		}
+		// Re-fetch steps after potential skips.
+		steps, err = we.getWorkflowRunSteps(ctx, run.ID)
+		if err != nil {
+			return fmt.Errorf("re-getting workflow run steps: %w", err)
+		}
+	}
+
 	allComplete := true
 	anyFailed := false
 
@@ -733,7 +792,7 @@ func (we *WorkflowEngine) getAllStepStatuses(ctx context.Context, runID string) 
 }
 
 // injectStepInputs processes step inputs and injects them into the task request.
-func (we *WorkflowEngine) injectStepInputs(ctx context.Context, runID string, step *WorkflowStep, taskReq *TaskRequest) error {
+func (we *WorkflowEngine) injectStepInputs(ctx context.Context, runID string, step *WorkflowStep, taskReq *TaskRequest, triggerRef ...string) error {
 	if len(step.Inputs) == 0 {
 		return nil
 	}
@@ -744,10 +803,16 @@ func (we *WorkflowEngine) injectStepInputs(ctx context.Context, runID string, st
 		return fmt.Errorf("getting step outputs: %w", err)
 	}
 
+	// Get trigger ref for template expansion
+	ref := ""
+	if len(triggerRef) > 0 {
+		ref = triggerRef[0]
+	}
+
 	// Process each input
 	processedInputs := make(map[string]interface{})
 	for key, value := range step.Inputs {
-		processedValue, err := we.processInputValue(value, stepOutputs)
+		processedValue, err := we.processInputValue(value, stepOutputs, ref)
 		if err != nil {
 			return fmt.Errorf("processing input %s: %w", key, err)
 		}
@@ -778,23 +843,33 @@ func (we *WorkflowEngine) injectStepInputs(ctx context.Context, runID string, st
 }
 
 // processInputValue processes a single input value, expanding templates if necessary.
-func (we *WorkflowEngine) processInputValue(value interface{}, stepOutputs map[string]interface{}) (interface{}, error) {
+func (we *WorkflowEngine) processInputValue(value interface{}, stepOutputs map[string]interface{}, triggerRef string) (interface{}, error) {
 	if str, ok := value.(string); ok {
-		// Check for template syntax like "{{steps.implement.outputs.summary}}"
+		// Check for template syntax like "{{steps.implement.outputs.summary}}" or "{{trigger.issue_number}}"
 		if strings.Contains(str, "{{") && strings.Contains(str, "}}") {
-			return we.expandTemplate(str, stepOutputs)
+			return we.expandTemplateWithContext(str, stepOutputs, triggerRef)
 		}
 	}
 	return value, nil
 }
 
 // expandTemplate expands template variables in a string.
-func (we *WorkflowEngine) expandTemplate(template string, stepOutputs map[string]interface{}) (string, error) {
+// Supports {{steps.stepName.outputs.outputName}} and {{trigger.issue_number}}.
+func (we *WorkflowEngine) expandTemplateWithContext(template string, stepOutputs map[string]interface{}, triggerRef string) (string, error) {
 	result := template
 
+	// Pattern: {{trigger.issue_number}} — extract from triggerRef like "owner/repo#42"
+	if strings.Contains(result, "{{trigger.issue_number}}") {
+		issueNumber := ""
+		if idx := strings.LastIndex(triggerRef, "#"); idx >= 0 {
+			issueNumber = triggerRef[idx+1:]
+		}
+		result = strings.ReplaceAll(result, "{{trigger.issue_number}}", issueNumber)
+	}
+
 	// Pattern: {{steps.stepName.outputs.outputName}}
-	pattern := regexp.MustCompile(`\{\{steps\.(\w+)\.outputs\.(\w+)\}\}`)
-	matches := pattern.FindAllStringSubmatch(template, -1)
+	pattern := regexp.MustCompile(`\{\{steps\.([\w-]+)\.outputs\.([\w-]+)\}\}`)
+	matches := pattern.FindAllStringSubmatch(result, -1)
 
 	for _, match := range matches {
 		fullMatch := match[0]
@@ -804,15 +879,35 @@ func (we *WorkflowEngine) expandTemplate(template string, stepOutputs map[string
 		if stepOutput, exists := stepOutputs[stepID]; exists {
 			if outputMap, ok := stepOutput.(map[string]interface{}); ok {
 				if outputValue, exists := outputMap[outputKey]; exists {
-					if str, ok := outputValue.(string); ok {
-						result = strings.ReplaceAll(result, fullMatch, str)
-					}
+					result = strings.ReplaceAll(result, fullMatch, fmt.Sprintf("%v", outputValue))
+				}
+			}
+		}
+	}
+
+	// Pattern: {{steps.stepName.inputs.inputName}} — resolve from workflow definition
+	inputPattern := regexp.MustCompile(`\{\{steps\.([\w-]+)\.inputs\.([\w-]+)\}\}`)
+	inputMatches := inputPattern.FindAllStringSubmatch(result, -1)
+	for _, match := range inputMatches {
+		fullMatch := match[0]
+		stepID := match[1]
+		inputKey := match[2]
+
+		if stepOutput, exists := stepOutputs[stepID]; exists {
+			if outputMap, ok := stepOutput.(map[string]interface{}); ok {
+				if inputVal, exists := outputMap["_input_"+inputKey]; exists {
+					result = strings.ReplaceAll(result, fullMatch, fmt.Sprintf("%v", inputVal))
 				}
 			}
 		}
 	}
 
 	return result, nil
+}
+
+// expandTemplate is the legacy wrapper without trigger context.
+func (we *WorkflowEngine) expandTemplate(template string, stepOutputs map[string]interface{}) (string, error) {
+	return we.expandTemplateWithContext(template, stepOutputs, "")
 }
 
 // resolveInputs resolves template references in step inputs using outputs from previous steps.
@@ -1410,8 +1505,15 @@ func (we *WorkflowEngine) updateRunStepOutputs(ctx context.Context, runID, stepI
 		return fmt.Errorf("getting current step outputs: %w", err)
 	}
 
-	// Update with new step outputs
-	currentOutputs[stepID] = stepOutputs
+	// Merge with existing outputs for this step (preserve _input_* keys from dispatch time)
+	if existing, ok := currentOutputs[stepID].(map[string]interface{}); ok {
+		for k, v := range stepOutputs {
+			existing[k] = v
+		}
+		currentOutputs[stepID] = existing
+	} else {
+		currentOutputs[stepID] = stepOutputs
+	}
 
 	// Marshal and update
 	outputsJSON, err := json.Marshal(currentOutputs)


### PR DESCRIPTION
## Summary
- Fix 9 bugs preventing the workflow graph from running end-to-end
- Route workflow schedules through StartWorkflowRun instead of DispatchTask
- Add trigger template expansion ({{trigger.issue_number}}), cross-step input references ({{steps.X.inputs.Y}}), and hyphenated step ID support
- Merge step outputs on completion to preserve _input_* keys
- Mark unreachable steps as skipped for proper workflow completion
- Create /workspace in Skiff image and fix git dubious ownership
- Treat repos with no CI as passed after 90s in await-ci

## Test plan
- [x] End-to-end local test: issue → implement → create-pr → await-ci → code-review + security-review → merge on bmbouter/alcove-testing
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)