### PR TITLE
Clean up orphaned Gate sidecar containers after session ends

### DIFF
--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -781,8 +781,26 @@ func (d *Dispatcher) ListenForStatusUpdates(ctx context.Context) error {
 		// Clean up handle on terminal states.
 		if update.Status == "completed" || update.Status == "error" || update.Status == "timeout" {
 			d.mu.Lock()
+			handle, hasHandle := d.handles[update.SessionID]
 			delete(d.handles, update.SessionID)
 			d.mu.Unlock()
+
+			// Clean up the Gate sidecar container after a grace period.
+			// The goroutine waits 5 seconds so Gate can flush final logs.
+			// Uses a detached context so cleanup completes even if the
+			// parent context is cancelled (e.g., during Bridge shutdown).
+			if hasHandle {
+				go func(taskID, sessionID string) {
+					time.Sleep(5 * time.Second)
+					gateName := runtime.GateContainerName(taskID)
+					log.Printf("cleanup: stopping gate sidecar %s for completed session %s", gateName, sessionID)
+					cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+					defer cancel()
+					if err := d.rt.StopService(cleanupCtx, gateName); err != nil {
+						log.Printf("cleanup: failed to stop gate %s: %v", gateName, err)
+					}
+				}(handle.ID, update.SessionID)
+			}
 
 			// Notify workflow engine of step completion
 			if d.workflowEngine != nil {
@@ -894,7 +912,8 @@ func (d *Dispatcher) RecoverHandles(ctx context.Context) {
 
 // ReconcileLoop periodically checks for sessions stuck in "running" state
 // whose containers have exited. This catches status updates lost during
-// Bridge restarts or NATS message drops.
+// Bridge restarts or NATS message drops. It also sweeps orphaned Gate
+// sidecar containers whose Skiff containers are gone.
 func (d *Dispatcher) ReconcileLoop(ctx context.Context) {
 	ticker := time.NewTicker(2 * time.Minute)
 	defer ticker.Stop()
@@ -905,6 +924,14 @@ func (d *Dispatcher) ReconcileLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			d.RecoverHandles(ctx)
+
+			// Sweep orphaned Gate containers.
+			cleaned, err := d.rt.CleanupOrphanedContainers(ctx, "gate-")
+			if err != nil {
+				log.Printf("reconcile: error cleaning up orphaned gate containers: %v", err)
+			} else if cleaned > 0 {
+				log.Printf("reconcile: cleaned up %d orphaned gate container(s)", cleaned)
+			}
 		}
 	}
 }

--- a/internal/bridge/reconcile_test.go
+++ b/internal/bridge/reconcile_test.go
@@ -62,6 +62,10 @@ func (m *mockRuntime) Info(_ context.Context) (runtime.RuntimeInfo, error) {
 	return runtime.RuntimeInfo{Type: "mock"}, nil
 }
 
+func (m *mockRuntime) CleanupOrphanedContainers(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+
 // TestReconcileLoop_ContextCancellation verifies that ReconcileLoop exits
 // when its context is cancelled.
 func TestReconcileLoop_ContextCancellation(t *testing.T) {

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -352,6 +352,63 @@ type dockerVersionInfo struct {
 	} `json:"Client"`
 }
 
+// CleanupOrphanedContainers finds containers whose names start with prefix
+// (e.g., "gate-") and removes any whose corresponding skiff container is gone.
+func (d *DockerRuntime) CleanupOrphanedContainers(ctx context.Context, prefix string) (int, error) {
+	// List all containers (running and stopped) matching the prefix.
+	// Docker ps -a --format json returns one JSON object per line.
+	out, err := d.run(ctx, "ps", "-a", "--filter", "name=^"+prefix, "--format", "json")
+	if err != nil {
+		return 0, fmt.Errorf("listing containers with prefix %s: %w", prefix, err)
+	}
+
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return 0, nil
+	}
+
+	var entries []dockerPsEntry
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var entry dockerPsEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+
+	cleaned := 0
+	for _, entry := range entries {
+		name := entry.Names
+		if name == "" || !strings.HasPrefix(name, prefix) {
+			continue
+		}
+
+		// Derive the corresponding skiff container name.
+		// "gate-<taskID>" -> "skiff-<taskID>"
+		taskID := strings.TrimPrefix(name, prefix)
+		skiffName := SkiffContainerName(taskID)
+
+		// Check if the skiff container still exists.
+		skiffHandle := TaskHandle{ID: taskID}
+		status, err := d.TaskStatus(ctx, skiffHandle)
+		if err == nil && status == "running" {
+			// Skiff is still running — do not remove its Gate.
+			continue
+		}
+
+		// Skiff is gone or not running — clean up the gate container.
+		log.Printf("cleanup: removing orphaned container %s (skiff %s status: %s)", name, skiffName, status)
+		_ = d.stopAndRemove(ctx, name)
+		cleaned++
+	}
+
+	return cleaned, nil
+}
+
 // Info returns runtime metadata including the docker version.
 func (d *DockerRuntime) Info(ctx context.Context) (RuntimeInfo, error) {
 	out, err := d.run(ctx, "version", "--format", "json")

--- a/internal/runtime/kubernetes.go
+++ b/internal/runtime/kubernetes.go
@@ -506,6 +506,13 @@ func (k *KubernetesRuntime) CreateVolume(ctx context.Context, name string) (stri
 	return name, nil
 }
 
+// CleanupOrphanedContainers is a no-op on Kubernetes. Gate runs as a native
+// sidecar (init container with restartPolicy: Always) within the same pod as
+// Skiff, so it is automatically cleaned up when the pod terminates.
+func (k *KubernetesRuntime) CleanupOrphanedContainers(ctx context.Context, prefix string) (int, error) {
+	return 0, nil
+}
+
 // Info returns runtime metadata for the Kubernetes runtime, including the
 // server version reported by the API server.
 func (k *KubernetesRuntime) Info(ctx context.Context) (RuntimeInfo, error) {

--- a/internal/runtime/podman.go
+++ b/internal/runtime/podman.go
@@ -356,6 +356,57 @@ type podmanVersionInfo struct {
 	} `json:"Client"`
 }
 
+// CleanupOrphanedContainers finds containers whose names start with prefix
+// (e.g., "gate-") and removes any whose corresponding skiff container is gone.
+func (p *PodmanRuntime) CleanupOrphanedContainers(ctx context.Context, prefix string) (int, error) {
+	// List all containers (running and stopped) matching the prefix.
+	out, err := p.run(ctx, "ps", "-a", "--filter", "name=^"+prefix, "--format", "json")
+	if err != nil {
+		return 0, fmt.Errorf("listing containers with prefix %s: %w", prefix, err)
+	}
+
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" || trimmed == "null" || trimmed == "[]" {
+		return 0, nil
+	}
+
+	var entries []podmanPsEntry
+	if err := json.Unmarshal([]byte(trimmed), &entries); err != nil {
+		return 0, fmt.Errorf("parsing container list: %w", err)
+	}
+
+	cleaned := 0
+	for _, entry := range entries {
+		if len(entry.Names) == 0 {
+			continue
+		}
+		name := entry.Names[0]
+
+		// Derive the corresponding skiff container name.
+		// "gate-<taskID>" -> "skiff-<taskID>"
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		taskID := strings.TrimPrefix(name, prefix)
+		skiffName := SkiffContainerName(taskID)
+
+		// Check if the skiff container still exists.
+		skiffHandle := TaskHandle{ID: taskID}
+		status, err := p.TaskStatus(ctx, skiffHandle)
+		if err == nil && status == "running" {
+			// Skiff is still running — do not remove its Gate.
+			continue
+		}
+
+		// Skiff is gone or not running — clean up the gate container.
+		log.Printf("cleanup: removing orphaned container %s (skiff %s status: %s)", name, skiffName, status)
+		_ = p.stopAndRemove(ctx, name)
+		cleaned++
+	}
+
+	return cleaned, nil
+}
+
 // Info returns runtime metadata including the podman version.
 func (p *PodmanRuntime) Info(ctx context.Context) (RuntimeInfo, error) {
 	out, err := p.run(ctx, "version", "--format", "json")

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -71,6 +71,12 @@ type Runtime interface {
 
 	// Info returns runtime metadata (type, version, etc.).
 	Info(ctx context.Context) (RuntimeInfo, error)
+
+	// CleanupOrphanedContainers finds and removes containers matching the
+	// given name prefix (e.g., "gate-") whose corresponding partner container
+	// is gone. For "gate-" prefix, it checks whether the matching "skiff-"
+	// container still exists. Returns the count of cleaned-up containers.
+	CleanupOrphanedContainers(ctx context.Context, prefix string) (int, error)
 }
 
 // RuntimeInfo describes the container runtime.


### PR DESCRIPTION
## Summary
- Gate sidecar containers kept running after Skiff sessions completed, accumulating over time and exhausting the kernel keyctl quota
- Add status handler cleanup: 5-second grace period for log flushing, then stop+remove Gate
- Add reconcile loop sweep: every 2 minutes, find gate-* containers whose skiff-* is gone and clean them up
- Handles both new sessions (status handler) and pre-existing orphans (reconcile sweep)
- Implemented for Podman and Docker; Kubernetes is a no-op (native sidecar cleanup)

## Test plan
- [x] Build and all tests pass
- [x] Local test: status handler cleaned up Gate container after session completed
- [x] Local test: reconcile loop cleaned up 5 orphaned gate containers (2 real + 3 simulated)
- [x] Verified zero gate containers remaining after cleanup
- [x] Code reviewed for race conditions, log flushing safety, error handling
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)