### PR TITLE
Pass issue context to SDLC workflow agent steps

### DIFF
--- a/.alcove/workflows/feature-pipeline.yml
+++ b/.alcove/workflows/feature-pipeline.yml
@@ -16,6 +16,9 @@ workflow:
       branch: "issue-{{trigger.issue_number}}-fix"
       issue_number: "{{trigger.issue_number}}"
       repo: "bmbouter/alcove"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_body}}"
+      issue_url: "{{trigger.issue_url}}"
     outputs: [summary]
 
   - id: create-pr
@@ -44,6 +47,11 @@ workflow:
     max_iterations: 3
     inputs:
       branch: "{{steps.implement.inputs.branch}}"
+      issue_number: "{{trigger.issue_number}}"
+      repo: "bmbouter/alcove"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_body}}"
+      issue_url: "{{trigger.issue_url}}"
       ci_logs: "{{steps.await-ci.outputs.failure_logs}}"
     outputs: [summary]
 
@@ -72,6 +80,11 @@ workflow:
     max_iterations: 3
     inputs:
       branch: "{{steps.implement.inputs.branch}}"
+      issue_number: "{{trigger.issue_number}}"
+      repo: "bmbouter/alcove"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_body}}"
+      issue_url: "{{trigger.issue_url}}"
       code_feedback: "{{steps.code-review.outputs.comments}}"
       security_feedback: "{{steps.security-review.outputs.comments}}"
     outputs: [summary]


### PR DESCRIPTION
## Summary

Add `issue_title`, `issue_body`, and `issue_url` trigger context inputs to the implement, ci-fix, and revision workflow steps. Without these, the agent had no way to know what the issue was about.

Matches the working pattern from bmbouter/alcove-testing's sdlc-pipeline.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)