### PR TITLE
Fix executable agents: don't require PROMPT when ALCOVE_EXECUTABLE is set

### DIFF
--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -65,7 +65,10 @@ func main() {
 	// --- Read task from environment variables (injected by Bridge) ---
 	taskID := requireEnv("TASK_ID")
 	sessionID := envOrDefault("SESSION_ID", taskID)
-	prompt := requireEnv("PROMPT")
+	prompt := os.Getenv("PROMPT")
+	if prompt == "" && os.Getenv("ALCOVE_EXECUTABLE") == "" {
+		log.Fatal("required environment variable PROMPT is not set")
+	}
 	repo := os.Getenv("REPO")
 	branch := os.Getenv("BRANCH")
 	provider := envOrDefault("PROVIDER", "anthropic")

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -230,9 +230,10 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		TeamID:      activeTeamID,
 	}
 
-	// For executable agents, store the prompt as the description/context if empty
+	// For executable agents, set a descriptive prompt if empty.
 	if req.Executable != nil && req.Prompt == "" {
-		session.Prompt = fmt.Sprintf("Executable agent: %s", req.Executable.URL)
+		req.Prompt = fmt.Sprintf("Executable agent: %s", req.Executable.URL)
+		session.Prompt = req.Prompt
 	}
 
 	// Generate a session token for the Skiff pod to authenticate to Ledger.
@@ -708,7 +709,7 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		DirectOutbound: req.DirectOutbound,
 	}
 
-	handle, err := d.rt.RunTask(ctx, spec)
+handle, err := d.rt.RunTask(ctx, spec)
 	if err != nil {
 		// Update session to error state.
 		d.updateSessionStatus(ctx, sessionID, "error", nil, nil)

--- a/internal/bridge/tools.go
+++ b/internal/bridge/tools.go
@@ -158,23 +158,37 @@ func (ts *ToolStore) ListTools(ctx context.Context, teamID string) ([]ToolDefini
 // GetTool looks up a tool by name. Returns builtin tools regardless of owner;
 // returns custom tools only if the owner matches.
 func (ts *ToolStore) GetTool(ctx context.Context, name, teamID string) (*ToolDefinition, error) {
-	query := `SELECT id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, team_id, created_at
-		FROM mcp_tools
-		WHERE name = $1 AND (tool_type = 'builtin' OR team_id = $2)
-		LIMIT 1`
+	var query string
+	var args []any
+	if teamID != "" {
+		query = `SELECT id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, team_id, created_at
+			FROM mcp_tools
+			WHERE name = $1 AND (tool_type = 'builtin' OR team_id = $2)
+			LIMIT 1`
+		args = []any{name, teamID}
+	} else {
+		query = `SELECT id, name, display_name, tool_type, mcp_command, mcp_args, api_host, auth_header, auth_format, operations, team_id, created_at
+			FROM mcp_tools
+			WHERE name = $1 AND tool_type = 'builtin'
+			LIMIT 1`
+		args = []any{name}
+	}
 
 	var t ToolDefinition
-	var mcpCommand, apiHost, authHeader, authFormat *string
+	var mcpCommand, apiHost, authHeader, authFormat, scannedTeamID *string
 	var mcpArgs, operations string
 
-	err := ts.db.QueryRow(ctx, query, name, teamID).Scan(
+	err := ts.db.QueryRow(ctx, query, args...).Scan(
 		&t.ID, &t.Name, &t.DisplayName, &t.ToolType,
 		&mcpCommand, &mcpArgs, &apiHost, &authHeader, &authFormat,
-		&operations, &t.TeamID, &t.CreatedAt)
+		&operations, &scannedTeamID, &t.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("tool %q not found: %w", name, err)
 	}
 
+	if scannedTeamID != nil {
+		t.TeamID = *scannedTeamID
+	}
 	if mcpCommand != nil {
 		t.MCPCommand = *mcpCommand
 	}


### PR DESCRIPTION
## Summary

Fix executable agents (like debug-env) silently failing when dispatched via "Run Now" on the Schedules page.

## Root Cause

`skiff-init` called `requireEnv("PROMPT")` which exits if PROMPT is empty. Executable agents have no prompt — they use `executable.url` instead. When dispatched via agent-definition-run, the PROMPT env var was empty, so skiff-init exited before ever checking ALCOVE_EXECUTABLE. Claude Code then ran with an empty prompt for 60+ seconds.

## Fixes

1. **skiff-init**: Only require PROMPT when ALCOVE_EXECUTABLE is not set
2. **dispatcher**: Set `req.Prompt` to a descriptive value for executable agents
3. **tools.go**: Fix `GetTool` NULL team_id scan (same bug pattern as ListTools)

## Verified

- Dispatched via agent-definition-run: completed in 1.6s with 71 transcript events
- Transcript shows full debug-env output (env vars, installation status, credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)