### PR TITLE
Add dev container support and multi-repo cloning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           done
 
           # Build server components for Linux AMD64 (existing pattern)
-          for cmd in bridge gate skiff-init debug-env; do
+          for cmd in bridge gate skiff-init debug-env shim; do
             echo "Building ${cmd}..."
             CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
               go build -ldflags="-s -w -X main.Version=${VERSION}" \
@@ -149,6 +149,7 @@ jobs:
             dist/alcove-gate-linux-amd64
             dist/alcove-skiff-init-linux-amd64
             dist/alcove-debug-env-linux-amd64
+            dist/alcove-shim-linux-amd64
             dist/alcove-linux-amd64
             dist/alcove-linux-arm64
             dist/alcove-darwin-amd64

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ a complete session transcript. No persistent state crosses session boundaries.
 | **Bridge** | Controller, REST API, dashboard, scheduler, agent repo syncer | `cmd/bridge` | Deployment |
 | **Skiff** | Ephemeral Claude Code worker | `cmd/skiff-init` | Job / `podman run --rm` / `docker run --rm` |
 | **Gate** | Auth proxy sidecar (token swap, LLM proxy, SCM proxy, scope enforcement) | `cmd/gate` | Sidecar in Skiff pod |
+| **Shim** | Execution sidecar injected into dev containers (`GET /healthz`, `POST /exec` with NDJSON streaming) | `cmd/shim` | Sidecar in dev container |
 | **Hail** | Message bus (NATS) | external | Deployment |
 | **Ledger** | Session store (PostgreSQL) | external | Deployment + PVC |
 
@@ -22,12 +23,14 @@ a complete session transcript. No persistent state crosses session boundaries.
 
 ```
 Bridge → Hail (NATS) → Skiff Pod [skiff container + gate sidecar] → Gate → External Services
-                                                                  → Ledger (PostgreSQL)
+                                ↕ /workspace volume (optional)              → Ledger (PostgreSQL)
+                        Dev Container [project image + shim]
 ```
 
 - Skiff pods are ephemeral: one session, one container, then destroyed
 - Gate is a sidecar (shares network namespace with Skiff)
 - Gate proxies ALL external traffic including LLM API calls (Skiff has no real credentials)
+- Optional dev container runs alongside Skiff with a shared `/workspace` volume, enabling agents to build/test code in project-specific environments; the shim binary is injected as the entrypoint
 - On OpenShift, a static `alcove-allow-internal` NetworkPolicy restricts egress (per-task NetworkPolicy is disabled due to OVN-Kubernetes DNS resolution issues); dual-network isolation (`--internal` flag) on podman; no network isolation on Docker (see Key Decisions)
 
 ## Design Documents
@@ -36,7 +39,7 @@ Read these for full context:
 
 1. `docs/design/implementation-status.md` — **START HERE** — current state, what works, what's next
 2. `docs/design/architecture.md` — component design, deployment diagrams, network isolation, roadmap
-3. `docs/design/architecture-decisions.md` — 19 resolved decisions, CLI design, config format, repo layout
+3. `docs/design/architecture-decisions.md` — 21 resolved decisions, CLI design, config format, repo layout
 4. `docs/design/problem-statement.md` — why ephemeral agents
 5. `docs/design/credential-management.md` — credential storage, encryption, OAuth2 token flow
 6. `docs/design/auth-backends.md` — auth backend design (memory, postgres, rh-identity)
@@ -112,3 +115,5 @@ podman run -d --replace --name alcove-bridge ...  # same args as dev-up
 - **YAML is the single source of truth for schedules, security profiles, and tools** — no API-based creation, update, or deletion; schedules are defined via `schedule:` in `.alcove/tasks/*.yml`; security profiles in `.alcove/security-profiles/*.yml`; tools come from catalog or builtin definitions; the API provides read-only access to synced data
 - **`alcove.yaml` for infrastructure settings** — config file search order: `ALCOVE_CONFIG_FILE` env var → `./alcove.yaml` → `/etc/alcove/alcove.yaml`; env vars always override; `database_encryption_key` is required (Bridge refuses to start without it); `make up` auto-generates the file for local dev; file is gitignored
 - **`.dev-credentials.yaml` for dev credentials** — single source of truth for local dev LLM provider and GitHub PAT; copy `.dev-credentials.yaml.example`, fill in values; `make dev-config` (run by `make up`) merges LLM settings into `alcove.yaml`; the dev-up process reads it to create API credentials in the database; file is gitignored
+- **Dev containers are optional sidecars** — agent definitions can declare `dev_container.image` to run a project-provided container alongside Skiff; Podman creates a shared workspace volume at `/workspace`, starts the dev container with the shim binary as entrypoint, and mounts the volume in both containers; the shim provides bearer-auth-protected `POST /exec` for remote command execution with NDJSON streaming; `dev_container.network_access` controls network access (`internal` default, `external` joins both networks on Podman); on Kubernetes, the dev container runs as a native sidecar with the shim copied via init container and emptyDir volumes (`SHIM_IMAGE` env var, `DEV_CONTAINER_HOST=localhost:9090`); Docker rejects dev containers with a clear error; `SHIM_BIN_PATH` env var tells Bridge where to find the host shim binary (Podman); `--security-opt label=disable` and `:z` mount flag handle SELinux compatibility; see architecture decision #20 in `docs/design/architecture-decisions.md` for the full design
+- **Multi-repo support** — agent definitions use `repos:` (a list of `RepoSpec` with `name`, `url`, `ref` fields) instead of a single `repo:` string; Skiff receives a `REPOS` JSON env var and clones each repo into `/workspace/<name>/`; database migration `031_multi_repo.sql` replaces the `repo TEXT` column with `repos JSONB`; see architecture decision #21 in `docs/design/architecture-decisions.md` for the full design

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ IMAGES       := bridge gate skiff-base
 GO       := go
 PODMAN   := podman
 
-CMDS     := bridge gate skiff-init alcove debug-env
+CMDS     := bridge gate skiff-init alcove debug-env shim
 
 # Stamp directory for image build tracking
 STAMP_DIR := .stamps
@@ -41,7 +41,11 @@ build: ## Build all Go binaries locally
 	@mkdir -p $(BINDIR)
 	@for cmd in $(CMDS); do \
 		echo "Building $$cmd..."; \
-		$(GO) build $(LDFLAGS) -o $(BINDIR)/$$cmd ./cmd/$$cmd; \
+		if [ "$$cmd" = "shim" ]; then \
+			CGO_ENABLED=0 $(GO) build $(LDFLAGS) -o $(BINDIR)/$$cmd ./cmd/$$cmd; \
+		else \
+			$(GO) build $(LDFLAGS) -o $(BINDIR)/$$cmd ./cmd/$$cmd; \
+		fi; \
 	done
 	@echo "Binaries written to $(BINDIR)/"
 
@@ -110,6 +114,7 @@ up: dev-config dev-infra build build-images ## Build locally and start Bridge + 
 		-e ALCOVE_EXTERNAL_NETWORK=$(EXTERNAL_NET) \
 		-e SKIFF_IMAGE=localhost/alcove-skiff-base:$(VERSION) \
 		-e GATE_IMAGE=localhost/alcove-gate:$(VERSION) \
+		-e SHIM_BIN_PATH=$(CURDIR)/$(BINDIR)/shim \
 		localhost/alcove-bridge:$(VERSION) > /dev/null
 	@sleep 2
 	@echo ""
@@ -234,6 +239,7 @@ dev-up: dev-config ## Start full containerized environment
 		-e ALCOVE_EXTERNAL_NETWORK=$(EXTERNAL_NET) \
 		-e SKIFF_IMAGE=localhost/alcove-skiff-base:$(VERSION) \
 		-e GATE_IMAGE=localhost/alcove-gate:$(VERSION) \
+		-e SHIM_BIN_PATH=$(CURDIR)/$(BINDIR)/shim \
 		localhost/alcove-bridge:$(VERSION)
 	@echo ""
 	@echo "Alcove is starting up. Fetching admin password..."

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -88,7 +88,7 @@ func main() {
 	}
 
 	// Initialize the container runtime.
-	rt, err := bridge.NewRuntime(cfg.RuntimeType)
+	rt, err := bridge.NewRuntime(cfg.RuntimeType, os.Getenv("SHIM_BIN_PATH"))
 	if err != nil {
 		log.Fatalf("initializing runtime: %v", err)
 	}

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -1,0 +1,311 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command shim runs a small HTTP server inside dev containers, providing
+// an authenticated endpoint for executing commands with streaming output.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// Version is set at build time via -ldflags.
+var Version = "dev"
+
+type shimServer struct {
+	token      string
+	maxTimeout int
+	mu         sync.Mutex // serializes command execution
+}
+
+type execRequest struct {
+	Cmd     string `json:"cmd"`
+	Timeout int    `json:"timeout"`
+}
+
+type streamLine struct {
+	Stream  string  `json:"stream"`
+	Data    string  `json:"data,omitempty"`
+	Code    *int    `json:"code,omitempty"`
+	Error   string  `json:"error,omitempty"`
+	Elapsed float64 `json:"elapsed,omitempty"`
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func (s *shimServer) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, `{"status":"ok"}`)
+	fmt.Fprint(w, "\n")
+}
+
+func (s *shimServer) handleExec(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// Auth check
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer "+s.token {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	// Parse request body
+	var req execRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	if req.Cmd == "" {
+		writeError(w, http.StatusBadRequest, "cmd is required")
+		return
+	}
+
+	timeout := req.Timeout
+	if timeout <= 0 {
+		timeout = 60
+	}
+	if timeout > s.maxTimeout {
+		timeout = s.maxTimeout
+	}
+
+	// Serialize command execution
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Set up streaming response
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.WriteHeader(http.StatusOK)
+
+	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", req.Cmd)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 5 * time.Second
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "stdout pipe: "+err.Error())
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "stderr pipe: "+err.Error())
+		return
+	}
+
+	start := time.Now()
+
+	if err := cmd.Start(); err != nil {
+		writeError(w, http.StatusInternalServerError, "start: "+err.Error())
+		return
+	}
+
+	var writeMu sync.Mutex
+	clientGone := false
+
+	writeLine := func(line streamLine) bool {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		if clientGone {
+			return false
+		}
+		data, _ := json.Marshal(line)
+		data = append(data, '\n')
+		_, writeErr := w.Write(data)
+		if writeErr != nil {
+			clientGone = true
+			cancel()
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Stream stdout
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 4096)
+		for {
+			n, err := stdout.Read(buf)
+			if n > 0 {
+				if !writeLine(streamLine{Stream: "stdout", Data: string(buf[:n])}) {
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// Stream stderr
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 4096)
+		for {
+			n, err := stderr.Read(buf)
+			if n > 0 {
+				if !writeLine(streamLine{Stream: "stderr", Data: string(buf[:n])}) {
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	waitErr := cmd.Wait()
+	elapsed := time.Since(start).Seconds()
+
+	if waitErr != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			writeLine(streamLine{
+				Stream:  "exit",
+				Code:    intPtr(-1),
+				Error:   fmt.Sprintf("timeout after %ds", timeout),
+				Elapsed: elapsed,
+			})
+			return
+		}
+		// Try to extract exit code
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
+			writeLine(streamLine{
+				Stream:  "exit",
+				Code:    intPtr(exitErr.ExitCode()),
+				Elapsed: elapsed,
+			})
+			return
+		}
+		// Unknown error
+		writeLine(streamLine{
+			Stream:  "exit",
+			Code:    intPtr(-1),
+			Error:   waitErr.Error(),
+			Elapsed: elapsed,
+		})
+		return
+	}
+
+	writeLine(streamLine{
+		Stream:  "exit",
+		Code:    intPtr(0),
+		Elapsed: elapsed,
+	})
+}
+
+func writeError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+func newMux(s *shimServer) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.handleHealthz)
+	mux.HandleFunc("/exec", s.handleExec)
+	return mux
+}
+
+func main() {
+	token := os.Getenv("SHIM_TOKEN")
+	if token == "" {
+		log.Fatal("SHIM_TOKEN is required")
+	}
+
+	port := os.Getenv("SHIM_PORT")
+	if port == "" {
+		port = "9090"
+	}
+
+	maxTimeout := 600
+	if v := os.Getenv("SHIM_MAX_TIMEOUT"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			log.Fatalf("invalid SHIM_MAX_TIMEOUT: %v", err)
+		}
+		maxTimeout = n
+	}
+
+	s := &shimServer{
+		token:      token,
+		maxTimeout: maxTimeout,
+	}
+
+	srv := &http.Server{
+		Addr:         ":" + port,
+		Handler:      newMux(s),
+		WriteTimeout: 0, // streaming needs no write deadline
+	}
+
+	// Graceful shutdown
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
+
+	go func() {
+		log.Printf("shim %s listening on :%s (maxTimeout=%d)", Version, port, maxTimeout)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("server error: %v", err)
+		}
+	}()
+
+	<-stop
+	log.Println("shutting down...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("shutdown error: %v", err)
+	}
+	log.Println("stopped")
+}

