### PR TITLE
Render executable agent transcripts as formatted blocks with color badges

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -3119,6 +3119,51 @@ details[open] > .tx-tool-expand-toggle::before {
     flex-wrap: wrap;
 }
 
+/* Executable agent transcript (debug-env, etc.) */
+.tx-exec-block {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.6;
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: var(--radius);
+    padding: 12px 16px;
+    margin: 8px 0;
+    overflow-x: auto;
+}
+.tx-exec-section {
+    font-size: 14px;
+    font-weight: 700;
+    color: #fff;
+    padding: 10px 0 4px;
+    margin-top: 8px;
+    border-left: 3px solid var(--status-running);
+    padding-left: 10px;
+}
+.tx-exec-section:first-child { margin-top: 0; padding-top: 2px; }
+.tx-exec-subheader {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text);
+    padding: 6px 0 2px;
+    margin-top: 4px;
+}
+.tx-exec-line { color: var(--text-muted); padding: 1px 0; white-space: pre; }
+.tx-exec-blank { height: 8px; }
+.tx-exec-badge {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 700;
+    padding: 1px 5px;
+    border-radius: 3px;
+    letter-spacing: 0.3px;
+}
+.tx-exec-dummy { background: rgba(243,156,18,0.2); color: #f39c12; }
+.tx-exec-masked { background: rgba(230,126,34,0.2); color: #e67e22; }
+.tx-exec-gate { background: rgba(52,152,219,0.15); color: #3498db; }
+.tx-exec-real { background: rgba(46,204,113,0.2); color: #2ecc71; }
+.tx-exec-ok { color: var(--status-completed); font-weight: 700; }
+.tx-exec-miss { color: var(--status-error); font-weight: 700; }
+
 /* === Footer === */
 .alcove-footer {
     text-align: center;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2508,8 +2508,12 @@
 
             // Re-render all events (simple and reliable)
             content.innerHTML = '';
-            for (var i = 0; i < events.length; i++) {
-                appendTranscriptEvent(content, events[i]);
+            if (isExecutableTranscript(events)) {
+                renderExecutableTranscript(content, events);
+            } else {
+                for (var i = 0; i < events.length; i++) {
+                    appendTranscriptEvent(content, events[i]);
+                }
             }
             // Auto-scroll to bottom
             content.scrollTop = content.scrollHeight;
@@ -2519,6 +2523,84 @@
                 content.innerHTML = '<div class="transcript-system" style="color:var(--status-error)">Failed to load transcript.</div>';
             }
         }
+    }
+
+    function isExecutableTranscript(events) {
+        if (!events || events.length < 3) return false;
+        var execCount = 0;
+        for (var i = 0; i < events.length; i++) {
+            var ev = events[i];
+            var type = ev.type || ev.role || 'system';
+            if (type === 'text' && ev.source === 'executable') {
+                execCount++;
+            } else if (type === 'system' || type === 'result') {
+                continue;
+            }
+        }
+        return execCount > 3;
+    }
+
+    function renderExecutableTranscript(container, events) {
+        var lines = [];
+        for (var i = 0; i < events.length; i++) {
+            var ev = events[i];
+            var type = ev.type || ev.role || 'system';
+            if (type === 'system' || type === 'result') {
+                if (lines.length > 0) {
+                    flushExecutableBlock(container, lines);
+                    lines = [];
+                }
+                appendTranscriptEvent(container, ev);
+                continue;
+            }
+            if (type === 'text' && ev.source === 'executable') {
+                lines.push(ev.content || '');
+            }
+        }
+        if (lines.length > 0) {
+            flushExecutableBlock(container, lines);
+        }
+    }
+
+    function flushExecutableBlock(container, lines) {
+        var div = document.createElement('div');
+        div.className = 'tx-exec-block';
+        var html = '';
+        for (var i = 0; i < lines.length; i++) {
+            html += renderExecutableLine(lines[i]);
+        }
+        div.innerHTML = html;
+        container.appendChild(div);
+    }
+
+    function renderExecutableLine(line) {
+        var escaped = escapeHtml(line);
+
+        // Section headers: === Category Name ===
+        if (/^=== .+ ===$/.test(line)) {
+            var name = line.replace(/^=== /, '').replace(/ ===$/, '');
+            return '<div class="tx-exec-section">' + escapeHtml(name) + '</div>';
+        }
+
+        // Empty lines
+        if (line.trim() === '') {
+            return '<div class="tx-exec-blank"></div>';
+        }
+
+        // Sub-section headers: "  Plugins (requested: 2):" or "  Credentials (3):"
+        if (/^\s{2}\w[\w\s]*\(.*\):\s*$/.test(line)) {
+            return '<div class="tx-exec-subheader">' + escaped + '</div>';
+        }
+
+        // Apply annotation badges
+        escaped = escaped.replace(/\[DUMMY\]/g, '<span class="tx-exec-badge tx-exec-dummy">DUMMY</span>');
+        escaped = escaped.replace(/\[MASKED\]/g, '<span class="tx-exec-badge tx-exec-masked">MASKED</span>');
+        escaped = escaped.replace(/\[GATE-PROXY\]/g, '<span class="tx-exec-badge tx-exec-gate">GATE-PROXY</span>');
+        escaped = escaped.replace(/\[REAL\]/g, '<span class="tx-exec-badge tx-exec-real">REAL</span>');
+        escaped = escaped.replace(/\[OK\]\s*/g, '<span class="tx-exec-ok">[OK]</span> ');
+        escaped = escaped.replace(/\[MISS\]/g, '<span class="tx-exec-miss">[MISS]</span>');
+
+        return '<div class="tx-exec-line">' + escaped + '</div>';
     }
 
     // Simple markdown-like rendering (no library needed)


### PR DESCRIPTION
## Summary

Executable agent transcripts (debug-env, etc.) now render as a clean monospace block with colored annotations instead of 70+ individual bullet-point events.

- Section headers: bold with blue left border
- `[DUMMY]` amber badges, `[GATE-PROXY]` blue, `[REAL]` green, `[MASKED]` orange
- `[OK]` green / `[MISS]` red status indicators
- No more bullets or "text" labels

Detection: checks if transcript events are `type=text, source=executable`. Falls back to normal rendering for Claude Code transcripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)