### PR TITLE
Convert agent definitions to repos: list format

### DIFF
--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -20,7 +20,8 @@ prompt: |
 
   Output: {"summary": "what you implemented"}
 
-repo: https://github.com/bmbouter/alcove.git
+repos:
+  - url: https://github.com/bmbouter/alcove.git
 timeout: 7200
 
 outputs:

--- a/.alcove/tasks/planning.yml
+++ b/.alcove/tasks/planning.yml
@@ -12,7 +12,8 @@ prompt: |
 
   Output: {"plan_posted": true, "issue_number": N}
 
-repo: https://github.com/bmbouter/alcove.git
+repos:
+  - url: https://github.com/bmbouter/alcove.git
 timeout: 1800
 
 outputs:

--- a/.alcove/tasks/release.yml
+++ b/.alcove/tasks/release.yml
@@ -15,7 +15,8 @@ prompt: |
 
   Output: {"version": "vX.Y.Z", "has_commits": true/false}
 
-repo: https://github.com/bmbouter/alcove.git
+repos:
+  - url: https://github.com/bmbouter/alcove.git
 timeout: 3600
 
 outputs:

--- a/.alcove/tasks/reviewer.yml
+++ b/.alcove/tasks/reviewer.yml
@@ -12,7 +12,8 @@ prompt: |
 
   Output: {"approved": true/false, "comments": "summary of review"}
 
-repo: https://github.com/bmbouter/alcove.git
+repos:
+  - url: https://github.com/bmbouter/alcove.git
 timeout: 1800
 
 outputs:

--- a/.alcove/tasks/security-reviewer.yml
+++ b/.alcove/tasks/security-reviewer.yml
@@ -14,7 +14,8 @@ prompt: |
 
   Output: {"approved": true/false, "comments": "security findings"}
 
-repo: https://github.com/bmbouter/alcove.git
+repos:
+  - url: https://github.com/bmbouter/alcove.git
 timeout: 1800
 
 outputs:


### PR DESCRIPTION
## Summary
- Convert all 5 agent definitions in `.alcove/tasks/` from `repo:` (string) to `repos:` (list)
- Ports the format change from alcove-testing to alcove's own SDLC pipeline definitions
- Required by the multi-repo support added in v0.25.0

## Test plan
- [x] YAML is valid (same format as alcove-testing which is already syncing correctly)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)