--- a/cmd/shim/main_test.go
+++ b/cmd/shim/main_test.go
@@ -1,0 +1,343 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const testToken = "test-secret-token"
+
+func newTestServer() *shimServer {
+	return &shimServer{token: testToken, maxTimeout: 600}
+}
+
+func newTestMux(s *shimServer) http.Handler {
+	return newMux(s)
+}
+
+// execAndCollect performs a POST /exec request and collects all NDJSON lines.
+func execAndCollect(t *testing.T, mux http.Handler, body string) (*http.Response, []streamLine) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	resp := w.Result()
+
+	var lines []streamLine
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		var sl streamLine
+		if err := json.Unmarshal([]byte(line), &sl); err != nil {
+			t.Fatalf("failed to parse NDJSON line %q: %v", line, err)
+		}
+		lines = append(lines, sl)
+	}
+	return resp, lines
+}
+
+func TestHealthz(t *testing.T) {
+	s := newTestServer()
+	mux := newTestMux(s)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if result["status"] != "ok" {
+		t.Fatalf("expected status ok, got %q", result["status"])
+	}
+}
+
+func TestExecValidCommand(t *testing.T) {
+	s := newTestServer()
+	mux := newTestMux(s)
+
+	_, lines := execAndCollect(t, mux, `{"cmd":"echo hello"}`)
+
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %d", len(lines))
+	}
+
+	// Find stdout line
+	foundStdout := false
+	for _, l := range lines {
+		if l.Stream == "stdout" && strings.Contains(l.Data, "hello") {
+			foundStdout = true
+		}
+	}
+	if !foundStdout {
+		t.Fatal("expected stdout line containing 'hello'")
+	}
+
+	// Last line should be exit
+	last := lines[len(lines)-1]
+	if last.Stream != "exit" {
+		t.Fatalf("expected last line stream=exit, got %q", last.Stream)
+	}
+	if last.Code == nil || *last.Code != 0 {
+		t.Fatalf("expected exit code 0, got %v", last.Code)
+	}
+}
+
+func TestExecUnauthorized(t *testing.T) {
+	s := newTestServer()
+	mux := newTestMux(s)
+
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(`{"cmd":"echo hi"}`))
+	// No auth header
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestExecInvalidJSON(t *testing.T) {
+	s := newTestServer()
+	mux := newTestMux(s)
+
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(`{bad json`))
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestExecTimeout(t *testing.T) {
+	s := &shimServer{token: testToken, maxTimeout: 5}
+	mux := newTestMux(s)
+
+	start := time.Now()
+	_, lines := execAndCollect(t, mux, `{"cmd":"sleep 10","timeout":1}`)
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("timeout took too long: %v", elapsed)
+	}
+
+	last := lines[len(lines)-1]
+	if last.Stream != "exit" {
+		t.Fatalf("expected exit stream, got %q", last.Stream)
+	}
+	if last.Code == nil || *last.Code != -1 {
+		t.Fatalf("expected exit code -1, got %v", last.Code)
+	}
+	if !strings.Contains(last.Error, "timeout") {
+		t.Fatalf("expected timeout error, got %q", last.Error)
+	}
+}
+
+func TestExecFailingCommand(t *testing.T) {
+	s := newTestServer()
+	mux := newTestMux(s)
+
+	_, lines := execAndCollect(t, mux, `{"cmd":"exit 42"}`)
+
+	last := lines[len(lines)-1]
+	if last.Stream != "exit" {
+		t.Fatalf("expected exit stream, got %q", last.Stream)
+	}
+	if last.Code == nil || *last.Code != 42 {
+		t.Fatalf("expected exit code 42, got %v", last.Code)
+	}
+}
+
+func TestExecConcurrentSerialized(t *testing.T) {
+	s := newTestServer()
+	mux := newTestMux(s)
+
+	start := time.Now()
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(`{"cmd":"sleep 0.3"}`))
+			req.Header.Set("Authorization", "Bearer "+testToken)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+		}()
+	}
+
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("expected serialized execution >= 500ms, got %v", elapsed)
+	}
+}
+
+func TestExecMissingCmd(t *testing.T) {
+	s := newTestServer()
+	mux := newTestMux(s)
+
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(`{"cmd":""}`))
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestExecWrongMethod(t *testing.T) {
+	s := newTestServer()
+	mux := newTestMux(s)
+
+	req := httptest.NewRequest(http.MethodGet, "/exec", nil)
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestExecWrongToken(t *testing.T) {
+	s := newTestServer()
+	mux := newTestMux(s)
+
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(`{"cmd":"echo hi"}`))
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestExecDefaultTimeout(t *testing.T) {
+	s := newTestServer()
+	mux := newTestMux(s)
+
+	// Omit timeout, command should run with default (60s)
+	_, lines := execAndCollect(t, mux, `{"cmd":"echo default"}`)
+
+	foundStdout := false
+	for _, l := range lines {
+		if l.Stream == "stdout" && strings.Contains(l.Data, "default") {
+			foundStdout = true
+		}
+	}
+	if !foundStdout {
+		t.Fatal("expected stdout line containing 'default'")
+	}
+
+	last := lines[len(lines)-1]
+	if last.Code == nil || *last.Code != 0 {
+		t.Fatalf("expected exit code 0, got %v", last.Code)
+	}
+}
+
+func TestExecTimeoutClamped(t *testing.T) {
+	s := &shimServer{token: testToken, maxTimeout: 2}
+	mux := newTestMux(s)
+
+	start := time.Now()
+	_, lines := execAndCollect(t, mux, `{"cmd":"sleep 10","timeout":9999}`)
+	elapsed := time.Since(start)
+
+	// Should be killed at ~2s, not 9999s
+	if elapsed > 5*time.Second {
+		t.Fatalf("expected clamped timeout ~2s, took %v", elapsed)
+	}
+
+	last := lines[len(lines)-1]
+	if last.Code == nil || *last.Code != -1 {
+		t.Fatalf("expected exit code -1, got %v", last.Code)
+	}
+	if !strings.Contains(last.Error, "timeout") {
+		t.Fatalf("expected timeout error, got %q", last.Error)
+	}
+}
+
+func TestExecMixedOutput(t *testing.T) {
+	s := newTestServer()
+	mux := newTestMux(s)
+
+	_, lines := execAndCollect(t, mux, `{"cmd":"echo out && echo err >&2 && echo out2"}`)
+
+	foundStdout := false
+	foundStderr := false
+	for _, l := range lines {
+		if l.Stream == "stdout" {
+			foundStdout = true
+		}
+		if l.Stream == "stderr" {
+			foundStderr = true
+		}
+	}
+	if !foundStdout {
+		t.Fatal("expected stdout stream")
+	}
+	if !foundStderr {
+		t.Fatal("expected stderr stream")
+	}
+}
+
+func TestExecStderr(t *testing.T) {
+	s := newTestServer()
+	mux := newTestMux(s)
+
+	_, lines := execAndCollect(t, mux, `{"cmd":"echo errout >&2"}`)
+
+	foundStderr := false
+	for _, l := range lines {
+		if l.Stream == "stderr" && strings.Contains(l.Data, "errout") {
+			foundStderr = true
+		}
+	}
+	if !foundStderr {
+		t.Fatal("expected stderr line containing 'errout'")
+	}
+
+	last := lines[len(lines)-1]
+	if last.Stream != "exit" {
+		t.Fatalf("expected exit stream, got %q", last.Stream)
+	}
+	if last.Code == nil || *last.Code != 0 {
+		t.Fatalf("expected exit code 0, got %v", last.Code)
+	}
+}

--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -69,8 +69,6 @@ func main() {
 	if prompt == "" && os.Getenv("ALCOVE_EXECUTABLE") == "" {
 		log.Fatal("required environment variable PROMPT is not set")
 	}
-	repo := os.Getenv("REPO")
-	branch := os.Getenv("BRANCH")
 	provider := envOrDefault("PROVIDER", "anthropic")
 	model := os.Getenv("CLAUDE_MODEL")
 	budgetStr := os.Getenv("TASK_BUDGET")
@@ -88,18 +86,28 @@ func main() {
 
 	heartbeatTimeout := parseDuration(os.Getenv("HEARTBEAT_TIMEOUT"), defaultHeartbeatTimeout)
 
+	var repos []internal.RepoSpec
+	if reposJSON := os.Getenv("REPOS"); reposJSON != "" {
+		if err := json.Unmarshal([]byte(reposJSON), &repos); err != nil {
+			log.Fatalf("invalid REPOS JSON: %v", err)
+		}
+	}
+
 	task := internal.Task{
 		ID:       taskID,
 		Prompt:   prompt,
-		Repo:     repo,
-		Branch:   branch,
+		Repos:    repos,
 		Provider: provider,
 		Model:    model,
 		Budget:   budget,
 		Timeout:  time.Duration(timeoutSecs) * time.Second,
 	}
 
-	log.Printf("task %s received: prompt=%q repo=%s", task.ID, truncate(task.Prompt, 60), task.Repo)
+	repoDisplay := ""
+	if len(task.Repos) > 0 {
+		repoDisplay = task.Repos[0].URL
+	}
+	log.Printf("task %s received: prompt=%q repo=%s", task.ID, truncate(task.Prompt, 60), repoDisplay)
 
 	// --- Connect to NATS (Hail) for status updates and cancellation ---
 	hailURL := envOrDefault("HAIL_URL", "nats://localhost:4222")
@@ -145,11 +153,29 @@ func main() {
 	// --- Set up environment ---
 	setupEnv(task)
 
-	// --- Clone repo if specified ---
-	if task.Repo != "" {
-		if err := cloneRepo(task.Repo, task.Branch); err != nil {
-			log.Printf("warning: repo clone failed: %v", err)
+	// --- Clone repos if specified ---
+	if len(task.Repos) > 0 {
+		for i, r := range task.Repos {
+			dir := r.Name
+			if dir == "" {
+				dir = repoNameFromURL(r.URL)
+			}
+			// Single repo: clone directly into /workspace.
+			// Multiple repos: clone into /workspace/<name>.
+			var target string
+			if len(task.Repos) == 1 {
+				target = "/workspace"
+			} else {
+				target = filepath.Join("/workspace", dir)
+			}
+			if err := cloneRepoToDir(r.URL, r.Ref, target); err != nil {
+				log.Printf("warning: repo clone failed for %s: %v", r.URL, err)
+				continue
+			}
+			log.Printf("cloned repo %d/%d: %s -> %s", i+1, len(task.Repos), r.URL, target)
 		}
+		// Set CWD: single repo -> /workspace, multi -> /workspace
+		os.Chdir("/workspace")
 	}
 
 	// --- Install lola modules (must run after cloneRepo so cwd is correct) ---
@@ -987,18 +1013,22 @@ func installPlugins() {
 	}
 }
 
-// cloneRepo performs a shallow clone of the given repo.
-func cloneRepo(repo, branch string) error {
-	// Mark /workspace as safe to avoid "dubious ownership" errors when the
+// cloneRepoToDir performs a shallow clone of the given repo into the specified directory.
+func cloneRepoToDir(repo, ref, targetDir string) error {
+	if err := os.MkdirAll(filepath.Dir(targetDir), 0755); err != nil {
+		return fmt.Errorf("creating parent dir for %s: %w", targetDir, err)
+	}
+
+	// Mark the target directory as safe to avoid "dubious ownership" errors when the
 	// directory is owned by a different UID (e.g., root-created in the image).
-	safeDir := exec.Command("git", "config", "--global", "--add", "safe.directory", "/workspace")
+	safeDir := exec.Command("git", "config", "--global", "--add", "safe.directory", targetDir)
 	safeDir.Run()
 
 	args := []string{"clone", "--depth=1"}
-	if branch != "" {
-		args = append(args, "--branch", branch)
+	if ref != "" {
+		args = append(args, "--branch", ref)
 	}
-	args = append(args, repo, "/workspace")
+	args = append(args, repo, targetDir)
 
 	cmd := exec.Command("git", args...)
 	cmd.Stdout = os.Stdout
@@ -1007,7 +1037,14 @@ func cloneRepo(repo, branch string) error {
 		return fmt.Errorf("git clone %s: %w", repo, err)
 	}
 
-	return os.Chdir("/workspace")
+	return nil
+}
+
+// repoNameFromURL derives a short repo name from a URL by taking the
+// basename and stripping any ".git" suffix.
+func repoNameFromURL(rawURL string) string {
+	base := filepath.Base(strings.TrimRight(rawURL, "/"))
+	return strings.TrimSuffix(base, ".git")
 }
 
 // requireEnv returns the value of an environment variable or exits fatally.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,8 @@ can also be set in `alcove.yaml` (see [alcove.yaml](#alcoveyaml) above).
 | `SKIFF_HAIL_URL` | string | `nats://alcove-hail:4222` | NATS URL injected into Skiff containers (may differ from Bridge's own `HAIL_URL`). |
 | `ALCOVE_SKILL_REPOS` | string (JSON) | _(unset)_ | JSON array of skill repo objects. Overrides database-configured skill repos. Each object has `url` (required), `ref` (optional, default `main`), and `name` (optional). |
 | `AGENT_REPO_SYNC_INTERVAL` | string (duration) | `15m` | How often Bridge syncs YAML agent definitions from registered agent repos. Accepts Go duration syntax. Manual sync available via API or dashboard "Sync Now" button. |
+| `SHIM_BIN_PATH` | string | `./bin/shim` | Host path to the shim binary. When a dev container is configured on Podman, Bridge volume-mounts this binary into the dev container as its entrypoint. |
+| `SHIM_IMAGE` | string | `ghcr.io/bmbouter/alcove-shim:latest` | Container image for the shim init container. Used on Kubernetes to copy the shim binary into the dev container pod via an init container. |
 | `BRIDGE_LLM_PROVIDER` | string | _(unset)_ | System LLM provider: `anthropic`, `google-vertex`, or `claude-oauth`. Overrides `system_llm.provider` in alcove.yaml. |
 | `BRIDGE_LLM_API_KEY` | string | _(unset)_ | Anthropic API key for the system LLM. Overrides `system_llm.api_key` in alcove.yaml. |
 | `BRIDGE_LLM_OAUTH_TOKEN` | string | _(unset)_ | Claude Pro/Max OAuth token for the system LLM (for `claude-oauth` provider). Overrides `system_llm.oauth_token` in alcove.yaml. |
@@ -214,7 +216,8 @@ Skiff is the ephemeral worker container (`cmd/skiff-init`). These variables are
 | `TASK_ID` | string | _(required)_ | Unique identifier for the task. |
 | `SESSION_ID` | string | value of `TASK_ID` | Session identifier. Defaults to the task ID if not set separately. |
 | `PROMPT` | string | _(required)_ | The natural-language prompt sent to Claude Code. |
-| `REPO` | string | _(unset)_ | Git repository URL to clone into the workspace. |
+| `REPOS` | string (JSON) | _(unset)_ | JSON array of `RepoSpec` objects (`[{"name":"...","url":"...","ref":"..."}]`). Each repo is cloned into `/workspace/<name>/`. |
+| `REPO` | string | _(unset)_ | Git repository URL to clone into the workspace (legacy; `REPOS` takes precedence). |
 | `BRANCH` | string | _(unset)_ | Branch to check out after cloning. |
 | `PROVIDER` | string | `anthropic` | LLM provider name. |
 | `CLAUDE_MODEL` | string | _(unset)_ | Model override passed to `claude --model`. |
@@ -231,6 +234,8 @@ Skiff is the ephemeral worker container (`cmd/skiff-init`). These variables are
 | `ANTHROPIC_API_KEY` | string | `sk-placeholder-routed-through-gate` | Placeholder key that satisfies Claude Code validation. Real key is held by Gate. |
 | `ALCOVE_SKILL_REPOS` | string (JSON) | _(injected)_ | JSON array of skill repo objects. Skiff clones each repo and passes them to Claude Code via `--plugin-dir` flags. |
 | `ALCOVE_PLUGINS` | string (JSON) | _(injected)_ | JSON array of plugin specs from the agent definition. Skiff installs each plugin at startup (marketplace, official, or git-sourced). |
+| `DEV_TOKEN` | string | _(injected)_ | Bearer token for authenticating with the dev container's shim. Set only when `dev_container` is configured. |
+| `DEV_CONTAINER_HOST` | string | _(injected)_ | Hostname and port of the dev container's shim (e.g., `dev-<taskID>:9090`). Set only when `dev_container` is configured. |
 
 The following SCM-related environment variables are injected by Bridge when the
 task's scope includes a `github` or `gitlab` service. They configure the `gh`
@@ -644,7 +649,10 @@ Repos that haven't changed since the last sync are skipped. Each YAML file defin
 name: run-tests
 prompt: |
   Run the full test suite and fix any failures.
-repo: https://github.com/org/myproject.git
+repos:
+  - name: myproject
+    url: https://github.com/org/myproject.git
+    ref: main
 provider: anthropic
 model: claude-sonnet-4-20250514
 timeout: 1800
@@ -669,7 +677,8 @@ schedule: "0 2 * * *"
 |-------------|----------|----------|-------------|
 | `name`      | string   | yes      | Unique agent name |
 | `prompt`    | string   | yes      | The agent instruction |
-| `repo`      | string   | no       | Git repository URL to clone |
+| `repos`     | RepoSpec[] | no     | List of git repositories to clone (see [RepoSpec](#repospec) below) |
+| `repo`      | string   | no       | Git repository URL to clone (legacy; converted to single-element `repos` list) |
 | `provider`  | string   | no       | LLM provider name |
 | `model`     | string   | no       | Model override |
 | `timeout`   | int      | no       | Timeout in seconds |
@@ -679,6 +688,7 @@ schedule: "0 2 * * *"
 | `plugins`   | PluginSpec[] | no   | Claude Code plugins to install (see [Plugins](#plugins)) |
 | `credentials` | map[string]string | no | Environment variable names to credential provider mappings (see [Credentials](#credentials)) |
 | `direct_outbound` | bool | no | Allow direct outbound connections bypassing Gate proxy (default `false`) |
+| `dev_container` | object | no | Dev container sidecar configuration (see [Dev Containers](#dev-containers)) |
 | `schedule`  | string   | no       | Cron expression for automatic execution |
 | `labels`    | string[] | no       | GitHub issue/PR labels for event filtering (see below) |
 | `users`     | string[] | no       | GitHub usernames for event filtering (see below) |
@@ -700,6 +710,67 @@ On Kubernetes, the cluster administrator must deploy the
 `alcove-allow-direct-outbound` NetworkPolicy before using this feature. Without
 it, pods with `direct_outbound: true` will still be subject to the default
 per-task NetworkPolicy that restricts egress.
+
+### Dev Containers
+
+Agent definitions can declare an optional `dev_container` block to run a
+project-provided container alongside Skiff. This lets agents build, test, and
+lint code in a project-specific environment without bloating the Skiff base
+image.
+
+```yaml
+name: go-developer
+prompt: |
+  Implement the feature and run tests before pushing.
+repos:
+  - url: https://github.com/org/myproject.git
+dev_container:
+  image: golang:1.25
+  network_access: internal
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `dev_container.image` | string | yes (if block present) | Container image for the dev container |
+| `dev_container.network_access` | string | no | Network access level: `internal` (default, no internet) or `external` (internet access) |
+
+### RepoSpec
+
+Each entry in the `repos` list is a `RepoSpec` object:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | no | Directory name under `/workspace/`. Derived from URL if omitted. |
+| `url`  | string | yes | Git repository URL to clone |
+| `ref`  | string | no | Branch, tag, or commit to check out (default: repo default branch) |
+
+Skiff clones each repo into `/workspace/<name>/`. If a single `repo:` string
+is provided (legacy), it is converted to a single-element `repos` list
+internally. The `REPOS` JSON env var is injected into Skiff with the full list.
+
+**How it works:**
+
+- Podman creates a shared workspace volume and mounts it at `/workspace` in both
+  Skiff and the dev container.
+- The shim binary (`cmd/shim`) is volume-mounted into the dev container from the
+  host (`SHIM_BIN_PATH`, default `./bin/shim`) with `:ro,z` flags and used as
+  the entrypoint. `--security-opt label=disable` is set on the dev container
+  for SELinux compatibility.
+- The shim exposes `GET /healthz` and `POST /exec` (NDJSON streaming) on port
+  9090, protected by bearer auth (`SHIM_TOKEN`).
+- Bridge generates a random `SHIM_TOKEN` and passes it to the dev container. Skiff
+  receives `DEV_TOKEN` (same value) and `DEV_CONTAINER_HOST` (hostname:port).
+- When `network_access` is `internal` (default), the dev container runs on the
+  internal network only (no external access). When `external`, it joins both
+  the internal and external networks on Podman, giving it internet access.
+
+**Runtime support:**
+
+| Runtime | Behavior |
+|---------|----------|
+| **Podman** | Full support. Workspace volume, shim injection, `network_access` controls network. |
+| **Docker** | Not supported. Bridge returns an error if `dev_container` is set. |
+| **Kubernetes** | Full support. Dev container as native sidecar, shim copied via init container (`SHIM_IMAGE`), emptyDir volumes, `DEV_CONTAINER_HOST=localhost:9090`. `network_access=external` is logged as a warning since all containers in a Pod share the same network namespace. |
 
 ### Event Delivery Mode
 
@@ -732,7 +803,8 @@ triggering automated development tasks.
 name: auto-fix
 prompt: |
   Investigate and fix the issue described above.
-repo: https://github.com/org/myproject.git
+repos:
+  - url: https://github.com/org/myproject.git
 trigger:
   github:
     events: [issues]
@@ -756,7 +828,8 @@ session dispatch to trusted users.
 name: auto-fix
 prompt: |
   Investigate and fix the issue described above.
-repo: https://github.com/org/myproject.git
+repos:
+  - url: https://github.com/org/myproject.git
 trigger:
   github:
     events: [issues, issue_comment]
@@ -976,6 +1049,7 @@ review/revision patterns.
 | `max_iterations` | int | no | `1` | Maximum times this step can execute (1 = no revisiting) |
 | `max_retries` | int | no | `0` | Maximum retry count on failure |
 | `inputs` | map | no | — | Key-value inputs passed to the step |
+| `repos` | RepoSpec[] | no | — | Override repos for this step (same format as agent-level `repos`) |
 | `credentials` | map[string]string | no | — | Env var to credential provider mappings; merges with agent credentials (step overrides agent) |
 | `direct_outbound` | bool | no | `false` | Allow direct outbound connections bypassing Gate proxy |
 

--- a/docs/design/architecture-decisions.md
+++ b/docs/design/architecture-decisions.md
@@ -330,6 +330,74 @@ eliminates prompt engineering fragility and makes workflows auditable. Bounded
 cycles enable practical review/revision patterns without risking infinite loops.
 
 
+### 20. Dev Containers with Execution Shim
+
+**Decision**: Agent definitions can optionally declare a `dev_container.image`
+to run a project-provided container alongside Skiff. A shared volume at
+`/workspace` is mounted in both containers. A small Go HTTP server (the shim,
+`cmd/shim`) is injected into the dev container as its entrypoint.
+
+**How it works**:
+- Podman creates a workspace volume, starts the dev container with the shim
+  binary volume-mounted as `/usr/local/bin/alcove-shim` (with `:ro,z` for
+  SELinux compatibility), and uses it as the entrypoint.
+  `--security-opt label=disable` is set on the dev container to avoid
+  SELinux label conflicts with the shared workspace volume.
+- The shim serves `GET /healthz` and `POST /exec` (bearer auth via
+  `SHIM_TOKEN`), streaming stdout/stderr as NDJSON.
+- The dispatcher generates a random `SHIM_TOKEN` and passes it to both the
+  dev container and Skiff (as `DEV_TOKEN`). Skiff also receives
+  `DEV_CONTAINER_HOST` pointing to the dev container's hostname and port.
+- `dev_container.network_access` controls network access: `internal`
+  (default) restricts the dev container to the internal network only;
+  `external` joins both internal and external networks on Podman, giving
+  the dev container internet access (e.g., for `pip install` or `npm install`).
+  On Kubernetes, `external` is logged as a warning since all containers in a
+  Pod share the same network namespace.
+- On Kubernetes, the dev container runs as a native sidecar (init container
+  with `restartPolicy: Always`). The shim binary is copied into the pod via
+  an init container using the `SHIM_IMAGE` container image and shared
+  emptyDir volumes. `DEV_CONTAINER_HOST` is overridden to `localhost:9090`
+  since K8s pod containers share a network namespace.
+- Docker rejects dev containers with a clear error (`RUNTIME=docker`).
+- The shim binary is built with `CGO_ENABLED=0` for static linking and
+  `SHIM_BIN_PATH` tells Bridge where to find it on the host (Podman).
+  `SHIM_IMAGE` tells Bridge which container image to use for the shim init
+  container (Kubernetes).
+
+**Rationale**: Agents need to build and test code in project-specific
+environments (e.g., a Go project needs `go build`, a Python project needs
+`pip install`). Running these tools inside Skiff would bloat the base image
+and create security surface. A separate container with the project's own
+image keeps Skiff minimal and lets each project define its own toolchain.
+The shim injection pattern means dev container images do not need any
+Alcove-specific tooling pre-installed.
+
+### 21. Multi-Repo Support
+
+**Decision**: Agent definitions support a `repos:` list (each entry is a
+`RepoSpec` with `name`, `url`, and optional `ref` fields) instead of a
+single `repo:` string. Skiff clones each repo into `/workspace/<name>/`.
+
+**How it works**:
+- The `repos:` field in YAML agent definitions is a list of objects:
+  `{name: "myapp", url: "https://github.com/org/myapp.git", ref: "main"}`.
+- If `name` is omitted, it is derived from the repository URL (last path
+  segment without `.git`).
+- The dispatcher serializes the list as a `REPOS` JSON env var for Skiff.
+- Skiff clones each repo into `/workspace/<name>/`.
+- Database migration `031_multi_repo.sql` replaces `repo TEXT` with
+  `repos JSONB` on both `sessions` and `schedules` tables, migrating
+  existing single-repo data into the new format.
+- The old `repo:` string field is still accepted in YAML and is converted
+  to a single-element `repos` list internally.
+
+**Rationale**: Many development tasks span multiple repositories (e.g., an
+application and its shared library). Supporting multiple repos per session
+lets agents work across repo boundaries without manual workarounds. The
+`/workspace/<name>/` layout keeps each clone isolated and predictable.
+
+
 ## CLI Design
 
 ### Phase 1 Commands
@@ -428,6 +496,7 @@ alcove/
 ├── cmd/
 │   ├── bridge/         # Controller binary
 │   ├── gate/           # Authorization proxy binary
+│   ├── shim/           # Dev container execution sidecar binary
 │   └── skiff-init/     # Skiff init process binary
 ├── internal/
 │   ├── runtime/        # KubeRuntime + PodmanRuntime + DockerRuntime

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -43,7 +43,8 @@ schedules:
   - name: nightly-dependency-audit
     cron: "0 2 * * *"                # 2 AM daily
     prompt: "Audit dependencies in pulp-service for known CVEs. Open a PR if updates are needed."
-    repo: https://github.com/pulp/pulp-service
+    repos:
+      - url: https://github.com/pulp/pulp-service
     scope_preset: security-audit     # predefined scope (clone + read + create_pr_draft)
     provider: vertex-ai
     timeout: 30m
@@ -51,7 +52,8 @@ schedules:
   - name: weekly-docs-sync
     cron: "0 9 * * 1"                # Monday 9 AM
     prompt: "Check if any CLI flags were added in the last week and update the docs."
-    repo: https://github.com/pulp/pulp-service
+    repos:
+      - url: https://github.com/pulp/pulp-service
     scope_preset: docs-update
     provider: vertex-ai
     timeout: 45m
@@ -102,6 +104,17 @@ The Skiff image is built with:
 - A git credential helper that routes authentication through Gate
 - **Puppeteer for wireframe generation** — enables planning agents to create
   UI wireframes as HTML files and capture screenshots for GitHub issue posting
+
+**Dev containers** (optional): Agent definitions can declare a `dev_container.image`
+to run a project-provided container alongside Skiff. A shared volume at
+`/workspace` lets the agent write code in Skiff and build/test it in the dev
+container via the execution shim (`cmd/shim`). The shim binary is injected as
+the dev container's entrypoint and provides `POST /exec` with NDJSON streaming,
+protected by bearer auth. `dev_container.network_access` controls network access
+(`internal` default, `external` for internet access). On Podman, the shim is
+volume-mounted from the host; on Kubernetes, it is copied via an init container
+(`SHIM_IMAGE`). Dev containers support multi-repo workspaces where each repo is
+cloned into `/workspace/<name>/`.
 
 ### Gate — The Authorization Proxy
 
@@ -505,5 +518,6 @@ dispatch time. Skiff containers never hold LLM API keys.
 | Controller | **Bridge** | Deployment | Yes | Coordination, dashboard, API, scheduler |
 | Worker | **Skiff** | Job / `podman run --rm` / `docker run --rm` | No (ephemeral) | Execute Claude Code prompts |
 | Auth Proxy | **Gate** | Sidecar in Skiff pod | No (per-session) | Network sandbox, token swap, LLM proxy |
+| Exec Sidecar | **Shim** | Injected into dev container | No (per-session) | Remote command execution in dev containers |
 | Message Bus | **Hail** | Deployment (NATS) | Yes | Session dispatch, status updates |
 | Session Store | **Ledger** | Deployment + PVC | Yes | Audit trail, session history |

--- a/docs/design/implementation-status.md
+++ b/docs/design/implementation-status.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-Last updated: 2026-04-16
+Last updated: 2026-04-18
 
 ## Project Overview
 
@@ -29,10 +29,11 @@ alcove/
 │   ├── bridge/main.go          ✅ Controller: REST API, auth, session dispatch, migration, scheduling, admin settings
 │   ├── gate/main.go            ✅ HTTP proxy with scope enforcement, LLM proxying, SCM proxying (/github/, /gitlab/), token refresh, MCP tool configs
 │   ├── skiff-init/main.go      ✅ PID 1 init: reads session config from env, runs claude, streams output, publishes transcript events to NATS
+│   ├── shim/main.go            ✅ Dev container execution sidecar: GET /healthz + POST /exec with NDJSON streaming, bearer auth, timeout enforcement
 │   ├── hashpw/main.go          ✅ Utility: password hashing tool
 │   └── alcove/main.go          ✅ CLI: 8 subcommands (run, list, logs, status, cancel, login, config, version)
 ├── internal/
-│   ├── types.go                ✅ Shared types (Task, Session, Scope, TranscriptEvent, etc.)
+│   ├── types.go                ✅ Shared types (Task, Session, Scope, TranscriptEvent, RepoSpec, etc.)
 │   ├── runtime/
 │   │   ├── runtime.go          ✅ Runtime interface (RunTask, CancelTask, EnsureService, etc.) with Podman, Docker, and Kubernetes backends (RunTask starts a session)
 │   │   ├── podman.go           ✅ PodmanRuntime implementation (podman CLI wrapper)
@@ -68,7 +69,8 @@ alcove/
 │   │       ├── 027_teams.sql           ✅ Teams, team_members, team_settings tables; owner→team_id migration
 │   │       ├── 028_workflow_graph_v2.sql  ✅ Workflow run steps iteration tracking
 │   │       ├── 029_catalog_items.sql   ✅ Catalog items and team_catalog_items tables
-│   │       └── 030_session_runtime_config.sql  ✅ Session runtime configuration storage
+│   │       ├── 030_session_runtime_config.sql  ✅ Session runtime configuration storage
+│   │       └── 031_multi_repo.sql     ✅ Migrate repo TEXT → repos JSONB on sessions and schedules
 │   ├── gate/
 │   │   ├── proxy.go            ✅ HTTP proxy, CONNECT tunneling, LLM API injection (api_key + bearer + oauth_token), audit logging, 401 token refresh
 │   │   ├── proxy_test.go       ✅ Proxy tests
@@ -97,7 +99,7 @@ alcove/
 │   └── design/
 │       ├── implementation-status.md    ✅ This file
 │       ├── architecture.md             ✅ Full component design
-│       ├── architecture-decisions.md   ✅ 19 resolved decisions
+│       ├── architecture-decisions.md   ✅ 21 resolved decisions
 │       ├── problem-statement.md        ✅ Why ephemeral agents
 │       ├── credential-management.md    ✅ Credential storage and token flow design
 │       ├── auth-backends.md            ✅ Dual auth backend design
@@ -255,7 +257,7 @@ alcove/
 
 20. **YAML Agent Definitions** — Agents defined in `.alcove/tasks/*.yml` in git
     repos. Agent repo registration (system + per-user) via settings API.
-    YAML schema supports name, prompt, repo, provider, model, timeout, budget,
+    YAML schema supports name, prompt, repos, provider, model, timeout, budget,
     profiles, tools, and schedule fields. Auto-sync every 15 minutes. Dashboard
     supports Run Now and View YAML actions. Starter templates available via
     `GET /api/v1/agent-templates`.
@@ -264,13 +266,19 @@ alcove/
     implements the `Runtime` interface using direct client-go API calls (no
     operator needed). Each session runs as a k8s Job with Gate as a native sidecar
     (init container with `restartPolicy: Always`) and Skiff as the main
-    container. Per-task NetworkPolicy creation is disabled due to OVN-Kubernetes
-    DNS resolution failures; a static `alcove-allow-internal` policy provides
-    egress restriction instead. Service hostnames (HAIL_URL, LEDGER_URL) are
-    resolved to IPs at dispatch time to bypass DNS issues in task pods. Compatible
-    with OpenShift restricted-v2 SCC (runs as non-root, drops all capabilities,
-    sets `seccompProfile: RuntimeDefault`). Minimal RBAC: Bridge needs create/delete
-    permissions for Jobs and NetworkPolicies.
+    container. Dev containers are supported as native sidecars with the shim
+    binary copied via an init container (`SHIM_IMAGE`), emptyDir volumes for
+    workspace and shim binary sharing, and `DEV_CONTAINER_HOST` overridden to
+    `localhost:9090` (K8s pod containers share a network namespace).
+    `network_access=external` is logged as a warning since per-container network
+    isolation is not enforceable in a K8s Pod. Per-task NetworkPolicy creation
+    is disabled due to OVN-Kubernetes DNS resolution failures; a static
+    `alcove-allow-internal` policy provides egress restriction instead. Service
+    hostnames (HAIL_URL, LEDGER_URL) are resolved to IPs at dispatch time to
+    bypass DNS issues in task pods. Compatible with OpenShift restricted-v2 SCC
+    (runs as non-root, drops all capabilities, sets `seccompProfile:
+    RuntimeDefault`). Minimal RBAC: Bridge needs create/delete permissions for
+    Jobs and NetworkPolicies.
 
 22. **CI/CD** — GitHub Actions workflows for testing (`ci.yml`) and releasing
     (`release.yml`). Container images published to `ghcr.io/bmbouter`.
@@ -339,6 +347,31 @@ alcove/
     Iteration tracking is stored in `workflow_run_steps` (migration
     `028_workflow_graph_v2.sql`). The old `needs` list syntax remains supported
     for backward compatibility.
+
+29. **Dev Containers** — Optional project-provided containers that run alongside
+    Skiff so agents can build and test code in a project-specific environment.
+    Agent definitions declare `dev_container.image` and optionally
+    `dev_container.network_access` (`internal` default, `external` for internet
+    access) in YAML. Podman creates a shared workspace volume at `/workspace`,
+    starts the dev container with the shim binary (`cmd/shim`) injected as
+    entrypoint, and mounts the volume in both Skiff and dev containers. The
+    shim exposes `GET /healthz` and `POST /exec` with NDJSON streaming,
+    protected by bearer auth (`SHIM_TOKEN`). The dispatcher generates a random
+    `SHIM_TOKEN` and passes `DEV_TOKEN` and `DEV_CONTAINER_HOST` to Skiff.
+    On Kubernetes, the dev container runs as a native sidecar with the shim
+    binary copied via an init container (`SHIM_IMAGE`) and shared emptyDir
+    volumes; `DEV_CONTAINER_HOST` is overridden to `localhost:9090` since K8s
+    pod containers share a network namespace. Docker rejects dev containers
+    with a clear error. The shim binary is built with `CGO_ENABLED=0` for
+    static linking and is uploaded as a release asset.
+
+30. **Multi-Repo Support** — Agent definitions use a `repos:` list (each entry
+    is a `RepoSpec` with `name`, `url`, and optional `ref` fields) instead of
+    a single `repo:` string. Skiff receives a `REPOS` JSON env var containing
+    the list and clones each repo into `/workspace/<name>/`. If `name` is
+    omitted, it is derived from the URL. Database migration
+    `031_multi_repo.sql` replaces the `repo TEXT` column with `repos JSONB`
+    on both `sessions` and `schedules` tables, migrating existing data.
 
 ## How to Run (Developer Workflow)
 
@@ -411,7 +444,7 @@ See the full roadmap in [architecture-decisions.md](architecture-decisions.md#ro
 ## Key Design Documents
 
 - [architecture.md](architecture.md) — full component design, deployment diagrams, network isolation
-- [architecture-decisions.md](architecture-decisions.md) — 19 resolved decisions, CLI design, config format, repo layout, revised roadmap
+- [architecture-decisions.md](architecture-decisions.md) — 21 resolved decisions, CLI design, config format, repo layout, revised roadmap
 - [problem-statement.md](problem-statement.md) — why ephemeral agents (context contamination, credential drift, filesystem poisoning, credential exposure)
 - [credential-management.md](credential-management.md) — credential storage, encryption, OAuth2 token flow, token refresh design
 - [auth-backends.md](auth-backends.md) — auth backend design (memory, postgres, rh-identity)
@@ -458,6 +491,8 @@ See the full roadmap in [architecture-decisions.md](architecture-decisions.md#ro
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-20250514` | Default model for Anthropic provider |
 | `VERTEX_MODEL` | `claude-sonnet-4-20250514` | Default model for Vertex AI provider |
 | `BRIDGE_URL` | `http://alcove-bridge:<port>` | Bridge URL used for Gate token refresh callbacks |
+| `SHIM_BIN_PATH` | `./bin/shim` | Host path to the shim binary (Podman dev containers) |
+| `SHIM_IMAGE` | `ghcr.io/bmbouter/alcove-shim:latest` | Container image for the shim init container (K8s dev containers) |
 
 ### Skiff (injected by Bridge)
 
@@ -466,7 +501,8 @@ See the full roadmap in [architecture-decisions.md](architecture-decisions.md#ro
 | `TASK_ID` | Unique task identifier |
 | `SESSION_ID` | Session identifier for Ledger |
 | `PROMPT` | The Claude Code prompt to execute |
-| `REPO` | Git repository URL to clone (optional) |
+| `REPOS` | JSON array of RepoSpec objects for multi-repo cloning |
+| `REPO` | Git repository URL to clone (legacy; `REPOS` takes precedence) |
 | `CLAUDE_MODEL` | LLM model name |
 | `TASK_BUDGET` | Max spend in USD |
 | `TASK_TIMEOUT` | Timeout in seconds |
@@ -491,6 +527,8 @@ See the full roadmap in [architecture-decisions.md](architecture-decisions.md#ro
 | `GLAB_HOST` | GitLab host for `glab` CLI |
 | `GATE_CREDENTIAL_URL` | Gate endpoint for git credential helper |
 | `GIT_SSH_COMMAND` | Disables SSH git operations (forces HTTPS via Gate) |
+| `DEV_TOKEN` | Bearer token for authenticating with the dev container's shim (set when `dev_container` is configured) |
+| `DEV_CONTAINER_HOST` | Hostname and port of the dev container's shim (e.g., `dev-<taskID>:9090`; overridden to `localhost:9090` on K8s) |
 
 ### Gate (injected by Bridge)
 

--- a/docs/design/security-principles.md
+++ b/docs/design/security-principles.md
@@ -239,6 +239,16 @@ The five principles work together to create multiple security barriers:
 - Credential separation prevents real token exposure
 - Audit logs detect anomalous behavior
 
+**Dev Container Isolation:**
+- Dev containers default to the internal network only (no external access) via `network_access: internal`
+- When `network_access: external` is set, the dev container gains internet access (e.g., for `pip install`); this trades isolation for build-time convenience and should be used only when needed
+- On Kubernetes, `network_access: external` is logged as a warning because all containers in a Pod share the same network namespace and per-container isolation is not enforceable
+- The shim endpoint is protected by a per-session bearer token (`SHIM_TOKEN`)
+- `SHIM_TOKEN` is redacted in error messages to prevent leaking via logs
+- The shim binary is injected read-only from the host (`:ro,z` mount on Podman) or copied via init container (Kubernetes); dev container images need no Alcove-specific tooling
+- `--security-opt label=disable` is set on the dev container (Podman) to avoid SELinux label conflicts with the shared workspace volume
+- Commands execute inside the dev container's own filesystem and toolchain; the shared `/workspace` volume is the only overlap with Skiff
+
 **Container Escape:**
 - Ephemeral execution limits persistence
 - Network policies prevent external communication

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -11,6 +11,7 @@ alcove/
     alcove/          CLI client
     bridge/          Bridge controller (REST API, scheduler, dashboard)
     gate/            Gate auth proxy sidecar
+    shim/            Dev container execution sidecar (GET /healthz, POST /exec)
     skiff-init/      Skiff ephemeral worker init process
   internal/
     auth/            Authentication backends (Authenticator interface)
@@ -24,7 +25,7 @@ alcove/
     gate/            Gate proxy, scope enforcement, domain allowlist
     hail/            NATS messaging helpers
     ledger/          PostgreSQL session store helpers
-    runtime/         Runtime interface and implementations (podman, kubernetes)
+    runtime/         Runtime interface and implementations (podman, docker, kubernetes)
     types.go         Shared types (Session, Scope, TranscriptEvent, etc.)
   build/
     alcove-credential-helper  Git credential helper binary (installed in Skiff image)
@@ -45,9 +46,10 @@ All build and test operations use `make`. Run `make help` to see all targets.
 make build
 ```
 
-This compiles all four binaries (`bridge`, `gate`, `skiff-init`, `alcove`) into
-the `bin/` directory. Version information is injected via `-ldflags` from
-`git describe`.
+This compiles all binaries (`bridge`, `gate`, `skiff-init`, `alcove`, `shim`,
+etc.) into the `bin/` directory. Version information is injected via `-ldflags`
+from `git describe`. The `shim` binary is built with `CGO_ENABLED=0` for static
+linking so it can be injected into arbitrary dev container images.
 
 ### Building container images
 
@@ -215,6 +217,8 @@ Bridge reads these environment variables:
 | `BRIDGE_URL` | URL where Bridge is reachable by Skiff/Gate | `http://host.containers.internal:8080` |
 | `SKIFF_HAIL_URL` | NATS URL as seen from inside Skiff containers | `nats://host.containers.internal:4222` |
 | `AGENT_REPO_SYNC_INTERVAL` | How often Bridge syncs agent definitions from repos | `15m` (default) |
+| `SHIM_BIN_PATH` | Host path to the shim binary (injected into dev containers on Podman) | `./bin/shim` (default) |
+| `SHIM_IMAGE` | Container image for the shim init container (K8s only) | `ghcr.io/bmbouter/alcove-shim:latest` (default) |
 
 Set these as environment variables before running Bridge.
 
@@ -536,7 +540,8 @@ Agent definitions are YAML files in `.alcove/tasks/*.yml` within an agent repo:
 name: run-tests
 prompt: |
   Run the full test suite and fix any failures.
-repo: https://github.com/org/myproject.git
+repos:
+  - url: https://github.com/org/myproject.git
 provider: anthropic
 model: claude-sonnet-4-20250514
 timeout: 1800

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -448,6 +448,14 @@ Agents that need direct internet access (bypassing Gate's proxy) can opt in
 with `direct_outbound: true` in the agent definition. See
 `docs/configuration.md` for runtime-specific details.
 
+Agents that need to build or test code in a project-specific environment can
+declare a `dev_container.image` in their agent definition. This starts an
+additional container alongside Skiff with a shared `/workspace` volume and an
+execution shim for running commands remotely. Agents can also work across
+multiple repositories using the `repos:` list in their definition -- each
+repo is cloned into `/workspace/<name>/`. See `docs/configuration.md` for
+the full `dev_container` and `repos` field references.
+
 ## GitHub/GitLab/JIRA Integration
 
 Alcove can interact with GitHub, GitLab, and JIRA on behalf of your coding agent.

--- a/docs/workflow-authoring.md
+++ b/docs/workflow-authoring.md
@@ -466,6 +466,28 @@ Post your review via the GitHub API.
 Output {"approved": true} or {"approved": false, "comments": "..."}.
 ```
 
+## Dev Containers in Workflows
+
+Agent steps can use agents that declare a `dev_container.image`. When the
+workflow dispatches the step, the dev container is started alongside Skiff
+with a shared `/workspace` volume. The agent can then build and test code
+inside the dev container via the execution shim. This is configured in the
+agent definition, not in the workflow step itself.
+
+```yaml
+# In .alcove/tasks/go-dev.yml
+name: go-dev
+prompt: |
+  Implement the feature, then run `go test ./...` in the dev container.
+repos:
+  - url: https://github.com/org/myproject.git
+dev_container:
+  image: golang:1.25
+```
+
+See `docs/configuration.md` for the full `dev_container` field reference and
+runtime support matrix.
+
 ## Direct Outbound Mode
 
 By default, Skiff containers route all network traffic through the Gate proxy.

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -933,7 +933,7 @@ func (a *API) listSessions(ctx context.Context, status, repo, since, until, team
 		COALESCE(s.task_name, td.name, '') as task_name,
 		COALESCE(s.trigger_type, '') as trigger_type,
 		COALESCE(s.trigger_ref, '') as trigger_ref,
-		COALESCE(s.repo, '') as repo
+		s.repos
 		FROM sessions s
 		LEFT JOIN schedules sc ON s.prompt LIKE '%[' || sc.source_key || ']%' AND sc.source_key IS NOT NULL AND sc.source_key != ''
 		LEFT JOIN agent_definitions td ON sc.source_key = td.source_key` +
@@ -952,15 +952,15 @@ func (a *API) listSessions(ctx context.Context, status, repo, since, until, team
 	var sessions []internal.Session
 	for rows.Next() {
 		var s internal.Session
-		var scopeJSON, artifactsJSON []byte
+		var scopeJSON, artifactsJSON, reposJSON []byte
 		var finishedAt *time.Time
 		var exitCode *int
 		var parentID *string
-		var taskName, triggerType, triggerRef, repo string
+		var taskName, triggerType, triggerRef string
 
 		if err := rows.Scan(&s.ID, &s.TaskID, &s.Submitter, &s.Prompt,
 			&scopeJSON, &s.Provider, &s.Status, &s.StartedAt, &finishedAt,
-			&exitCode, &artifactsJSON, &parentID, &taskName, &triggerType, &triggerRef, &repo); err != nil {
+			&exitCode, &artifactsJSON, &parentID, &taskName, &triggerType, &triggerRef, &reposJSON); err != nil {
 			return nil, 0, err
 		}
 
@@ -982,7 +982,9 @@ func (a *API) listSessions(ctx context.Context, status, repo, since, until, team
 		if parentID != nil {
 			s.ParentID = *parentID
 		}
-		s.Repo = repo
+		if reposJSON != nil {
+			_ = json.Unmarshal(reposJSON, &s.Repos)
+		}
 
 		// Set task name with fallback
 		if taskName != "" {
@@ -1017,25 +1019,25 @@ func (a *API) listSessions(ctx context.Context, status, repo, since, until, team
 
 func (a *API) getSession(ctx context.Context, id string) (*internal.Session, error) {
 	var s internal.Session
-	var scopeJSON, artifactsJSON []byte
+	var scopeJSON, artifactsJSON, reposJSON []byte
 	var finishedAt *time.Time
 	var exitCode *int
 	var parentID *string
-	var taskName, triggerType, triggerRef, repo string
+	var taskName, triggerType, triggerRef string
 
 	err := a.db.QueryRow(ctx,
 		`SELECT s.id, s.task_id, s.submitter, s.prompt, s.scope, s.provider, s.outcome, s.started_at, s.finished_at, s.exit_code, s.artifacts, s.parent_id,
 		COALESCE(s.task_name, td.name, '') as task_name,
 		COALESCE(s.trigger_type, '') as trigger_type,
 		COALESCE(s.trigger_ref, '') as trigger_ref,
-		COALESCE(s.repo, '') as repo
+		s.repos
 		FROM sessions s
 		LEFT JOIN schedules sc ON s.prompt LIKE '%[' || sc.source_key || ']%' AND sc.source_key IS NOT NULL AND sc.source_key != ''
 		LEFT JOIN agent_definitions td ON sc.source_key = td.source_key
 		WHERE s.id = $1`, id,
 	).Scan(&s.ID, &s.TaskID, &s.Submitter, &s.Prompt,
 		&scopeJSON, &s.Provider, &s.Status, &s.StartedAt, &finishedAt,
-		&exitCode, &artifactsJSON, &parentID, &taskName, &triggerType, &triggerRef, &repo)
+		&exitCode, &artifactsJSON, &parentID, &taskName, &triggerType, &triggerRef, &reposJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -1058,7 +1060,9 @@ func (a *API) getSession(ctx context.Context, id string) (*internal.Session, err
 	if parentID != nil {
 		s.ParentID = *parentID
 	}
-	s.Repo = repo
+	if reposJSON != nil {
+		_ = json.Unmarshal(reposJSON, &s.Repos)
+	}
 
 	// Set task name with fallback
 	if taskName != "" {
@@ -1896,7 +1900,7 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 
 	// Query schedules with event triggers.
 	rows, queryErr := a.db.Query(ctx, `
-		SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, team_id, debug, trigger_type, event_config
+		SELECT id, name, cron, prompt, repos, provider, scope_preset, timeout, enabled, team_id, debug, trigger_type, event_config
 		FROM schedules
 		WHERE enabled = true
 		  AND COALESCE(trigger_type, 'cron') IN ('event', 'cron-and-event')
@@ -1918,7 +1922,7 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 			Name        string
 			Cron        string
 			Prompt      string
-			Repo        string
+			ReposJSON   []byte
 			Provider    string
 			ScopePreset string
 			Timeout     int
@@ -1931,11 +1935,16 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 
 		if err := rows.Scan(
 			&sched.ID, &sched.Name, &sched.Cron, &sched.Prompt,
-			&sched.Repo, &sched.Provider, &sched.ScopePreset, &sched.Timeout,
+			&sched.ReposJSON, &sched.Provider, &sched.ScopePreset, &sched.Timeout,
 			&sched.Enabled, &sched.TeamID, &sched.Debug, &sched.TriggerType, &sched.EventConfig,
 		); err != nil {
 			log.Printf("webhook: error scanning schedule: %v", err)
 			continue
+		}
+
+		var schedRepos []internal.RepoSpec
+		if sched.ReposJSON != nil {
+			_ = json.Unmarshal(sched.ReposJSON, &schedRepos)
 		}
 
 		var trigger EventTrigger
@@ -1953,7 +1962,7 @@ func (a *API) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
 		// Build TaskRequest with webhook context as env vars.
 		taskReq := TaskRequest{
 			Prompt:      sched.Prompt,
-			Repo:        sched.Repo,
+			Repos:       schedRepos,
 			Provider:    sched.Provider,
 			Timeout:     sched.Timeout,
 			Debug:       sched.Debug,

--- a/internal/bridge/cigate.go
+++ b/internal/bridge/cigate.go
@@ -348,7 +348,7 @@ func (m *CIGateMonitor) handleCIFailure(ctx context.Context, sessionID, repo str
 	}
 
 	// Fallback: recover key fields from the original session if task def lookup fails.
-	if taskReq.Repo == "" || originalPrompt == "" {
+	if len(taskReq.Repos) == 0 || originalPrompt == "" {
 		var origPrompt, origProvider string
 		_ = m.db.QueryRow(ctx,
 			`SELECT COALESCE(prompt, ''), COALESCE(provider, '') FROM sessions WHERE id = $1`,

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -16,6 +16,8 @@ package bridge
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -74,11 +76,21 @@ func (d *Dispatcher) SetWorkflowEngine(we *WorkflowEngine) {
 	d.workflowEngine = we
 }
 
+// generateShimToken returns a cryptographically random hex-encoded token
+// of the specified byte length (the resulting string is 2*n hex characters).
+func generateShimToken(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}
+
 // TaskRequest is the JSON body for POST /api/v1/sessions.
 type TaskRequest struct {
 	Prompt         string                   `json:"prompt,omitempty"`
 	Executable     *internal.ExecutableSpec `json:"executable,omitempty"`
-	Repo           string                   `json:"repo,omitempty"`
+	Repos          []internal.RepoSpec      `json:"repos,omitempty"`
 	Provider       string                   `json:"provider,omitempty"`
 	Timeout        int                      `json:"timeout,omitempty"` // seconds, default 3600
 	Scope          *internal.Scope          `json:"scope,omitempty"`
@@ -90,6 +102,7 @@ type TaskRequest struct {
 	Plugins        []PluginSpec             `json:"-"` // Set internally from agent definition
 	Credentials    map[string]string        `json:"-"` // ENV_VAR_NAME: credential_provider_name
 	DirectOutbound bool                     `json:"direct_outbound,omitempty"`
+	DevContainer   *DevContainerSpec       `json:"dev_container,omitempty"`
 	// Task metadata — set by dispatch code paths, stored in sessions table.
 	TaskName    string `json:"-"` // Schedule/agent definition name
 	TriggerType string `json:"-"` // "event", "cron", "manual", "webhook"
@@ -219,7 +232,7 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		TaskID:      taskID,
 		Submitter:   submitter,
 		Prompt:      req.Prompt,
-		Repo:        req.Repo,
+		Repos:       req.Repos,
 		Provider:    provider,
 		Scope:       scope,
 		Status:      "running",
@@ -248,7 +261,7 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 	task := internal.Task{
 		ID:       taskID,
 		Prompt:   req.Prompt,
-		Repo:     req.Repo,
+		Repos:    req.Repos,
 		Provider: provider,
 		Scope:    scope,
 		Timeout:  time.Duration(timeout) * time.Second,
@@ -336,8 +349,9 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 	if req.Budget > 0 {
 		skiffEnv["TASK_BUDGET"] = fmt.Sprintf("%.2f", req.Budget)
 	}
-	if req.Repo != "" {
-		skiffEnv["REPO"] = req.Repo
+	if len(req.Repos) > 0 {
+		reposJSON, _ := json.Marshal(req.Repos)
+		skiffEnv["REPOS"] = string(reposJSON)
 	}
 
 	// For Vertex AI, fetch project/region for Gate URL construction.
@@ -692,6 +706,10 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		runtimeConfig["credentials"] = credEntries
 	}
 
+	if req.DevContainer != nil && req.DevContainer.Image != "" {
+		runtimeConfig["dev_container"] = req.DevContainer
+	}
+
 	runtimeConfigJSON, _ := json.Marshal(runtimeConfig)
 	_, _ = d.db.Exec(ctx, `UPDATE sessions SET runtime_config = $1 WHERE id = $2`, runtimeConfigJSON, sessionID)
 
@@ -707,6 +725,21 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		ExternalNet:    envOrDefault("ALCOVE_EXTERNAL_NETWORK", runtime.DefaultExternalNetwork),
 		Debug:          req.Debug || d.cfg.DebugMode,
 		DirectOutbound: req.DirectOutbound,
+	}
+
+	if req.DevContainer != nil && req.DevContainer.Image != "" {
+		spec.DevContainerImage = req.DevContainer.Image
+		spec.DevContainerNetworkAccess = req.DevContainer.NetworkAccess
+		spec.ShimImage = envOrDefault("SHIM_IMAGE", "ghcr.io/bmbouter/alcove-shim:latest")
+
+		shimToken := generateShimToken(32)
+		spec.DevContainerEnv = map[string]string{
+			"SHIM_TOKEN": shimToken,
+		}
+
+		devHost := runtime.DevContainerName(taskID) + ":9090"
+		skiffEnv["DEV_TOKEN"] = shimToken
+		skiffEnv["DEV_CONTAINER_HOST"] = devHost
 	}
 
 	handle, err := d.rt.RunTask(ctx, spec)
@@ -799,6 +832,11 @@ func (d *Dispatcher) ListenForStatusUpdates(ctx context.Context) error {
 					if err := d.rt.StopService(cleanupCtx, gateName); err != nil {
 						log.Printf("cleanup: failed to stop gate %s: %v", gateName, err)
 					}
+					// Clean up dev container and workspace volume (no-op if not present).
+					devName := runtime.DevContainerName(taskID)
+					if err := d.rt.StopService(cleanupCtx, devName); err != nil {
+						log.Printf("cleanup: failed to stop dev container %s: %v (may not exist)", devName, err)
+					}
 				}(handle.ID, update.SessionID)
 			}
 
@@ -822,11 +860,15 @@ func (d *Dispatcher) ListenForStatusUpdates(ctx context.Context) error {
 // insertSession writes a new session record to the Ledger (PostgreSQL).
 func (d *Dispatcher) insertSession(ctx context.Context, s *internal.Session, sessionToken string) error {
 	scopeJSON, _ := json.Marshal(s.Scope)
+	var reposJSON []byte
+	if len(s.Repos) > 0 {
+		reposJSON, _ = json.Marshal(s.Repos)
+	}
 	_, err := d.db.Exec(ctx, `
-		INSERT INTO sessions (id, task_id, submitter, prompt, scope, provider, started_at, outcome, session_token, task_name, trigger_type, trigger_ref, repo, team_id)
+		INSERT INTO sessions (id, task_id, submitter, prompt, scope, provider, started_at, outcome, session_token, task_name, trigger_type, trigger_ref, repos, team_id)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 	`, s.ID, s.TaskID, s.Submitter, s.Prompt, scopeJSON, s.Provider, s.StartedAt, s.Status, sessionToken,
-		nilIfEmpty(s.TaskName), nilIfEmpty(s.TriggerType), nilIfEmpty(s.TriggerRef), nilIfEmpty(s.Repo), s.TeamID)
+		nilIfEmpty(s.TaskName), nilIfEmpty(s.TriggerType), nilIfEmpty(s.TriggerRef), reposJSON, s.TeamID)
 	return err
 }
 
@@ -931,6 +973,14 @@ func (d *Dispatcher) ReconcileLoop(ctx context.Context) {
 				log.Printf("reconcile: error cleaning up orphaned gate containers: %v", err)
 			} else if cleaned > 0 {
 				log.Printf("reconcile: cleaned up %d orphaned gate container(s)", cleaned)
+			}
+
+			// Sweep orphaned dev containers.
+			devCleaned, devErr := d.rt.CleanupOrphanedContainers(ctx, "dev-")
+			if devErr != nil {
+				log.Printf("reconcile: error cleaning up orphaned dev containers: %v", devErr)
+			} else if devCleaned > 0 {
+				log.Printf("reconcile: cleaned up %d orphaned dev container(s)", devCleaned)
 			}
 		}
 	}

--- a/internal/bridge/migrations/031_multi_repo.sql
+++ b/internal/bridge/migrations/031_multi_repo.sql
@@ -1,0 +1,15 @@
+-- Add repos JSONB column to sessions, migrate existing data, drop repo
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS repos JSONB;
+UPDATE sessions SET repos = CASE
+    WHEN repo IS NOT NULL AND repo != '' THEN jsonb_build_array(jsonb_build_object('url', repo))
+    ELSE '[]'::jsonb
+END WHERE repos IS NULL;
+ALTER TABLE sessions DROP COLUMN IF EXISTS repo;
+
+-- Add repos JSONB column to schedules, migrate existing data, drop repo
+ALTER TABLE schedules ADD COLUMN IF NOT EXISTS repos JSONB;
+UPDATE schedules SET repos = CASE
+    WHEN repo IS NOT NULL AND repo != '' THEN jsonb_build_array(jsonb_build_object('url', repo))
+    ELSE '[]'::jsonb
+END WHERE repos IS NULL;
+ALTER TABLE schedules DROP COLUMN IF EXISTS repo;

--- a/internal/bridge/poller.go
+++ b/internal/bridge/poller.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bmbouter/alcove/internal"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -63,7 +64,7 @@ type pollSchedule struct {
 	ID        string
 	Name      string
 	Prompt    string
-	Repo      string
+	Repos     []internal.RepoSpec
 	Provider  string
 	Timeout   int
 	TeamID    string
@@ -82,7 +83,7 @@ func (p *GitHubPoller) PollAll(ctx context.Context) {
 	}
 
 	rows, err := p.db.Query(ctx, `
-		SELECT id, name, prompt, repo, provider, timeout, team_id, debug, event_config, COALESCE(source_key, '')
+		SELECT id, name, prompt, repos, provider, timeout, team_id, debug, event_config, COALESCE(source_key, '')
 		FROM schedules
 		WHERE enabled = true
 		  AND COALESCE(trigger_type, 'cron') IN ('event', 'cron-and-event')
@@ -103,12 +104,16 @@ func (p *GitHubPoller) PollAll(ctx context.Context) {
 
 	for rows.Next() {
 		var ps pollSchedule
+		var reposJSON []byte
 		var eventConfigJSON []byte
 
-		if err := rows.Scan(&ps.ID, &ps.Name, &ps.Prompt, &ps.Repo,
+		if err := rows.Scan(&ps.ID, &ps.Name, &ps.Prompt, &reposJSON,
 			&ps.Provider, &ps.Timeout, &ps.TeamID, &ps.Debug, &eventConfigJSON, &ps.SourceKey); err != nil {
 			log.Printf("poller: error scanning schedule: %v", err)
 			continue
+		}
+		if reposJSON != nil {
+			_ = json.Unmarshal(reposJSON, &ps.Repos)
 		}
 
 		var trigger EventTrigger
@@ -483,7 +488,7 @@ func (p *GitHubPoller) pollRepo(ctx context.Context, repo, teamID string, schedu
 			// Build session request. Look up agent definition for profiles.
 			taskReq := TaskRequest{
 				Prompt:   sched.Prompt,
-				Repo:     sched.Repo,
+				Repos:    sched.Repos,
 				Provider: sched.Provider,
 				Timeout:  sched.Timeout,
 				Debug:    sched.Debug,

--- a/internal/bridge/runtime.go
+++ b/internal/bridge/runtime.go
@@ -21,10 +21,16 @@ import (
 )
 
 // NewRuntime creates a Runtime implementation based on the type string.
-func NewRuntime(runtimeType string) (runtime.Runtime, error) {
+// The optional shimBinPath is used by PodmanRuntime to volume-mount the
+// shim binary into dev containers.
+func NewRuntime(runtimeType string, shimBinPath string) (runtime.Runtime, error) {
 	switch runtimeType {
 	case "podman":
-		return runtime.NewPodmanRuntime(), nil
+		rt := runtime.NewPodmanRuntime()
+		if shimBinPath != "" {
+			rt.ShimBin = shimBinPath
+		}
+		return rt, nil
 	case "docker":
 		return runtime.NewDockerRuntime(), nil
 	case "kubernetes":

--- a/internal/bridge/scheduler.go
+++ b/internal/bridge/scheduler.go
@@ -25,31 +25,32 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bmbouter/alcove/internal"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Schedule defines a recurring task.
 type Schedule struct {
-	ID          string     `json:"id"`
-	Name        string     `json:"name"`
-	Cron        string     `json:"cron"`          // cron expression (5-field: min hour dom month dow)
-	Prompt      string     `json:"prompt"`
-	Repo        string     `json:"repo,omitempty"`
-	Provider    string     `json:"provider,omitempty"`
-	ScopePreset string     `json:"scope_preset,omitempty"`
-	Timeout     int        `json:"timeout,omitempty"` // seconds
-	Enabled     bool       `json:"enabled"`
-	LastRun     *time.Time `json:"last_run,omitempty"`
-	NextRun     *time.Time `json:"next_run,omitempty"`
-	CreatedAt   time.Time  `json:"created_at"`
-	TeamID      string     `json:"team_id,omitempty"`
-	Debug       bool          `json:"debug,omitempty"`
-	Source      string        `json:"source,omitempty"`
-	SourceKey   string        `json:"source_key,omitempty"`
-	TriggerType  string        `json:"trigger_type,omitempty"`
-	EventConfig  *EventTrigger `json:"event_config,omitempty"`
-	RepoDisabled bool          `json:"repo_disabled"`
+	ID          string              `json:"id"`
+	Name        string              `json:"name"`
+	Cron        string              `json:"cron"`          // cron expression (5-field: min hour dom month dow)
+	Prompt      string              `json:"prompt"`
+	Repos       []internal.RepoSpec `json:"repos,omitempty"`
+	Provider    string              `json:"provider,omitempty"`
+	ScopePreset string              `json:"scope_preset,omitempty"`
+	Timeout     int                 `json:"timeout,omitempty"` // seconds
+	Enabled     bool                `json:"enabled"`
+	LastRun     *time.Time          `json:"last_run,omitempty"`
+	NextRun     *time.Time          `json:"next_run,omitempty"`
+	CreatedAt   time.Time           `json:"created_at"`
+	TeamID      string              `json:"team_id,omitempty"`
+	Debug       bool                `json:"debug,omitempty"`
+	Source      string              `json:"source,omitempty"`
+	SourceKey   string              `json:"source_key,omitempty"`
+	TriggerType  string              `json:"trigger_type,omitempty"`
+	EventConfig  *EventTrigger       `json:"event_config,omitempty"`
+	RepoDisabled bool                `json:"repo_disabled"`
 }
 
 // CronExpr represents a parsed 5-field cron expression.
@@ -314,7 +315,7 @@ func (s *Scheduler) tick(ctx context.Context) {
 	now := time.Now().UTC()
 
 	rows, err := s.db.Query(ctx, `
-		SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, last_run, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config
+		SELECT id, name, cron, prompt, repos, provider, scope_preset, timeout, enabled, last_run, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config
 		FROM schedules
 		WHERE enabled = true AND next_run <= $1
 		  AND COALESCE(trigger_type, 'cron') IN ('cron', 'cron-and-event')
@@ -328,16 +329,20 @@ func (s *Scheduler) tick(ctx context.Context) {
 	var due []Schedule
 	for rows.Next() {
 		var sched Schedule
+		var reposJSON []byte
 		var source, sourceKey, triggerType *string
 		var eventConfigJSON []byte
 		if err := rows.Scan(
 			&sched.ID, &sched.Name, &sched.Cron, &sched.Prompt,
-			&sched.Repo, &sched.Provider, &sched.ScopePreset, &sched.Timeout,
+			&reposJSON, &sched.Provider, &sched.ScopePreset, &sched.Timeout,
 			&sched.Enabled, &sched.LastRun, &sched.NextRun, &sched.CreatedAt, &sched.TeamID, &sched.Debug,
 			&source, &sourceKey, &triggerType, &eventConfigJSON,
 		); err != nil {
 			log.Printf("scheduler: error scanning schedule row: %v", err)
 			continue
+		}
+		if reposJSON != nil {
+			_ = json.Unmarshal(reposJSON, &sched.Repos)
 		}
 		if source != nil {
 			sched.Source = *source
@@ -366,7 +371,7 @@ func (s *Scheduler) tick(ctx context.Context) {
 
 		req := TaskRequest{
 			Prompt:      sched.Prompt,
-			Repo:        sched.Repo,
+			Repos:       sched.Repos,
 			Provider:    sched.Provider,
 			Timeout:     sched.Timeout,
 			Debug:       sched.Debug,
@@ -445,10 +450,15 @@ func (s *Scheduler) CreateSchedule(ctx context.Context, sched *Schedule, teamID 
 		}
 	}
 
+	var reposJSON []byte
+	if len(sched.Repos) > 0 {
+		reposJSON, _ = json.Marshal(sched.Repos)
+	}
+
 	_, err := s.db.Exec(ctx, `
-		INSERT INTO schedules (id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config)
+		INSERT INTO schedules (id, name, cron, prompt, repos, provider, scope_preset, timeout, enabled, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-	`, sched.ID, sched.Name, sched.Cron, sched.Prompt, sched.Repo, sched.Provider,
+	`, sched.ID, sched.Name, sched.Cron, sched.Prompt, reposJSON, sched.Provider,
 		sched.ScopePreset, sched.Timeout, sched.Enabled, sched.NextRun, sched.CreatedAt, teamID, sched.Debug,
 		source, nilIfEmptySched(sched.SourceKey), triggerType, eventConfigJSON)
 	if err != nil {
@@ -461,7 +471,7 @@ func (s *Scheduler) CreateSchedule(ctx context.Context, sched *Schedule, teamID 
 // ListSchedules returns schedules from the database.
 // If owner is non-empty, only schedules belonging to that owner are returned.
 func (s *Scheduler) ListSchedules(ctx context.Context, teamID string) ([]Schedule, error) {
-	query := `SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, last_run, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config
+	query := `SELECT id, name, cron, prompt, repos, provider, scope_preset, timeout, enabled, last_run, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config
 		FROM schedules`
 	args := []any{}
 	if teamID != "" {
@@ -479,15 +489,19 @@ func (s *Scheduler) ListSchedules(ctx context.Context, teamID string) ([]Schedul
 	var schedules []Schedule
 	for rows.Next() {
 		var sched Schedule
+		var reposJSON []byte
 		var source, sourceKey, triggerType *string
 		var eventConfigJSON []byte
 		if err := rows.Scan(
 			&sched.ID, &sched.Name, &sched.Cron, &sched.Prompt,
-			&sched.Repo, &sched.Provider, &sched.ScopePreset, &sched.Timeout,
+			&reposJSON, &sched.Provider, &sched.ScopePreset, &sched.Timeout,
 			&sched.Enabled, &sched.LastRun, &sched.NextRun, &sched.CreatedAt, &sched.TeamID, &sched.Debug,
 			&source, &sourceKey, &triggerType, &eventConfigJSON,
 		); err != nil {
 			return nil, fmt.Errorf("scanning schedule: %w", err)
+		}
+		if reposJSON != nil {
+			_ = json.Unmarshal(reposJSON, &sched.Repos)
 		}
 		if source != nil {
 			sched.Source = *source
@@ -516,7 +530,7 @@ func (s *Scheduler) ListSchedules(ctx context.Context, teamID string) ([]Schedul
 // GetSchedule retrieves a single schedule by ID.
 // If owner is non-empty, only returns the schedule if it belongs to that owner.
 func (s *Scheduler) GetSchedule(ctx context.Context, id, teamID string) (*Schedule, error) {
-	query := `SELECT id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, last_run, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config
+	query := `SELECT id, name, cron, prompt, repos, provider, scope_preset, timeout, enabled, last_run, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config
 		FROM schedules WHERE id = $1`
 	args := []any{id}
 	if teamID != "" {
@@ -525,16 +539,20 @@ func (s *Scheduler) GetSchedule(ctx context.Context, id, teamID string) (*Schedu
 	}
 
 	var sched Schedule
+	var reposJSON []byte
 	var source, sourceKey, triggerType *string
 	var eventConfigJSON []byte
 	err := s.db.QueryRow(ctx, query, args...).Scan(
 		&sched.ID, &sched.Name, &sched.Cron, &sched.Prompt,
-		&sched.Repo, &sched.Provider, &sched.ScopePreset, &sched.Timeout,
+		&reposJSON, &sched.Provider, &sched.ScopePreset, &sched.Timeout,
 		&sched.Enabled, &sched.LastRun, &sched.NextRun, &sched.CreatedAt, &sched.TeamID, &sched.Debug,
 		&source, &sourceKey, &triggerType, &eventConfigJSON,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("querying schedule %s: %w", id, err)
+	}
+	if reposJSON != nil {
+		_ = json.Unmarshal(reposJSON, &sched.Repos)
 	}
 	if source != nil {
 		sched.Source = *source
@@ -583,12 +601,17 @@ func (s *Scheduler) UpdateSchedule(ctx context.Context, sched *Schedule, teamID 
 		}
 	}
 
+	var reposJSON []byte
+	if len(sched.Repos) > 0 {
+		reposJSON, _ = json.Marshal(sched.Repos)
+	}
+
 	query := `UPDATE schedules
-		SET name = $1, cron = $2, prompt = $3, repo = $4, provider = $5,
+		SET name = $1, cron = $2, prompt = $3, repos = $4, provider = $5,
 		    scope_preset = $6, timeout = $7, enabled = $8, next_run = $9, debug = $10,
 		    trigger_type = $11, event_config = $12
 		WHERE id = $13`
-	args := []any{sched.Name, sched.Cron, sched.Prompt, sched.Repo, sched.Provider,
+	args := []any{sched.Name, sched.Cron, sched.Prompt, reposJSON, sched.Provider,
 		sched.ScopePreset, sched.Timeout, sched.Enabled, sched.NextRun, sched.Debug,
 		triggerType, eventConfigJSON, sched.ID}
 	if teamID != "" {

--- a/internal/bridge/taskdef.go
+++ b/internal/bridge/taskdef.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
+	"strings"
 	"time"
 
 	"github.com/bmbouter/alcove/internal"
@@ -33,6 +35,12 @@ type PluginSpec struct {
 	Ref    string `json:"ref,omitempty" yaml:"ref,omitempty"`       // Branch/tag for git sources
 }
 
+// DevContainerSpec declares a dev container image to run as a sidecar.
+type DevContainerSpec struct {
+	Image         string `json:"image" yaml:"image"`
+	NetworkAccess string `json:"network_access,omitempty" yaml:"network_access,omitempty"`
+}
+
 // CIGate configures Bridge-driven CI monitoring for PRs created by a task.
 type CIGate struct {
 	MaxRetries int `json:"max_retries" yaml:"max_retries"`
@@ -46,7 +54,7 @@ type TaskDefinition struct {
 	Description    string                   `json:"description" yaml:"description"`
 	Prompt         string                   `json:"prompt,omitempty" yaml:"prompt"`
 	Executable     *internal.ExecutableSpec `json:"executable,omitempty" yaml:"executable"`
-	Repo           string                   `json:"repo,omitempty" yaml:"repo"`
+	Repos          []internal.RepoSpec      `json:"repos,omitempty" yaml:"repos"`
 	Provider       string                   `json:"provider,omitempty" yaml:"provider"`
 	Model          string                   `json:"model,omitempty" yaml:"model"`
 	Timeout        int                      `json:"timeout,omitempty" yaml:"timeout"`
@@ -60,6 +68,7 @@ type TaskDefinition struct {
 	Trigger        *EventTrigger            `json:"trigger,omitempty" yaml:"trigger"`
 	CIGate         *CIGate                  `json:"ci_gate,omitempty" yaml:"ci_gate"`
 	DirectOutbound bool                     `json:"direct_outbound,omitempty" yaml:"direct_outbound"`
+	DevContainer   *DevContainerSpec       `json:"dev_container,omitempty" yaml:"dev_container"`
 
 	// Metadata (not from YAML).
 	TeamID       string     `json:"team_id,omitempty"`
@@ -118,6 +127,36 @@ func ParseTaskDefinition(data []byte) (*TaskDefinition, error) {
 		}
 	}
 
+	if td.DevContainer != nil && td.DevContainer.Image == "" {
+		return nil, fmt.Errorf("dev_container block present but image is empty")
+	}
+	if td.DevContainer != nil && td.DevContainer.NetworkAccess != "" {
+		if td.DevContainer.NetworkAccess != "internal" && td.DevContainer.NetworkAccess != "external" {
+			return nil, fmt.Errorf("dev_container.network_access must be \"internal\" or \"external\", got %q", td.DevContainer.NetworkAccess)
+		}
+	}
+	// Default network_access to "internal" if not set.
+	if td.DevContainer != nil && td.DevContainer.NetworkAccess == "" {
+		td.DevContainer.NetworkAccess = "internal"
+	}
+
+	// Validate repos: each must have a non-empty URL, derive Name from URL if not provided, check for duplicates.
+	if len(td.Repos) > 0 {
+		namesSeen := make(map[string]bool)
+		for i := range td.Repos {
+			if td.Repos[i].URL == "" {
+				return nil, fmt.Errorf("repos[%d] has empty URL", i)
+			}
+			if td.Repos[i].Name == "" {
+				td.Repos[i].Name = repoNameFromURL(td.Repos[i].URL)
+			}
+			if namesSeen[td.Repos[i].Name] {
+				return nil, fmt.Errorf("duplicate repo name %q", td.Repos[i].Name)
+			}
+			namesSeen[td.Repos[i].Name] = true
+		}
+	}
+
 	return &td, nil
 }
 
@@ -127,7 +166,7 @@ func (td *TaskDefinition) ToTaskRequest() TaskRequest {
 	return TaskRequest{
 		Prompt:         td.Prompt,
 		Executable:     td.Executable,
-		Repo:           td.Repo,
+		Repos:          td.Repos,
 		Provider:       td.Provider,
 		Timeout:        td.Timeout,
 		Tools:          td.Tools,
@@ -138,6 +177,7 @@ func (td *TaskDefinition) ToTaskRequest() TaskRequest {
 		Plugins:        td.Plugins,
 		Credentials:    td.Credentials,
 		DirectOutbound: td.DirectOutbound,
+		DevContainer:   td.DevContainer,
 	}
 }
 
@@ -195,7 +235,7 @@ func (s *AgentDefStore) ListAgentDefinitions(ctx context.Context, teamID string)
 			if err := json.Unmarshal(parsedJSON, &parsed); err == nil {
 				td.Prompt = parsed.Prompt
 				td.Executable = parsed.Executable
-				td.Repo = parsed.Repo
+				td.Repos = parsed.Repos
 				td.Provider = parsed.Provider
 				td.Model = parsed.Model
 				td.Timeout = parsed.Timeout
@@ -209,6 +249,7 @@ func (s *AgentDefStore) ListAgentDefinitions(ctx context.Context, teamID string)
 				td.Credentials = parsed.Credentials
 				td.DirectOutbound = parsed.DirectOutbound
 				td.CIGate = parsed.CIGate
+				td.DevContainer = parsed.DevContainer
 			}
 		}
 
@@ -260,7 +301,7 @@ func (s *AgentDefStore) GetAgentDefinition(ctx context.Context, id, teamID strin
 		if err := json.Unmarshal(parsedJSON, &parsed); err == nil {
 			td.Prompt = parsed.Prompt
 			td.Executable = parsed.Executable
-			td.Repo = parsed.Repo
+			td.Repos = parsed.Repos
 			td.Provider = parsed.Provider
 			td.Model = parsed.Model
 			td.Timeout = parsed.Timeout
@@ -274,6 +315,7 @@ func (s *AgentDefStore) GetAgentDefinition(ctx context.Context, id, teamID strin
 			td.Credentials = parsed.Credentials
 			td.DirectOutbound = parsed.DirectOutbound
 			td.CIGate = parsed.CIGate
+			td.DevContainer = parsed.DevContainer
 		}
 	}
 
@@ -367,7 +409,7 @@ func (s *AgentDefStore) ListAgentDefinitionsByRepo(ctx context.Context, repoURL,
 			if err := json.Unmarshal(parsedJSON, &parsed); err == nil {
 				td.Prompt = parsed.Prompt
 				td.Executable = parsed.Executable
-				td.Repo = parsed.Repo
+				td.Repos = parsed.Repos
 				td.Provider = parsed.Provider
 				td.Model = parsed.Model
 				td.Timeout = parsed.Timeout
@@ -381,6 +423,7 @@ func (s *AgentDefStore) ListAgentDefinitionsByRepo(ctx context.Context, repoURL,
 				td.Credentials = parsed.Credentials
 				td.DirectOutbound = parsed.DirectOutbound
 				td.CIGate = parsed.CIGate
+				td.DevContainer = parsed.DevContainer
 			}
 		}
 		defs = append(defs, td)
@@ -439,6 +482,13 @@ func ResolvePluginBundles(plugins []PluginSpec) []PluginSpec {
 		}
 	}
 	return resolved
+}
+
+// repoNameFromURL derives a short repo name from a URL by taking the
+// basename and stripping any ".git" suffix.
+func repoNameFromURL(url string) string {
+	base := path.Base(url)
+	return strings.TrimSuffix(base, ".git")
 }
 
 // nilIfEmpty returns nil if the string is empty, otherwise a pointer to it.

--- a/internal/bridge/taskdef_test.go
+++ b/internal/bridge/taskdef_test.go
@@ -3,6 +3,7 @@ package bridge
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/bmbouter/alcove/internal"
@@ -174,6 +175,165 @@ prompt: "test"
 	}
 }
 
+func TestParseTaskDefinitionWithDevContainer(t *testing.T) {
+	yamlData := `
+name: Test Agent
+prompt: "test"
+dev_container:
+  image: "quay.io/myorg/devenv:latest"
+`
+	td, err := ParseTaskDefinition([]byte(yamlData))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if td.DevContainer == nil {
+		t.Fatal("expected DevContainer to be set")
+	}
+	if td.DevContainer.Image != "quay.io/myorg/devenv:latest" {
+		t.Errorf("DevContainer.Image: got %q, want %q", td.DevContainer.Image, "quay.io/myorg/devenv:latest")
+	}
+	if td.DevContainer.NetworkAccess != "internal" {
+		t.Errorf("DevContainer.NetworkAccess: got %q, want %q (default)", td.DevContainer.NetworkAccess, "internal")
+	}
+}
+
+func TestParseTaskDefinitionWithDevContainerNetworkAccess(t *testing.T) {
+	tests := []struct {
+		name          string
+		yaml          string
+		wantAccess    string
+		wantErr       string
+	}{
+		{
+			name: "default to internal",
+			yaml: `
+name: Test Agent
+prompt: "test"
+dev_container:
+  image: "golang:1.25"
+`,
+			wantAccess: "internal",
+		},
+		{
+			name: "explicit internal",
+			yaml: `
+name: Test Agent
+prompt: "test"
+dev_container:
+  image: "golang:1.25"
+  network_access: internal
+`,
+			wantAccess: "internal",
+		},
+		{
+			name: "external",
+			yaml: `
+name: Test Agent
+prompt: "test"
+dev_container:
+  image: "golang:1.25"
+  network_access: external
+`,
+			wantAccess: "external",
+		},
+		{
+			name: "invalid value",
+			yaml: `
+name: Test Agent
+prompt: "test"
+dev_container:
+  image: "golang:1.25"
+  network_access: public
+`,
+			wantErr: `dev_container.network_access must be "internal" or "external", got "public"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td, err := ParseTaskDefinition([]byte(tt.yaml))
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if err.Error() != tt.wantErr {
+					t.Errorf("error = %q, want %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if td.DevContainer.NetworkAccess != tt.wantAccess {
+				t.Errorf("NetworkAccess = %q, want %q", td.DevContainer.NetworkAccess, tt.wantAccess)
+			}
+		})
+	}
+}
+
+func TestParseTaskDefinitionWithDevContainerEmptyImage(t *testing.T) {
+	yamlData := `
+name: Test Agent
+prompt: "test"
+dev_container:
+  image: ""
+`
+	_, err := ParseTaskDefinition([]byte(yamlData))
+	if err == nil {
+		t.Fatal("expected error for dev_container with empty image")
+	}
+	if err.Error() != "dev_container block present but image is empty" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestParseTaskDefinitionWithDevContainerNoImage(t *testing.T) {
+	yamlData := `
+name: Test Agent
+prompt: "test"
+dev_container: {}
+`
+	_, err := ParseTaskDefinition([]byte(yamlData))
+	if err == nil {
+		t.Fatal("expected error for dev_container with no image")
+	}
+	if err.Error() != "dev_container block present but image is empty" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestParseTaskDefinitionWithoutDevContainer(t *testing.T) {
+	yamlData := `
+name: Test Agent
+prompt: "test"
+`
+	td, err := ParseTaskDefinition([]byte(yamlData))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if td.DevContainer != nil {
+		t.Error("expected DevContainer to be nil when omitted")
+	}
+}
+
+func TestToTaskRequestIncludesDevContainer(t *testing.T) {
+	def := &TaskDefinition{
+		Name:   "Test Agent",
+		Prompt: "Do something",
+		DevContainer: &DevContainerSpec{
+			Image: "quay.io/myorg/devenv:latest",
+		},
+	}
+
+	req := def.ToTaskRequest()
+	if req.DevContainer == nil {
+		t.Fatal("expected DevContainer to be set in task request")
+	}
+	if req.DevContainer.Image != "quay.io/myorg/devenv:latest" {
+		t.Errorf("DevContainer.Image: got %q, want %q", req.DevContainer.Image, "quay.io/myorg/devenv:latest")
+	}
+}
+
 func TestToTaskRequestIncludesDirectOutbound(t *testing.T) {
 	def := &TaskDefinition{
 		Name:           "Test Agent",
@@ -218,7 +378,7 @@ func TestToTaskRequest_AllFields(t *testing.T) {
 		Description: "An agent with every field set",
 		Prompt:      "Implement the thing",
 		Executable:  &internal.ExecutableSpec{URL: "https://example.com/bin", Args: []string{"--fast"}, Env: map[string]string{"K": "V"}},
-		Repo:        "pulp/pulp_python",
+		Repos:       []internal.RepoSpec{{URL: "https://github.com/pulp/pulp_python", Name: "pulp_python"}},
 		Provider:    "anthropic",
 		Model:       "claude-opus-4-6",
 		Timeout:     600,
@@ -230,6 +390,7 @@ func TestToTaskRequest_AllFields(t *testing.T) {
 		Credentials: map[string]string{"TOKEN": "my-svc"},
 		DirectOutbound: true,
 		CIGate:      &CIGate{MaxRetries: 3, Timeout: 900},
+		DevContainer: &DevContainerSpec{Image: "quay.io/myorg/devenv:latest", NetworkAccess: "external"},
 	}
 
 	req := def.ToTaskRequest()
@@ -241,8 +402,10 @@ func TestToTaskRequest_AllFields(t *testing.T) {
 	if req.Executable == nil || req.Executable.URL != def.Executable.URL {
 		t.Errorf("Executable: got %v, want URL %q", req.Executable, def.Executable.URL)
 	}
-	if req.Repo != def.Repo {
-		t.Errorf("Repo: got %q, want %q", req.Repo, def.Repo)
+	if len(req.Repos) != len(def.Repos) {
+		t.Errorf("Repos length: got %d, want %d", len(req.Repos), len(def.Repos))
+	} else if len(req.Repos) > 0 && req.Repos[0].URL != def.Repos[0].URL {
+		t.Errorf("Repos[0].URL: got %q, want %q", req.Repos[0].URL, def.Repos[0].URL)
 	}
 	if req.Provider != def.Provider {
 		t.Errorf("Provider: got %q, want %q", req.Provider, def.Provider)
@@ -274,6 +437,9 @@ func TestToTaskRequest_AllFields(t *testing.T) {
 	if !req.DirectOutbound {
 		t.Error("DirectOutbound: expected true in TaskRequest")
 	}
+	if req.DevContainer == nil || req.DevContainer.Image != "quay.io/myorg/devenv:latest" {
+		t.Errorf("DevContainer: got %v, want {Image: quay.io/myorg/devenv:latest}", req.DevContainer)
+	}
 
 	// CIGate is intentionally NOT mapped to TaskRequest (it is consumed by Bridge
 	// workflow logic, not sent to Skiff), so verify it is absent.
@@ -298,7 +464,7 @@ func TestGetAgentDefinitionFieldCopyRoundTrip(t *testing.T) {
 			Args: []string{"--flag"},
 			Env:  map[string]string{"KEY": "VAL"},
 		},
-		Repo:     "https://github.com/org/repo",
+		Repos:    []internal.RepoSpec{{URL: "https://github.com/org/repo", Name: "repo"}},
 		Provider: "anthropic",
 		Model:    "claude-opus-4-6",
 		Timeout:  600,
@@ -327,6 +493,10 @@ func TestGetAgentDefinitionFieldCopyRoundTrip(t *testing.T) {
 			Timeout:    900,
 		},
 		DirectOutbound: true,
+		DevContainer: &DevContainerSpec{
+			Image:         "quay.io/myorg/devenv:latest",
+			NetworkAccess: "external",
+		},
 	}
 
 	// Step 2: Marshal to JSON (simulates UpsertAgentDefinition storing parsed JSONB).
@@ -353,7 +523,7 @@ func TestGetAgentDefinitionFieldCopyRoundTrip(t *testing.T) {
 	}
 	td.Prompt = parsed.Prompt
 	td.Executable = parsed.Executable
-	td.Repo = parsed.Repo
+	td.Repos = parsed.Repos
 	td.Provider = parsed.Provider
 	td.Model = parsed.Model
 	td.Timeout = parsed.Timeout
@@ -367,6 +537,7 @@ func TestGetAgentDefinitionFieldCopyRoundTrip(t *testing.T) {
 	td.Credentials = parsed.Credentials
 	td.DirectOutbound = parsed.DirectOutbound
 	td.CIGate = parsed.CIGate
+	td.DevContainer = parsed.DevContainer
 
 	// Step 5: Use reflect to verify every yaml-tagged field matches the
 	// original. Fields with a yaml tag are "parseable" (come from the YAML
@@ -395,10 +566,99 @@ func TestGetAgentDefinitionFieldCopyRoundTrip(t *testing.T) {
 
 	// Sanity check: make sure we actually checked a meaningful number of fields.
 	// Update this count when adding new yaml-tagged fields to TaskDefinition.
-	const expectedYAMLFields = 18
+	const expectedYAMLFields = 19
 	if yamlFieldCount != expectedYAMLFields {
 		t.Errorf("expected %d yaml-tagged fields in TaskDefinition, found %d; "+
 			"update this test and the copy block in GetAgentDefinition",
 			expectedYAMLFields, yamlFieldCount)
+	}
+}
+
+func TestParseTaskDefinitionWithRepos(t *testing.T) {
+	yamlData := `
+name: Multi-Repo Agent
+prompt: "Do something across repos"
+repos:
+  - url: https://github.com/org/repo1.git
+    ref: main
+  - url: https://github.com/org/repo2.git
+    name: custom-name
+`
+	td, err := ParseTaskDefinition([]byte(yamlData))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(td.Repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(td.Repos))
+	}
+	// First repo: name derived from URL
+	if td.Repos[0].Name != "repo1" {
+		t.Errorf("Repos[0].Name: got %q, want %q", td.Repos[0].Name, "repo1")
+	}
+	if td.Repos[0].URL != "https://github.com/org/repo1.git" {
+		t.Errorf("Repos[0].URL: got %q, want %q", td.Repos[0].URL, "https://github.com/org/repo1.git")
+	}
+	if td.Repos[0].Ref != "main" {
+		t.Errorf("Repos[0].Ref: got %q, want %q", td.Repos[0].Ref, "main")
+	}
+	// Second repo: explicit name
+	if td.Repos[1].Name != "custom-name" {
+		t.Errorf("Repos[1].Name: got %q, want %q", td.Repos[1].Name, "custom-name")
+	}
+}
+
+func TestParseTaskDefinitionReposDuplicateName(t *testing.T) {
+	yamlData := `
+name: Dup Names Agent
+prompt: "test"
+repos:
+  - url: https://github.com/org/repo1.git
+    name: same-name
+  - url: https://github.com/org/repo2.git
+    name: same-name
+`
+	_, err := ParseTaskDefinition([]byte(yamlData))
+	if err == nil {
+		t.Fatal("expected error for duplicate repo names")
+	}
+	if !strings.Contains(err.Error(), "duplicate repo name") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestParseTaskDefinitionReposNameDerivation(t *testing.T) {
+	yamlData := `
+name: Name Derivation Agent
+prompt: "test"
+repos:
+  - url: https://github.com/org/my-project.git
+  - url: https://gitlab.com/team/another-project
+`
+	td, err := ParseTaskDefinition([]byte(yamlData))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if td.Repos[0].Name != "my-project" {
+		t.Errorf("Repos[0].Name: got %q, want %q", td.Repos[0].Name, "my-project")
+	}
+	if td.Repos[1].Name != "another-project" {
+		t.Errorf("Repos[1].Name: got %q, want %q", td.Repos[1].Name, "another-project")
+	}
+}
+
+func TestParseTaskDefinitionReposMissingURL(t *testing.T) {
+	yamlData := `
+name: Missing URL Agent
+prompt: "test"
+repos:
+  - name: some-repo
+  - url: https://github.com/org/valid.git
+`
+	_, err := ParseTaskDefinition([]byte(yamlData))
+	if err == nil {
+		t.Fatal("expected error for repo with empty URL")
+	}
+	if !strings.Contains(err.Error(), "empty URL") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }

--- a/internal/bridge/tasksync.go
+++ b/internal/bridge/tasksync.go
@@ -708,24 +708,29 @@ func (s *AgentRepoSyncer) reconcileSchedule(ctx context.Context, td *TaskDefinit
 	var existingID string
 	err := s.db.QueryRow(ctx, `SELECT id FROM schedules WHERE source_key = $1 AND source = 'yaml'`, td.SourceKey).Scan(&existingID)
 
+	var reposJSON []byte
+	if len(td.Repos) > 0 {
+		reposJSON, _ = json.Marshal(td.Repos)
+	}
+
 	if err != nil {
 		// No existing schedule — create one.
 		now := time.Now().UTC()
 		_, err = s.db.Exec(ctx, `
-			INSERT INTO schedules (id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config)
+			INSERT INTO schedules (id, name, cron, prompt, repos, provider, scope_preset, timeout, enabled, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config)
 			VALUES ($1, $2, $3, $4, $5, $6, '', $7, $8, $9, $10, $15, $11, 'yaml', $12, $13, $14)
-		`, uuid.New().String(), td.Name, cronExpr, td.Prompt, td.Repo, td.Provider,
+		`, uuid.New().String(), td.Name, cronExpr, td.Prompt, reposJSON, td.Provider,
 			td.Timeout, enabled, nextRun, now, td.Debug, td.SourceKey, triggerType, eventConfigJSON, teamID)
 		return err
 	}
 
 	// Existing schedule — update it.
 	_, err = s.db.Exec(ctx, `
-		UPDATE schedules SET name = $1, cron = $2, prompt = $3, repo = $4, provider = $5,
+		UPDATE schedules SET name = $1, cron = $2, prompt = $3, repos = $4, provider = $5,
 		    timeout = $6, enabled = $7, next_run = $8, debug = $9,
 		    trigger_type = $10, event_config = $11
 		WHERE id = $12 AND source = 'yaml'
-	`, td.Name, cronExpr, td.Prompt, td.Repo, td.Provider,
+	`, td.Name, cronExpr, td.Prompt, reposJSON, td.Provider,
 		td.Timeout, enabled, nextRun, td.Debug, triggerType, eventConfigJSON, existingID)
 	return err
 }
@@ -940,8 +945,8 @@ func (s *AgentRepoSyncer) reconcileWorkflowTrigger(ctx context.Context, wd *Work
 		now := time.Now().UTC()
 		// For workflow triggers, we create a schedule that points to the workflow (not an agent definition)
 		_, err = s.db.Exec(ctx, `
-			INSERT INTO schedules (id, name, cron, prompt, repo, provider, scope_preset, timeout, enabled, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config)
-			VALUES ($1, $2, '', '', '', 'workflow', '', 0, $3, NULL, $4, $5, false, 'yaml', $6, $7, $8)
+			INSERT INTO schedules (id, name, cron, prompt, repos, provider, scope_preset, timeout, enabled, next_run, created_at, team_id, debug, source, source_key, trigger_type, event_config)
+			VALUES ($1, $2, '', '', NULL, 'workflow', '', 0, $3, NULL, $4, $5, false, 'yaml', $6, $7, $8)
 		`, uuid.New().String(), wd.Name, enabled, now, teamID, sourceKey, triggerType, eventConfigJSON)
 		return err
 	}

--- a/internal/bridge/workflow.go
+++ b/internal/bridge/workflow.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bmbouter/alcove/internal"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"gopkg.in/yaml.v3"
@@ -46,7 +47,7 @@ type WorkflowStep struct {
 	Agent         string                 `json:"agent,omitempty" yaml:"agent,omitempty"`
 	Type          string                 `json:"type,omitempty" yaml:"type,omitempty"`                     // "agent" (default) or "bridge"
 	Action        string                 `json:"action,omitempty" yaml:"action,omitempty"`                 // Bridge action name (create-pr, await-ci, merge-pr)
-	Repo          string                 `json:"repo,omitempty" yaml:"repo,omitempty"`
+	Repos         []internal.RepoSpec    `json:"repos,omitempty" yaml:"repos,omitempty"`
 	Trigger       *EventTrigger          `json:"trigger,omitempty" yaml:"trigger,omitempty"`
 	Needs         []string               `json:"needs,omitempty" yaml:"needs,omitempty"`
 	Depends       string                 `json:"depends,omitempty" yaml:"depends,omitempty"`               // Enhanced dependency expression

--- a/internal/bridge/workflow_engine.go
+++ b/internal/bridge/workflow_engine.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bmbouter/alcove/internal"
 	"github.com/bmbouter/alcove/internal/bridge/condition"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -268,7 +269,7 @@ func (we *WorkflowEngine) dispatchStep(ctx context.Context, run *WorkflowRun, st
 				agentDef.Prompt = prompt
 			}
 			if repo, ok := item.Definition["repo"].(string); ok {
-				agentDef.Repo = repo
+				agentDef.Repos = []internal.RepoSpec{{URL: repo}}
 			}
 		}
 		err = nil
@@ -298,18 +299,15 @@ func (we *WorkflowEngine) dispatchStep(ctx context.Context, run *WorkflowRun, st
 		taskReq.DirectOutbound = true
 	}
 
-	// If step has a repo specified, override the agent's repo
-	if step.Repo != "" {
-		taskReq.Repo = step.Repo
-
-		// Validate cross-repo access: ensure credentials are available for the target repo
-		if err := we.validateCrossRepoCredentials(ctx, step.Repo, run.TeamID); err != nil {
-			return fmt.Errorf("cross-repo credential validation failed for repo %s: %w", step.Repo, err)
-		}
-
-		// Apply cross-repo enhancements to the task request
-		if err := we.enhanceTaskRequestForRepo(ctx, &taskReq, step.Repo, run.TeamID); err != nil {
-			return fmt.Errorf("cross-repo enhancement failed for repo %s: %w", step.Repo, err)
+	// If step has repos specified, override the agent's repos
+	if len(step.Repos) > 0 {
+		taskReq.Repos = step.Repos
+		// Cross-repo credential validation for each repo
+		for _, r := range step.Repos {
+			repoPath := r.URL
+			if err := we.validateCrossRepoCredentials(ctx, repoPath, run.TeamID); err != nil {
+				return fmt.Errorf("cross-repo credential validation failed for repo %s: %w", repoPath, err)
+			}
 		}
 	}
 

--- a/internal/bridge/workflow_test.go
+++ b/internal/bridge/workflow_test.go
@@ -492,14 +492,17 @@ name: Cross-Repo Workflow
 workflow:
   - id: implement-plugin
     agent: autonomous-developer
-    repo: pulp/pulp_python
+    repos:
+      - url: pulp/pulp_python
   - id: implement-core
     agent: autonomous-developer
-    repo: pulp/pulpcore
+    repos:
+      - url: pulp/pulpcore
     needs: [implement-plugin]
   - id: integration-test
     agent: test-runner
-    repo: pulp/pulp_integration
+    repos:
+      - url: pulp/pulp_integration
     needs: [implement-core]
 `
 
@@ -516,7 +519,7 @@ workflow:
 		t.Errorf("expected 3 workflow steps, got %d", len(wd.Workflow))
 	}
 
-	// Check each step has the correct repo
+	// Check each step has the correct repos
 	expectedRepos := map[string]string{
 		"implement-plugin": "pulp/pulp_python",
 		"implement-core":   "pulp/pulpcore",
@@ -525,8 +528,12 @@ workflow:
 
 	for _, step := range wd.Workflow {
 		expectedRepo := expectedRepos[step.ID]
-		if step.Repo != expectedRepo {
-			t.Errorf("step '%s': expected repo '%s', got '%s'", step.ID, expectedRepo, step.Repo)
+		if len(step.Repos) != 1 || step.Repos[0].URL != expectedRepo {
+			var got string
+			if len(step.Repos) > 0 {
+				got = step.Repos[0].URL
+			}
+			t.Errorf("step '%s': expected repo URL '%s', got '%s'", step.ID, expectedRepo, got)
 		}
 	}
 

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -94,7 +94,7 @@ func (d *DockerRuntime) run(ctx context.Context, args ...string) ([]byte, error)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("docker %s: %w: %s", strings.Join(args, " "), err, stderr.String())
+		return nil, fmt.Errorf("docker %s: %w: %s", redactEnvArgs(args), err, stderr.String())
 	}
 	return stdout.Bytes(), nil
 }
@@ -104,6 +104,10 @@ func (d *DockerRuntime) run(ctx context.Context, args ...string) ([]byte, error)
 // it can proxy traffic to external services. Skiff is attached ONLY to the
 // internal network so it cannot reach the internet directly.
 func (d *DockerRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHandle, error) {
+	if spec.DevContainerImage != "" {
+		return TaskHandle{}, fmt.Errorf("dev containers are not supported on the Docker runtime; use Podman or Kubernetes")
+	}
+
 	skiffName := SkiffContainerName(spec.TaskID)
 	gateName := GateContainerName(spec.TaskID)
 	internalNet := spec.Network

--- a/internal/runtime/kubernetes.go
+++ b/internal/runtime/kubernetes.go
@@ -277,6 +277,80 @@ func (k *KubernetesRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHan
 		},
 	}
 
+	// Dev container support: when a dev container image is specified, override
+	// DEV_CONTAINER_HOST to localhost (containers in a K8s Pod share network
+	// namespace) and add init containers, sidecar, and shared volumes.
+	var devInitContainers []corev1.Container
+	var devVolumes []corev1.Volume
+	var skiffExtraVolumeMounts []corev1.VolumeMount
+
+	if spec.DevContainerImage != "" {
+		// In K8s, all containers in a Pod share localhost — override the
+		// dispatcher-set hostname (dev-{taskID}:9090) with localhost:9090.
+		skiffEnv["DEV_CONTAINER_HOST"] = "localhost:9090"
+		// Rebuild skiffEnvVars after the override.
+		skiffEnvVars = envMapToVars(skiffEnv)
+
+		// Log a warning if the dev container requests external network access.
+		// All containers in a Pod share the same network namespace, so
+		// per-container network isolation is not enforceable on Kubernetes.
+		if spec.DevContainerNetworkAccess == "external" {
+			log.Printf("warning: dev container network_access=external is not enforceable on Kubernetes; all containers in a Pod share the same network namespace")
+		}
+
+		// Shared volumes for workspace and shim binary.
+		devVolumes = []corev1.Volume{
+			{Name: "workspace", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			{Name: "shim-bin", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		}
+
+		// shim-init: runs to completion, copies the shim binary to a shared emptyDir.
+		// Must be a regular init container (no restartPolicy) so it completes
+		// before the native sidecars start.
+		shimInitContainer := corev1.Container{
+			Name:            "shim-init",
+			Image:           spec.ShimImage,
+			Command:         []string{"cp", "/usr/local/bin/shim", "/shim-bin/alcove-shim"},
+			SecurityContext: securityContext,
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "shim-bin", MountPath: "/shim-bin"},
+			},
+		}
+
+		// dev: native sidecar running the dev container image via the copied shim.
+		devContainerEnvVars := envMapToVars(spec.DevContainerEnv)
+		devContainer := corev1.Container{
+			Name:            "dev",
+			Image:           spec.DevContainerImage,
+			Command:         []string{"/shim-bin/alcove-shim"},
+			Env:             devContainerEnvVars,
+			SecurityContext: securityContext,
+			RestartPolicy:   &sidecarRestart,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "workspace", MountPath: "/workspace"},
+				{Name: "shim-bin", MountPath: "/shim-bin", ReadOnly: true},
+			},
+		}
+
+		// shim-init runs to completion first, then Gate and dev start as sidecars.
+		devInitContainers = []corev1.Container{shimInitContainer, devContainer}
+
+		// Skiff also needs the workspace volume.
+		skiffExtraVolumeMounts = []corev1.VolumeMount{
+			{Name: "workspace", MountPath: "/workspace"},
+		}
+	}
+
 	// Skiff is the main container that runs the actual task.
 	skiffContainer := corev1.Container{
 		Name:            "skiff",
@@ -293,6 +367,20 @@ func (k *KubernetesRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHan
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 		},
+		VolumeMounts: skiffExtraVolumeMounts,
+	}
+
+	// Build the init container list: shim-init (if present) first, then
+	// Gate sidecar, then dev sidecar (if present).
+	// Order: shim-init (run-to-completion) → Gate (native sidecar) → dev (native sidecar)
+	var initContainers []corev1.Container
+	if len(devInitContainers) > 0 {
+		// shim-init first (runs to completion), then Gate, then dev sidecar.
+		initContainers = append(initContainers, devInitContainers[0]) // shim-init
+		initContainers = append(initContainers, gateContainer)         // Gate sidecar
+		initContainers = append(initContainers, devInitContainers[1]) // dev sidecar
+	} else {
+		initContainers = []corev1.Container{gateContainer}
 	}
 
 	// Build the Job spec.
@@ -310,8 +398,9 @@ func (k *KubernetesRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHan
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{gateContainer},
+					InitContainers: initContainers,
 					Containers:     []corev1.Container{skiffContainer},
+					Volumes:        devVolumes,
 					RestartPolicy:  corev1.RestartPolicyNever,
 				},
 			},

--- a/internal/runtime/kubernetes_test.go
+++ b/internal/runtime/kubernetes_test.go
@@ -1083,6 +1083,187 @@ func envVarsToMap(vars []corev1.EnvVar) map[string]string {
 	return m
 }
 
+func TestRunTask_DevContainer(t *testing.T) {
+	rt, clientset := newTestKubernetesRuntime()
+	ctx := context.Background()
+
+	spec := TaskSpec{
+		TaskID:            "task-dev",
+		Image:             "skiff:latest",
+		GateImage:         "gate:latest",
+		ShimImage:         "ghcr.io/bmbouter/alcove-shim:latest",
+		DevContainerImage: "golang:1.25",
+		DevContainerEnv:   map[string]string{"SHIM_TOKEN": "secret-token-123"},
+		DevContainerNetworkAccess: "internal",
+		Env: map[string]string{
+			"TASK_ID":            "task-dev",
+			"DEV_CONTAINER_HOST": "dev-task-dev:9090", // dispatcher sets this
+		},
+		GateEnv: map[string]string{"GATE_SCOPE": "read"},
+	}
+
+	handle, err := rt.RunTask(ctx, spec)
+	if err != nil {
+		t.Fatalf("RunTask() error: %v", err)
+	}
+	if handle.ID != "task-dev" {
+		t.Errorf("handle.ID = %q, want %q", handle.ID, "task-dev")
+	}
+
+	jobs, err := clientset.BatchV1().Jobs("test-ns").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("listing jobs: %v", err)
+	}
+	if len(jobs.Items) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs.Items))
+	}
+	job := jobs.Items[0]
+
+	// With dev container: 3 init containers (shim-init, gate, dev).
+	initContainers := job.Spec.Template.Spec.InitContainers
+	if len(initContainers) != 3 {
+		t.Fatalf("expected 3 init containers, got %d", len(initContainers))
+	}
+
+	// Verify init container order: shim-init, gate, dev.
+	if initContainers[0].Name != "shim-init" {
+		t.Errorf("init container 0 name = %q, want %q", initContainers[0].Name, "shim-init")
+	}
+	if initContainers[1].Name != "gate" {
+		t.Errorf("init container 1 name = %q, want %q", initContainers[1].Name, "gate")
+	}
+	if initContainers[2].Name != "dev" {
+		t.Errorf("init container 2 name = %q, want %q", initContainers[2].Name, "dev")
+	}
+
+	// Verify shim-init: runs to completion (no restartPolicy), uses ShimImage.
+	shimInit := initContainers[0]
+	if shimInit.Image != "ghcr.io/bmbouter/alcove-shim:latest" {
+		t.Errorf("shim-init image = %q, want %q", shimInit.Image, "ghcr.io/bmbouter/alcove-shim:latest")
+	}
+	if shimInit.RestartPolicy != nil {
+		t.Errorf("shim-init should have nil restartPolicy (runs to completion), got %v", *shimInit.RestartPolicy)
+	}
+	if len(shimInit.Command) != 3 || shimInit.Command[0] != "cp" {
+		t.Errorf("shim-init command = %v, want [cp /usr/local/bin/shim /shim-bin/alcove-shim]", shimInit.Command)
+	}
+	// shim-init should mount shim-bin volume.
+	shimInitMounts := volumeMountNames(shimInit.VolumeMounts)
+	if !shimInitMounts["shim-bin"] {
+		t.Error("shim-init should mount shim-bin volume")
+	}
+	assertSecurityContext(t, shimInit.SecurityContext, "shim-init")
+
+	// Verify gate: native sidecar (restartPolicy Always).
+	gate := initContainers[1]
+	if gate.RestartPolicy == nil || *gate.RestartPolicy != corev1.ContainerRestartPolicyAlways {
+		t.Errorf("gate restartPolicy should be Always")
+	}
+
+	// Verify dev container: native sidecar, correct image, command, env, volumes.
+	dev := initContainers[2]
+	if dev.Image != "golang:1.25" {
+		t.Errorf("dev image = %q, want %q", dev.Image, "golang:1.25")
+	}
+	if dev.RestartPolicy == nil || *dev.RestartPolicy != corev1.ContainerRestartPolicyAlways {
+		t.Errorf("dev restartPolicy should be Always")
+	}
+	if len(dev.Command) != 1 || dev.Command[0] != "/shim-bin/alcove-shim" {
+		t.Errorf("dev command = %v, want [/shim-bin/alcove-shim]", dev.Command)
+	}
+	devEnvMap := envVarsToMap(dev.Env)
+	if devEnvMap["SHIM_TOKEN"] != "secret-token-123" {
+		t.Errorf("dev SHIM_TOKEN = %q, want %q", devEnvMap["SHIM_TOKEN"], "secret-token-123")
+	}
+	devMounts := volumeMountNames(dev.VolumeMounts)
+	if !devMounts["workspace"] {
+		t.Error("dev should mount workspace volume")
+	}
+	if !devMounts["shim-bin"] {
+		t.Error("dev should mount shim-bin volume")
+	}
+	assertSecurityContext(t, dev.SecurityContext, "dev")
+
+	// Verify Skiff main container has workspace volume mount.
+	skiff := job.Spec.Template.Spec.Containers[0]
+	skiffMounts := volumeMountNames(skiff.VolumeMounts)
+	if !skiffMounts["workspace"] {
+		t.Error("skiff should mount workspace volume when dev container is configured")
+	}
+
+	// Verify DEV_CONTAINER_HOST is overridden to localhost:9090 for K8s.
+	skiffEnvMap := envVarsToMap(skiff.Env)
+	if skiffEnvMap["DEV_CONTAINER_HOST"] != "localhost:9090" {
+		t.Errorf("DEV_CONTAINER_HOST = %q, want %q (K8s override)", skiffEnvMap["DEV_CONTAINER_HOST"], "localhost:9090")
+	}
+
+	// Verify volumes: workspace and shim-bin emptyDirs.
+	volumes := job.Spec.Template.Spec.Volumes
+	if len(volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %d", len(volumes))
+	}
+	volNames := make(map[string]bool)
+	for _, v := range volumes {
+		volNames[v.Name] = true
+		if v.VolumeSource.EmptyDir == nil {
+			t.Errorf("volume %q should be emptyDir", v.Name)
+		}
+	}
+	if !volNames["workspace"] {
+		t.Error("missing workspace volume")
+	}
+	if !volNames["shim-bin"] {
+		t.Error("missing shim-bin volume")
+	}
+}
+
+func TestRunTask_NoDevContainer_NoExtraResources(t *testing.T) {
+	rt, clientset := newTestKubernetesRuntime()
+	ctx := context.Background()
+
+	spec := TaskSpec{
+		TaskID:    "task-no-dev",
+		Image:     "skiff:latest",
+		GateImage: "gate:latest",
+	}
+
+	_, err := rt.RunTask(ctx, spec)
+	if err != nil {
+		t.Fatalf("RunTask() error: %v", err)
+	}
+
+	jobs, _ := clientset.BatchV1().Jobs("test-ns").List(ctx, metav1.ListOptions{})
+	job := jobs.Items[0]
+
+	// Without dev container: only 1 init container (gate).
+	if len(job.Spec.Template.Spec.InitContainers) != 1 {
+		t.Errorf("expected 1 init container without dev container, got %d", len(job.Spec.Template.Spec.InitContainers))
+	}
+	if job.Spec.Template.Spec.InitContainers[0].Name != "gate" {
+		t.Errorf("init container name = %q, want %q", job.Spec.Template.Spec.InitContainers[0].Name, "gate")
+	}
+
+	// No volumes should be added.
+	if len(job.Spec.Template.Spec.Volumes) != 0 {
+		t.Errorf("expected 0 volumes without dev container, got %d", len(job.Spec.Template.Spec.Volumes))
+	}
+
+	// Skiff should have no volume mounts.
+	skiff := job.Spec.Template.Spec.Containers[0]
+	if len(skiff.VolumeMounts) != 0 {
+		t.Errorf("expected 0 volume mounts on skiff without dev container, got %d", len(skiff.VolumeMounts))
+	}
+}
+
+// volumeMountNames extracts a set of volume mount names for easy assertion.
+func volumeMountNames(mounts []corev1.VolumeMount) map[string]bool {
+	names := make(map[string]bool, len(mounts))
+	for _, m := range mounts {
+		names[m.Name] = true
+	}
+	return names
+}
+
 // assertSecurityContext verifies the standard security context settings
 // applied to Alcove containers (non-root, drop all capabilities, no privilege escalation).
 func assertSecurityContext(t *testing.T, sc *corev1.SecurityContext, containerName string) {

--- a/internal/runtime/podman.go
+++ b/internal/runtime/podman.go
@@ -29,6 +29,11 @@ type PodmanRuntime struct {
 	// PodmanBin is the path to the podman binary. Defaults to "podman".
 	PodmanBin string
 
+	// ShimBin is the host path to the shim binary. When a dev container is
+	// started, this binary is volume-mounted into the container and executed
+	// as a background process. Defaults to "./bin/shim".
+	ShimBin string
+
 	// execCommand is a hook for testing. If nil, exec.CommandContext is used.
 	execCommand func(ctx context.Context, name string, args ...string) *exec.Cmd
 }
@@ -90,6 +95,13 @@ func (p *PodmanRuntime) podmanBin() string {
 	return "podman"
 }
 
+func (p *PodmanRuntime) shimBin() string {
+	if p.ShimBin != "" {
+		return p.ShimBin
+	}
+	return "./bin/shim"
+}
+
 // run executes a podman command and returns its combined output.
 func (p *PodmanRuntime) run(ctx context.Context, args ...string) ([]byte, error) {
 	cmd := p.cmd(ctx, args...)
@@ -97,9 +109,24 @@ func (p *PodmanRuntime) run(ctx context.Context, args ...string) ([]byte, error)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("podman %s: %w: %s", strings.Join(args, " "), err, stderr.String())
+		return nil, fmt.Errorf("podman %s: %w: %s", redactEnvArgs(args), err, stderr.String())
 	}
 	return stdout.Bytes(), nil
+}
+
+// redactEnvArgs returns a string representation of podman args with --env
+// values redacted to prevent leaking secrets (SHIM_TOKEN, etc.) in error messages.
+func redactEnvArgs(args []string) string {
+	redacted := make([]string, len(args))
+	for i, arg := range args {
+		if i > 0 && args[i-1] == "--env" && strings.Contains(arg, "=") {
+			parts := strings.SplitN(arg, "=", 2)
+			redacted[i] = parts[0] + "=REDACTED"
+		} else {
+			redacted[i] = arg
+		}
+	}
+	return strings.Join(redacted, " ")
 }
 
 // SkiffContainerName returns the container name for the main skiff container.
@@ -110,6 +137,16 @@ func SkiffContainerName(taskID string) string {
 // GateContainerName returns the container name for the gate sidecar container.
 func GateContainerName(taskID string) string {
 	return "gate-" + taskID
+}
+
+// DevContainerName returns the container name for the dev container sidecar.
+func DevContainerName(taskID string) string {
+	return "dev-" + taskID
+}
+
+// WorkspaceVolumeName returns the volume name for the shared workspace.
+func WorkspaceVolumeName(taskID string) string {
+	return "workspace-" + taskID
 }
 
 // RunTask starts a skiff container and its gate sidecar using dual-network
@@ -154,6 +191,50 @@ func (p *PodmanRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHandle,
 		return TaskHandle{}, fmt.Errorf("starting gate sidecar: %w", err)
 	}
 
+	// Start dev container sidecar if configured.
+	devName := DevContainerName(spec.TaskID)
+	workspaceVol := WorkspaceVolumeName(spec.TaskID)
+	if spec.DevContainerImage != "" {
+		// Create a shared workspace volume for Skiff ↔ dev container.
+		if _, err := p.run(ctx, "volume", "create", workspaceVol); err != nil {
+			_ = p.stopAndRemove(ctx, gateName)
+			return TaskHandle{}, fmt.Errorf("creating workspace volume: %w", err)
+		}
+
+		// Start the dev container. By default it is on the internal network only
+		// (no external access). When DevContainerNetworkAccess is "external", it
+		// joins both the internal and external networks so it can reach the internet.
+		devArgs := []string{
+			"run", "-d",
+		}
+		if !spec.Debug {
+			devArgs = append(devArgs, "--rm")
+		}
+		devNetworkArg := internalNet
+		if spec.DevContainerNetworkAccess == "external" {
+			devNetworkArg = internalNet + "," + externalNet
+		}
+		devArgs = append(devArgs,
+			"--name", devName,
+			"--network", devNetworkArg,
+			"--security-opt", "label=disable",
+			"-v", workspaceVol+":/workspace",
+			"-v", p.shimBin()+":/usr/local/bin/alcove-shim:ro,z",
+			"--entrypoint", "/usr/local/bin/alcove-shim",
+		)
+		for k, v := range spec.DevContainerEnv {
+			devArgs = append(devArgs, "--env", k+"="+v)
+		}
+		devArgs = append(devArgs, spec.DevContainerImage)
+
+		if _, err := p.run(ctx, devArgs...); err != nil {
+			// Clean up gate + volume on dev container failure.
+			_ = p.stopAndRemove(ctx, gateName)
+			_, _ = p.run(ctx, "volume", "rm", workspaceVol)
+			return TaskHandle{}, fmt.Errorf("starting dev container: %w", err)
+		}
+	}
+
 	// Start the main skiff container on the internal network ONLY.
 	// It can reach Gate, Hail, Ledger, Bridge but NOT the internet.
 	skiffArgs := []string{
@@ -173,6 +254,11 @@ func (p *PodmanRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHandle,
 		skiffArgs = append(skiffArgs, "--network", internalNet)
 	}
 
+	// Mount workspace volume in Skiff if dev container is configured.
+	if spec.DevContainerImage != "" {
+		skiffArgs = append(skiffArgs, "-v", workspaceVol+":/workspace")
+	}
+
 	// Merge spec env with the proxy configuration.
 	skiffEnv := make(map[string]string)
 	for k, v := range spec.Env {
@@ -188,8 +274,12 @@ func (p *PodmanRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHandle,
 		}
 		// Exempt internal services and Gate from proxy. Gate must be reached directly
 		// (not through itself) for ANTHROPIC_BASE_URL to work.
+		noProxyBase := fmt.Sprintf("localhost,127.0.0.1,alcove-hail,alcove-bridge,alcove-ledger,host.containers.internal,%s", gateName)
+		if spec.DevContainerImage != "" {
+			noProxyBase += "," + devName
+		}
 		if _, ok := skiffEnv["NO_PROXY"]; !ok {
-			skiffEnv["NO_PROXY"] = fmt.Sprintf("localhost,127.0.0.1,alcove-hail,alcove-bridge,alcove-ledger,host.containers.internal,%s", gateName)
+			skiffEnv["NO_PROXY"] = noProxyBase
 		}
 	}
 
@@ -199,7 +289,11 @@ func (p *PodmanRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHandle,
 	skiffArgs = append(skiffArgs, spec.Image)
 
 	if _, err := p.run(ctx, skiffArgs...); err != nil {
-		// Clean up the gate container if skiff fails to start.
+		// Clean up the gate container (and dev container + volume if present).
+		if spec.DevContainerImage != "" {
+			_ = p.stopAndRemove(ctx, devName)
+			_, _ = p.run(ctx, "volume", "rm", workspaceVol)
+		}
 		_ = p.stopAndRemove(ctx, gateName)
 		return TaskHandle{}, fmt.Errorf("starting skiff container: %w", err)
 	}
@@ -211,9 +305,12 @@ func (p *PodmanRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHandle,
 }
 
 // CancelTask stops and removes both the skiff and gate containers for a task.
+// It also cleans up any dev container and workspace volume associated with the task.
 func (p *PodmanRuntime) CancelTask(ctx context.Context, handle TaskHandle) error {
 	skiffName := SkiffContainerName(handle.ID)
 	gateName := GateContainerName(handle.ID)
+	devName := DevContainerName(handle.ID)
+	workspaceVol := WorkspaceVolumeName(handle.ID)
 
 	var firstErr error
 	if err := p.stopAndRemove(ctx, skiffName); err != nil {
@@ -222,6 +319,10 @@ func (p *PodmanRuntime) CancelTask(ctx context.Context, handle TaskHandle) error
 	if err := p.stopAndRemove(ctx, gateName); err != nil && firstErr == nil {
 		firstErr = err
 	}
+	// Always attempt dev container cleanup (no-op if not present).
+	_ = p.stopAndRemove(ctx, devName)
+	// Always attempt workspace volume cleanup (no-op if not present).
+	_, _ = p.run(ctx, "volume", "rm", workspaceVol)
 	return firstErr
 }
 
@@ -398,9 +499,14 @@ func (p *PodmanRuntime) CleanupOrphanedContainers(ctx context.Context, prefix st
 			continue
 		}
 
-		// Skiff is gone or not running — clean up the gate container.
+		// Skiff is gone or not running — clean up the orphaned container.
 		log.Printf("cleanup: removing orphaned container %s (skiff %s status: %s)", name, skiffName, status)
 		_ = p.stopAndRemove(ctx, name)
+		// If cleaning up dev containers, also remove the workspace volume.
+		if prefix == "dev-" {
+			workspaceVol := WorkspaceVolumeName(taskID)
+			_, _ = p.run(ctx, "volume", "rm", workspaceVol)
+		}
 		cleaned++
 	}
 

--- a/internal/runtime/podman_test.go
+++ b/internal/runtime/podman_test.go
@@ -239,9 +239,10 @@ func TestCancelTask_CommandConstruction(t *testing.T) {
 		t.Fatalf("CancelTask() error: %v", err)
 	}
 
-	// Should have 4 calls: stop skiff, rm skiff, stop gate, rm gate.
-	if len(*calls) != 4 {
-		t.Fatalf("expected 4 podman calls, got %d", len(*calls))
+	// Should have 7 calls: stop skiff, rm skiff, stop gate, rm gate,
+	// stop dev, rm dev, volume rm.
+	if len(*calls) != 7 {
+		t.Fatalf("expected 7 podman calls, got %d", len(*calls))
 	}
 
 	// Verify stop calls include --time 10.
@@ -260,6 +261,18 @@ func TestCancelTask_CommandConstruction(t *testing.T) {
 	rmGate := strings.Join((*calls)[3], " ")
 	if !strings.Contains(rmGate, "rm -f gate-task-1") {
 		t.Errorf("expected rm gate call, got: %s", rmGate)
+	}
+	stopDev := strings.Join((*calls)[4], " ")
+	if !strings.Contains(stopDev, "stop --time 10 dev-task-1") {
+		t.Errorf("expected stop dev call, got: %s", stopDev)
+	}
+	rmDev := strings.Join((*calls)[5], " ")
+	if !strings.Contains(rmDev, "rm -f dev-task-1") {
+		t.Errorf("expected rm dev call, got: %s", rmDev)
+	}
+	volRm := strings.Join((*calls)[6], " ")
+	if !strings.Contains(volRm, "volume rm workspace-task-1") {
+		t.Errorf("expected volume rm call, got: %s", volRm)
 	}
 }
 
@@ -743,6 +756,276 @@ func TestCleanupOrphanedContainers_EmptyList(t *testing.T) {
 	// Only the ps call should be made.
 	if len(*calls) != 1 {
 		t.Errorf("expected 1 call (ps only), got %d", len(*calls))
+	}
+}
+
+func TestDevContainerName(t *testing.T) {
+	tests := []struct {
+		taskID        string
+		wantDev       string
+		wantWorkspace string
+	}{
+		{"abc123", "dev-abc123", "workspace-abc123"},
+		{"task-uuid-1234", "dev-task-uuid-1234", "workspace-task-uuid-1234"},
+		{"", "dev-", "workspace-"},
+	}
+
+	for _, tt := range tests {
+		if got := DevContainerName(tt.taskID); got != tt.wantDev {
+			t.Errorf("DevContainerName(%q) = %q, want %q", tt.taskID, got, tt.wantDev)
+		}
+		if got := WorkspaceVolumeName(tt.taskID); got != tt.wantWorkspace {
+			t.Errorf("WorkspaceVolumeName(%q) = %q, want %q", tt.taskID, got, tt.wantWorkspace)
+		}
+	}
+}
+
+func TestRunTask_WithDevContainer(t *testing.T) {
+	execFn, calls := fakeExecCommand(t, "container-id-123\n", 0)
+	p := &PodmanRuntime{
+		PodmanBin:   "podman",
+		ShimBin:     "/host/path/to/shim",
+		execCommand: execFn,
+	}
+
+	spec := TaskSpec{
+		TaskID:            "task-dc",
+		Image:             "quay.io/alcove/skiff:latest",
+		GateImage:         "quay.io/alcove/gate:latest",
+		Env:               map[string]string{"TASK_ID": "task-dc"},
+		GateEnv:           map[string]string{"GATE_SCOPE": "read"},
+		Network:           "test-internal",
+		ExternalNet:       "test-external",
+		DevContainerImage: "quay.io/myorg/devenv:latest",
+		DevContainerEnv:   map[string]string{"SHIM_TOKEN": "tok123"},
+	}
+
+	handle, err := p.RunTask(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("RunTask() error: %v", err)
+	}
+	if handle.ID != "task-dc" {
+		t.Errorf("handle.ID = %q, want %q", handle.ID, "task-dc")
+	}
+
+	// Expect 5 calls: gate start, volume create, dev container start, shim exec, skiff start.
+	if len(*calls) != 4 {
+		t.Fatalf("expected 4 podman calls, got %d", len(*calls))
+	}
+
+	// Call 0: gate start.
+	gateArgs := strings.Join((*calls)[0], " ")
+	if !strings.Contains(gateArgs, "--name gate-task-dc") {
+		t.Errorf("gate call missing --name gate-task-dc: %s", gateArgs)
+	}
+
+	// Call 1: volume create.
+	volArgs := strings.Join((*calls)[1], " ")
+	if !strings.Contains(volArgs, "volume create workspace-task-dc") {
+		t.Errorf("expected volume create, got: %s", volArgs)
+	}
+
+	// Call 2: dev container start — should include shim volume mount and entrypoint override.
+	devArgs := strings.Join((*calls)[2], " ")
+	if !strings.Contains(devArgs, "--name dev-task-dc") {
+		t.Errorf("dev call missing --name dev-task-dc: %s", devArgs)
+	}
+	if !strings.Contains(devArgs, "--network test-internal") {
+		t.Errorf("dev call missing internal network: %s", devArgs)
+	}
+	if strings.Contains(devArgs, "test-external") {
+		t.Errorf("dev call must NOT include external network: %s", devArgs)
+	}
+	if !strings.Contains(devArgs, "workspace-task-dc:/workspace") {
+		t.Errorf("dev call missing workspace volume: %s", devArgs)
+	}
+	if !strings.Contains(devArgs, "/host/path/to/shim:/usr/local/bin/alcove-shim:ro") {
+		t.Errorf("dev call missing shim volume mount: %s", devArgs)
+	}
+	if !strings.Contains(devArgs, "--entrypoint /usr/local/bin/alcove-shim") {
+		t.Errorf("dev call missing entrypoint override: %s", devArgs)
+	}
+	if !strings.Contains(devArgs, "SHIM_TOKEN=tok123") {
+		t.Errorf("dev call missing SHIM_TOKEN env: %s", devArgs)
+	}
+	if !strings.Contains(devArgs, "quay.io/myorg/devenv:latest") {
+		t.Errorf("dev call missing dev container image: %s", devArgs)
+	}
+
+	// Call 3: skiff start — should include workspace volume and NO_PROXY with dev container.
+	skiffArgs := strings.Join((*calls)[3], " ")
+	if !strings.Contains(skiffArgs, "--name skiff-task-dc") {
+		t.Errorf("skiff call missing --name skiff-task-dc: %s", skiffArgs)
+	}
+	if !strings.Contains(skiffArgs, "workspace-task-dc:/workspace") {
+		t.Errorf("skiff call missing workspace volume mount: %s", skiffArgs)
+	}
+	if !strings.Contains(skiffArgs, "dev-task-dc") {
+		t.Errorf("skiff NO_PROXY should include dev container name: %s", skiffArgs)
+	}
+}
+
+func TestRunTask_WithoutDevContainer(t *testing.T) {
+	execFn, calls := fakeExecCommand(t, "container-id-123\n", 0)
+	p := &PodmanRuntime{
+		PodmanBin:   "podman",
+		execCommand: execFn,
+	}
+
+	spec := TaskSpec{
+		TaskID:    "task-nodc",
+		Image:     "quay.io/alcove/skiff:latest",
+		GateImage: "quay.io/alcove/gate:latest",
+		Env:       map[string]string{"TASK_ID": "task-nodc"},
+		GateEnv:   map[string]string{"GATE_SCOPE": "read"},
+		Network:   "test-internal",
+		ExternalNet: "test-external",
+		// DevContainerImage intentionally omitted.
+	}
+
+	_, err := p.RunTask(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("RunTask() error: %v", err)
+	}
+
+	// Expect 2 calls: gate start, skiff start. No volume or dev container.
+	if len(*calls) != 2 {
+		t.Fatalf("expected 2 podman calls, got %d", len(*calls))
+	}
+
+	// Verify no volume or dev container calls.
+	for i, call := range *calls {
+		args := strings.Join(call, " ")
+		if strings.Contains(args, "volume create") {
+			t.Errorf("call %d unexpectedly creates a volume: %s", i, args)
+		}
+		if strings.Contains(args, "--name dev-") {
+			t.Errorf("call %d unexpectedly starts a dev container: %s", i, args)
+		}
+	}
+
+	// Skiff should NOT have workspace volume mount.
+	skiffArgs := strings.Join((*calls)[1], " ")
+	if strings.Contains(skiffArgs, "/workspace") {
+		t.Errorf("skiff call should NOT have workspace volume when no dev container: %s", skiffArgs)
+	}
+}
+
+func TestCancelTask_WithDevContainer(t *testing.T) {
+	execFn, calls := fakeExecCommand(t, "", 0)
+	p := &PodmanRuntime{
+		PodmanBin:   "podman",
+		execCommand: execFn,
+	}
+
+	handle := TaskHandle{ID: "task-dc", PodName: "skiff-task-dc"}
+	err := p.CancelTask(context.Background(), handle)
+	if err != nil {
+		t.Fatalf("CancelTask() error: %v", err)
+	}
+
+	// Should have 7 calls: stop/rm skiff, stop/rm gate, stop/rm dev, volume rm.
+	if len(*calls) != 7 {
+		t.Fatalf("expected 7 podman calls, got %d", len(*calls))
+	}
+
+	// Verify dev container cleanup calls.
+	stopDev := strings.Join((*calls)[4], " ")
+	if !strings.Contains(stopDev, "stop --time 10 dev-task-dc") {
+		t.Errorf("expected stop dev call, got: %s", stopDev)
+	}
+	rmDev := strings.Join((*calls)[5], " ")
+	if !strings.Contains(rmDev, "rm -f dev-task-dc") {
+		t.Errorf("expected rm dev call, got: %s", rmDev)
+	}
+	volRm := strings.Join((*calls)[6], " ")
+	if !strings.Contains(volRm, "volume rm workspace-task-dc") {
+		t.Errorf("expected volume rm call, got: %s", volRm)
+	}
+}
+
+func TestRunTask_WithDevContainerExternalNetwork(t *testing.T) {
+	execFn, calls := fakeExecCommand(t, "container-id-123\n", 0)
+	p := &PodmanRuntime{
+		PodmanBin:   "podman",
+		ShimBin:     "/host/path/to/shim",
+		execCommand: execFn,
+	}
+
+	spec := TaskSpec{
+		TaskID:                    "task-dcext",
+		Image:                     "quay.io/alcove/skiff:latest",
+		GateImage:                 "quay.io/alcove/gate:latest",
+		Env:                       map[string]string{"TASK_ID": "task-dcext"},
+		GateEnv:                   map[string]string{"GATE_SCOPE": "read"},
+		Network:                   "test-internal",
+		ExternalNet:               "test-external",
+		DevContainerImage:         "docker.io/library/golang:1.25",
+		DevContainerEnv:           map[string]string{"SHIM_TOKEN": "tok456"},
+		DevContainerNetworkAccess: "external",
+	}
+
+	handle, err := p.RunTask(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("RunTask() error: %v", err)
+	}
+	if handle.ID != "task-dcext" {
+		t.Errorf("handle.ID = %q, want %q", handle.ID, "task-dcext")
+	}
+
+	// Expect 4 calls: gate start, volume create, dev container start, skiff start.
+	if len(*calls) != 4 {
+		t.Fatalf("expected 4 podman calls, got %d", len(*calls))
+	}
+
+	// Call 2: dev container start — should include BOTH internal and external networks.
+	devArgs := strings.Join((*calls)[2], " ")
+	if !strings.Contains(devArgs, "--name dev-task-dcext") {
+		t.Errorf("dev call missing --name dev-task-dcext: %s", devArgs)
+	}
+	if !strings.Contains(devArgs, "--network test-internal,test-external") {
+		t.Errorf("dev call should include both networks when DevContainerNetworkAccess=external: %s", devArgs)
+	}
+}
+
+func TestRunTask_WithDevContainerInternalNetwork(t *testing.T) {
+	execFn, calls := fakeExecCommand(t, "container-id-123\n", 0)
+	p := &PodmanRuntime{
+		PodmanBin:   "podman",
+		ShimBin:     "/host/path/to/shim",
+		execCommand: execFn,
+	}
+
+	spec := TaskSpec{
+		TaskID:                    "task-dcint",
+		Image:                     "quay.io/alcove/skiff:latest",
+		GateImage:                 "quay.io/alcove/gate:latest",
+		Env:                       map[string]string{"TASK_ID": "task-dcint"},
+		GateEnv:                   map[string]string{"GATE_SCOPE": "read"},
+		Network:                   "test-internal",
+		ExternalNet:               "test-external",
+		DevContainerImage:         "docker.io/library/golang:1.25",
+		DevContainerEnv:           map[string]string{"SHIM_TOKEN": "tok789"},
+		DevContainerNetworkAccess: "internal",
+	}
+
+	_, err := p.RunTask(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("RunTask() error: %v", err)
+	}
+
+	// Expect 4 calls: gate start, volume create, dev container start, skiff start.
+	if len(*calls) != 4 {
+		t.Fatalf("expected 4 podman calls, got %d", len(*calls))
+	}
+
+	// Call 2: dev container start — should include ONLY internal network.
+	devArgs := strings.Join((*calls)[2], " ")
+	if !strings.Contains(devArgs, "--network test-internal") {
+		t.Errorf("dev call missing internal network: %s", devArgs)
+	}
+	if strings.Contains(devArgs, "test-external") {
+		t.Errorf("dev call must NOT include external network when DevContainerNetworkAccess=internal: %s", devArgs)
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -36,7 +36,11 @@ type TaskSpec struct {
 	Network      string            // podman network name (podman only); used as the internal network
 	ExternalNet    string            // podman external network for gate egress (podman only)
 	Debug          bool              // if true, containers are not auto-removed on exit
-	DirectOutbound bool              // if true, skiff gets both networks and no HTTP(S)_PROXY
+	DirectOutbound    bool              // if true, skiff gets both networks and no HTTP(S)_PROXY
+	DevContainerImage         string            // Container image for the dev container sidecar
+	DevContainerEnv           map[string]string // env vars for dev container (includes SHIM_TOKEN)
+	DevContainerNetworkAccess string            // "internal" or "external"; defaults to "internal"
+	ShimImage                 string            // Container image for the shim init container (k8s only)
 }
 
 // ServiceSpec describes a long-lived infrastructure service (Hail, Ledger).

--- a/internal/types.go
+++ b/internal/types.go
@@ -17,12 +17,18 @@ package internal
 
 import "time"
 
+// RepoSpec declares a repository for multi-repo agent sessions.
+type RepoSpec struct {
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	URL  string `json:"url" yaml:"url"`
+	Ref  string `json:"ref,omitempty" yaml:"ref,omitempty"`
+}
+
 // Task represents a unit of work dispatched to a Skiff pod.
 type Task struct {
 	ID       string            `json:"id"`
 	Prompt   string            `json:"prompt"`
-	Repo     string            `json:"repo,omitempty"`
-	Branch   string            `json:"branch,omitempty"`
+	Repos    []RepoSpec        `json:"repos,omitempty"`
 	Provider string            `json:"provider"`
 	Scope    Scope             `json:"scope"`
 	Timeout  time.Duration     `json:"timeout"`
@@ -48,7 +54,7 @@ type Session struct {
 	TaskID         string     `json:"task_id"`
 	Submitter      string     `json:"submitter"`
 	Prompt         string     `json:"prompt"`
-	Repo           string     `json:"repo,omitempty"`
+	Repos          []RepoSpec `json:"repos,omitempty"`
 	Provider       string     `json:"provider"`
 	Scope          Scope      `json:"scope"`
 	Status         string     `json:"status"` // running, completed, timeout, cancelled, error

--- a/scripts/test-dev-container.sh
+++ b/scripts/test-dev-container.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# test-dev-container.sh — API-level tests for dev container support.
+# Requires a running Bridge instance with credentials and alcove-testing configured.
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+TOKEN="${TOKEN:-$(curl -s "$BASE_URL/api/v1/auth/login" -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"admin"}' | python3 -c "import sys,json; print(json.load(sys.stdin).get('token',''))")}"
+
+if [ -z "$TOKEN" ]; then
+  echo "FAIL: Could not get auth token"
+  exit 1
+fi
+
+AUTH="Authorization: Bearer $TOKEN"
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+
+echo "=== Dev Container Support Tests ==="
+echo ""
+
+# Test 1: dev_container field appears in agent definitions API
+echo "--- Test 1: Agent definition has dev_container field ---"
+AGENT_DEF=$(curl -s "$BASE_URL/api/v1/agent-definitions" -H "$AUTH" | \
+  python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for item in data.get('agent_definitions', []):
+    if isinstance(item, dict) and item.get('name') == 'Dev Container Test':
+        print(json.dumps(item))
+        break
+")
+
+if [ -z "$AGENT_DEF" ]; then
+  fail "Dev Container Test agent definition not found"
+else
+  IMAGE=$(echo "$AGENT_DEF" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+dc = d.get('dev_container')
+print(dc.get('image', '') if dc else '')
+")
+  if [ "$IMAGE" = "docker.io/library/python:3.11-slim" ]; then
+    pass "dev_container.image = $IMAGE"
+  else
+    fail "Expected python:3.11-slim, got '$IMAGE'"
+  fi
+fi
+
+# Test 2: Agent definition without dev_container has null/missing field
+echo ""
+echo "--- Test 2: Agent definition without dev_container ---"
+TEST_TASK=$(curl -s "$BASE_URL/api/v1/agent-definitions" -H "$AUTH" | \
+  python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for item in data.get('agent_definitions', []):
+    if isinstance(item, dict) and item.get('name') == 'Test Task':
+        dc = item.get('dev_container')
+        print('none' if dc is None else json.dumps(dc))
+        break
+")
+if [ "$TEST_TASK" = "none" ]; then
+  pass "Test Task has no dev_container (null)"
+else
+  fail "Test Task should have null dev_container, got: $TEST_TASK"
+fi
+
+# Test 3: Shim binary builds and runs
+echo ""
+echo "--- Test 3: Shim binary integration test ---"
+if [ ! -f "./bin/shim" ]; then
+  fail "bin/shim not found"
+else
+  SHIM_TOKEN=e2e-test SHIM_PORT=19092 ./bin/shim &
+  SHIM_PID=$!
+  sleep 1
+
+  HEALTH=$(curl -s http://localhost:19092/healthz)
+  if echo "$HEALTH" | grep -q '"ok"'; then
+    pass "Shim healthz returns ok"
+  else
+    fail "Shim healthz unexpected: $HEALTH"
+  fi
+
+  EXEC_RESULT=$(curl -s -X POST http://localhost:19092/exec \
+    -H "Authorization: Bearer e2e-test" \
+    -H "Content-Type: application/json" \
+    -d '{"cmd": "echo hello-e2e", "timeout": 5}')
+  if echo "$EXEC_RESULT" | grep -q 'hello-e2e'; then
+    pass "Shim exec returns command output"
+  else
+    fail "Shim exec unexpected: $EXEC_RESULT"
+  fi
+
+  EXIT_CODE=$(echo "$EXEC_RESULT" | grep '"exit"' | python3 -c "import sys,json; print(json.load(sys.stdin).get('code','?'))")
+  if [ "$EXIT_CODE" = "0" ]; then
+    pass "Shim exec exit code is 0"
+  else
+    fail "Expected exit code 0, got $EXIT_CODE"
+  fi
+
+  AUTH_REJECT=$(curl -s -w "%{http_code}" -o /dev/null -X POST http://localhost:19092/exec \
+    -H "Authorization: Bearer wrong" \
+    -H "Content-Type: application/json" \
+    -d '{"cmd": "echo fail"}')
+  if [ "$AUTH_REJECT" = "401" ]; then
+    pass "Shim rejects bad auth with 401"
+  else
+    fail "Expected 401, got $AUTH_REJECT"
+  fi
+
+  kill $SHIM_PID 2>/dev/null
+  wait $SHIM_PID 2>/dev/null || true
+fi
+
+# Test 4: Makefile builds shim binary
+echo ""
+echo "--- Test 4: Makefile includes shim ---"
+if grep -q 'CMDS.*shim' Makefile; then
+  pass "Makefile CMDS includes shim"
+else
+  fail "Makefile CMDS missing shim"
+fi
+
+if grep -q 'SHIM_BIN_PATH' Makefile; then
+  pass "Makefile passes SHIM_BIN_PATH to Bridge"
+else
+  fail "Makefile missing SHIM_BIN_PATH"
+fi
+
+# Test 5: Shim binary is statically linked
+echo ""
+echo "--- Test 5: Shim binary ---"
+if [ -f "./bin/shim" ]; then
+  if file ./bin/shim | grep -q "statically linked"; then
+    pass "bin/shim is statically linked"
+  else
+    fail "bin/shim is not statically linked"
+  fi
+else
+  fail "bin/shim not found"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -714,7 +714,7 @@
     function renderTaskDefCard(d) {
         var name = d.name || 'Unnamed';
         var desc = d.description || '';
-        var repo = d.source_repo || d.repo || '';
+        var repo = d.source_repo || '';
         var id = d.id || '';
         var repoPaused = d.repo_disabled || false;
 
@@ -757,6 +757,17 @@
             tags.push('<span class="agent-def-tag agent-def-tag-repo">' + escapeHtml(shortRepo) + '</span>');
         }
         html += '<div class="agent-def-tags">' + tags.join('') + '</div>';
+
+        // Target repos list
+        if (d.repos && d.repos.length > 0) {
+            html += '<div class="agent-def-repos" style="margin-top:4px;font-size:12px;color:var(--text-muted);">';
+            html += '<span class="agent-def-label">Repos:</span> ';
+            html += d.repos.map(function(r) {
+                var url = r.url || r.URL || '';
+                return escapeHtml(url.replace(/^https?:\/\//, '').replace(/\.git$/, ''));
+            }).join(', ');
+            html += '</div>';
+        }
 
         // Schedule and trigger details
         var details = [];
@@ -824,9 +835,9 @@
         } else {
             tags.push('<span class="agent-def-tag agent-def-tag-manual">manual</span>');
         }
-        if (s.repo) {
-            var shortRepo = s.repo.replace(/^https?:\/\//, '').replace(/\.git$/, '');
-            tags.push('<span class="agent-def-tag agent-def-tag-repo">' + escapeHtml(shortRepo) + '</span>');
+        if (s.repos && s.repos.length > 0) {
+            var repoSummary = formatReposSummary(s.repos);
+            tags.push('<span class="agent-def-tag agent-def-tag-repo">' + escapeHtml(repoSummary) + '</span>');
         }
         html += '<div class="agent-def-tags">' + tags.join('') + '</div>';
 
@@ -1334,6 +1345,15 @@
         show(empty);
     }
 
+    function formatReposSummary(repos) {
+        if (!repos || repos.length === 0) return '';
+        if (repos.length === 1) {
+            var url = repos[0].url || repos[0].URL || '';
+            return url.replace(/^https?:\/\//, '').replace(/\.git$/, '');
+        }
+        return repos.length + ' repos';
+    }
+
     function renderSessionRow(s) {
         var status = s.status || 'unknown';
         var taskName = s.task_name || 'Manual Session';
@@ -1352,9 +1372,15 @@
             durationHtml = escapeHtml(formatDuration(s.started_at, s.finished_at, s.duration));
         }
 
+        var repoLabel = '';
+        var repoSummary = formatReposSummary(s.repos);
+        if (repoSummary) {
+            repoLabel = ' <span style="color:var(--text-muted);font-size:12px;">' + escapeHtml(repoSummary) + '</span>';
+        }
+
         return '<tr class="clickable session-row session-row-' + escapeHtml(status) + '" data-session-id="' + escapeHtml(s.id) + '" tabindex="0" role="link">' +
             '<td><span class="status-dot status-dot-' + escapeHtml(status) + '" title="' + escapeHtml(status) + '"></span></td>' +
-            '<td><span class="agent-type-pill agent-type-' + escapeHtml(taskType.color) + '">' + escapeHtml(taskType.label) + '</span>' + escapeHtml(taskName) + '</td>' +
+            '<td><span class="agent-type-pill agent-type-' + escapeHtml(taskType.color) + '">' + escapeHtml(taskType.label) + '</span>' + escapeHtml(taskName) + repoLabel + '</td>' +
             '<td>' + escapeHtml(submitter) + '</td>' +
             '<td>' + escapeHtml(when) + '</td>' +
             '<td class="mono">' + durationHtml + '</td>' +
@@ -2246,6 +2272,17 @@
             { label: 'Exit Code', value: s.exit_code !== undefined && s.exit_code !== null ? String(s.exit_code) : '-' }
         ];
 
+        if (s.repos && s.repos.length > 0) {
+            var repoNames = s.repos.map(function(r) {
+                var url = r.url || r.URL || '';
+                var name = r.name || r.Name || '';
+                var display = url.replace(/^https?:\/\//, '').replace(/\.git$/, '');
+                if (name) display = name + ' (' + display + ')';
+                return display;
+            });
+            fields.push({ label: 'Repos', value: repoNames.join(', ') });
+        }
+
         if (s.direct_outbound) {
             fields.push({ label: 'Network', value: 'Direct Outbound', badge: false });
         }
@@ -2364,6 +2401,13 @@
         if (config.model) html += '<tr><td>Model</td><td>' + escapeHtml(config.model) + '</td></tr>';
         html += '<tr><td>Network</td><td>' + (config.direct_outbound ? '<span class="badge" style="background:rgba(231,76,60,0.2);color:#e74c3c;">Direct Outbound</span>' : '<span class="badge">Gate Proxied</span>') + '</td></tr>';
         html += '</tbody></table></div>';
+
+        // Dev Container
+        if (config.dev_container && config.dev_container.image) {
+            html += '<div class="rc-section"><h4>Dev Container</h4><table class="data-table"><tbody>';
+            html += '<tr><td>Image</td><td><code>' + escapeHtml(config.dev_container.image) + '</code></td></tr>';
+            html += '</tbody></table></div>';
+        }
 
         // Security Profiles
         if (config.profiles && config.profiles.length > 0) {


### PR DESCRIPTION
## Summary

- **Dev containers**: Optional project-provided containers alongside Skiff with execution shim (`cmd/shim`), shared `/workspace` volume, NDJSON streaming API, bearer auth, `network_access: internal|external`
- **Multi-repo**: `repos:` list replaces `repo:` string. `RepoSpec{Name, URL, Ref}`. `REPOS` JSON env var. `/workspace/<name>/` layout. DB migration: `repos JSONB` replaces `repo TEXT`
- **Kubernetes**: Dev container as native sidecar, shim-init container, `DEV_CONTAINER_HOST=localhost:9090`, network access limitation documented
- **Release**: Shim binary built and uploaded as release asset

## Details

37 files changed, ~2400 lines added. Covers: runtime (Podman, Docker, K8s), dispatcher, agent definitions, skiff-init, workflow engine, API, dashboard, database migration, CI/CD, and all documentation.

## Test plan

- [x] `go test -race ./...` — all pass
- [x] Single-repo session with dev container — exit 0, shim works
- [x] Multi-repo session (2 repos) — both cloned to `/workspace/<name>/`
- [x] Dev container internal network — DNS blocked, no internet
- [x] Dev container external network — httpbin.org reachable
- [x] Shared branch pipeline — 2 agents collaborate on same branch
- [x] K8s Pod spec construction — unit tests for sidecar, shim-init, volumes
- [x] `scripts/test-dev-container.sh` — 9/9 pass
- [x] Release simulation — shim binary built statically for all platforms

Closes #337, #338, #339, #340, #341, #342, #343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)