### PR TITLE
Add alcove agents CLI commands

### DIFF
--- a/cmd/alcove/agents.go
+++ b/cmd/alcove/agents.go
@@ -1,0 +1,447 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// agentDefinition represents an agent definition from GET /api/v1/agent-definitions.
+type agentDefinition struct {
+	ID           string          `json:"id"`
+	Name         string          `json:"name"`
+	Description  string          `json:"description"`
+	Repos        []agentRepoSpec `json:"repos,omitempty"`
+	DevContainer json.RawMessage `json:"dev_container,omitempty"`
+	SourceRepo   string          `json:"source_repo"`
+	SourceFile   string          `json:"source_file"`
+	SyncError    string          `json:"sync_error,omitempty"`
+	RepoDisabled bool            `json:"repo_disabled"`
+	LastSynced   string          `json:"last_synced,omitempty"`
+}
+
+// agentRepoSpec represents a repo entry in an agent definition.
+type agentRepoSpec struct {
+	URL string `json:"url"`
+	Ref string `json:"ref,omitempty"`
+}
+
+// agentDefinitionsResponse is the response from GET /api/v1/agent-definitions.
+type agentDefinitionsResponse struct {
+	AgentDefinitions []agentDefinition `json:"agent_definitions"`
+	Count            int               `json:"count"`
+}
+
+// agentRepo represents an agent repo from GET /api/v1/user/settings/agent-repos.
+type agentRepo struct {
+	URL     string `json:"url"`
+	Ref     string `json:"ref,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Enabled *bool  `json:"enabled,omitempty"`
+}
+
+// agentReposResponse is the response from GET /api/v1/user/settings/agent-repos.
+type agentReposResponse struct {
+	Repos []agentRepo `json:"repos"`
+}
+
+func newAgentsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agents",
+		Short: "Manage agent definitions and repos",
+	}
+	cmd.AddCommand(
+		newAgentsListCmd(),
+		newAgentsSyncCmd(),
+		newAgentsReposCmd(),
+		newAgentsRunCmd(),
+	)
+	return cmd
+}
+
+// ---------- agents list ----------
+
+func newAgentsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List synced agent definitions",
+		RunE:  runAgentsList,
+	}
+}
+
+func runAgentsList(cmd *cobra.Command, _ []string) error {
+	resp, err := apiRequest(cmd, http.MethodGet, "/api/v1/agent-definitions", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result agentDefinitionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(result)
+	}
+
+	if len(result.AgentDefinitions) == 0 {
+		fmt.Fprintln(os.Stderr, "No agent definitions found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tDESCRIPTION\tDEV_CONTAINER\tLAST_SYNCED\tSOURCE")
+	for _, d := range result.AgentDefinitions {
+		desc := d.Description
+		if len(desc) > 40 {
+			desc = desc[:37] + "..."
+		}
+
+		devContainer := "no"
+		if len(d.DevContainer) > 0 && string(d.DevContainer) != "null" {
+			devContainer = "yes"
+		}
+
+		lastSynced := d.LastSynced
+		if t, err := time.Parse(time.RFC3339Nano, d.LastSynced); err == nil {
+			lastSynced = t.Local().Format("2006-01-02 15:04")
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			d.Name, desc, devContainer, lastSynced, d.SourceRepo)
+	}
+	return w.Flush()
+}
+
+// ---------- agents sync ----------
+
+func newAgentsSyncCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "sync",
+		Short: "Trigger agent definition sync",
+		RunE:  runAgentsSync,
+	}
+}
+
+func runAgentsSync(cmd *cobra.Command, _ []string) error {
+	resp, err := apiRequest(cmd, http.MethodPost, "/api/v1/agent-definitions/sync", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	if isJSONOutput(cmd) {
+		var result map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return fmt.Errorf("decoding response: %w", err)
+		}
+		return outputJSON(result)
+	}
+
+	fmt.Fprintf(os.Stderr, "Synced successfully at %s\n", time.Now().Local().Format("2006-01-02 15:04:05"))
+	return nil
+}
+
+// ---------- agents repos ----------
+
+func newAgentsReposCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repos",
+		Short: "List configured agent repos",
+		RunE:  runAgentsRepos,
+	}
+	cmd.AddCommand(
+		newAgentsReposAddCmd(),
+		newAgentsReposRemoveCmd(),
+	)
+	return cmd
+}
+
+func runAgentsRepos(cmd *cobra.Command, _ []string) error {
+	repos, err := fetchAgentRepos(cmd)
+	if err != nil {
+		return err
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(repos)
+	}
+
+	if len(repos) == 0 {
+		fmt.Fprintln(os.Stderr, "No agent repos configured.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tURL\tREF")
+	for _, r := range repos {
+		ref := r.Ref
+		if ref == "" {
+			ref = "main"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", r.Name, r.URL, ref)
+	}
+	return w.Flush()
+}
+
+func fetchAgentRepos(cmd *cobra.Command) ([]agentRepo, error) {
+	resp, err := apiRequest(cmd, http.MethodGet, "/api/v1/user/settings/agent-repos", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result agentReposResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return result.Repos, nil
+}
+
+func putAgentRepos(cmd *cobra.Command, repos []agentRepo) error {
+	reqBody := map[string]interface{}{"repos": repos}
+	resp, err := apiRequest(cmd, http.MethodPut, "/api/v1/user/settings/agent-repos", reqBody)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// ---------- agents repos add ----------
+
+func newAgentsReposAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add an agent repo",
+		RunE:  runAgentsReposAdd,
+	}
+	cmd.Flags().String("url", "", "Repository URL (required)")
+	cmd.Flags().String("ref", "", "Branch, tag, or commit (default: main)")
+	cmd.Flags().String("name", "", "Display name for the repo")
+	return cmd
+}
+
+func runAgentsReposAdd(cmd *cobra.Command, _ []string) error {
+	repoURL, _ := cmd.Flags().GetString("url")
+	if repoURL == "" {
+		return fmt.Errorf("--url is required")
+	}
+
+	ref, _ := cmd.Flags().GetString("ref")
+	name, _ := cmd.Flags().GetString("name")
+
+	repos, err := fetchAgentRepos(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Check for duplicate URL.
+	for _, r := range repos {
+		if r.URL == repoURL {
+			return fmt.Errorf("agent repo with URL %q already exists", repoURL)
+		}
+	}
+
+	newRepo := agentRepo{
+		URL:  repoURL,
+		Ref:  ref,
+		Name: name,
+	}
+	repos = append(repos, newRepo)
+
+	if err := putAgentRepos(cmd, repos); err != nil {
+		return err
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(newRepo)
+	}
+
+	fmt.Fprintf(os.Stderr, "Agent repo added: %s\n", repoURL)
+	return nil
+}
+
+// ---------- agents repos remove ----------
+
+func newAgentsReposRemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove an agent repo",
+		RunE:  runAgentsReposRemove,
+	}
+	cmd.Flags().String("url", "", "Repository URL to remove")
+	cmd.Flags().String("name", "", "Name of the repo to remove")
+	return cmd
+}
+
+func runAgentsReposRemove(cmd *cobra.Command, _ []string) error {
+	repoURL, _ := cmd.Flags().GetString("url")
+	repoName, _ := cmd.Flags().GetString("name")
+
+	if repoURL == "" && repoName == "" {
+		return fmt.Errorf("either --url or --name is required")
+	}
+
+	repos, err := fetchAgentRepos(cmd)
+	if err != nil {
+		return err
+	}
+
+	var filtered []agentRepo
+	found := false
+	for _, r := range repos {
+		if (repoURL != "" && r.URL == repoURL) || (repoName != "" && r.Name == repoName) {
+			found = true
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+
+	if !found {
+		if repoURL != "" {
+			return fmt.Errorf("agent repo with URL %q not found", repoURL)
+		}
+		return fmt.Errorf("agent repo with name %q not found", repoName)
+	}
+
+	if filtered == nil {
+		filtered = []agentRepo{}
+	}
+
+	if err := putAgentRepos(cmd, filtered); err != nil {
+		return err
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(map[string]string{"status": "removed"})
+	}
+
+	identifier := repoURL
+	if identifier == "" {
+		identifier = repoName
+	}
+	fmt.Fprintf(os.Stderr, "Agent repo removed: %s\n", identifier)
+	return nil
+}
+
+// ---------- agents run ----------
+
+func newAgentsRunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run <name>",
+		Short: "Run an agent definition by name",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runAgentsRun,
+	}
+	cmd.Flags().Bool("watch", false, "Stream transcript via SSE after dispatch")
+	return cmd
+}
+
+func runAgentsRun(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	// Fetch agent definitions to find the one matching by name.
+	resp, err := apiRequest(cmd, http.MethodGet, "/api/v1/agent-definitions", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result agentDefinitionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	var matchedDef *agentDefinition
+	for i, d := range result.AgentDefinitions {
+		if d.Name == name {
+			matchedDef = &result.AgentDefinitions[i]
+			break
+		}
+	}
+
+	if matchedDef == nil {
+		return fmt.Errorf("agent definition %q not found", name)
+	}
+
+	// Dispatch the agent definition.
+	runPath := fmt.Sprintf("/api/v1/agent-definitions/%s/run", matchedDef.ID)
+	runResp, err := apiRequest(cmd, http.MethodPost, runPath, nil)
+	if err != nil {
+		return err
+	}
+	defer runResp.Body.Close()
+
+	if runResp.StatusCode != http.StatusCreated && runResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(runResp.Body)
+		return fmt.Errorf("bridge returned %d: %s", runResp.StatusCode, string(body))
+	}
+
+	var runResult runResponse
+	if err := json.NewDecoder(runResp.Body).Decode(&runResult); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(runResult)
+	}
+
+	fmt.Fprintf(os.Stderr, "Session dispatched: %s\n", runResult.ID)
+
+	watch, _ := cmd.Flags().GetBool("watch")
+	if watch {
+		return streamSSE(cmd, runResult.ID, "/api/v1/sessions/"+runResult.ID+"/transcript")
+	}
+
+	fmt.Println(runResult.ID)
+	return nil
+}

--- a/cmd/alcove/main.go
+++ b/cmd/alcove/main.go
@@ -103,6 +103,7 @@ func main() {
 		newTeamsCmd(),
 		newCatalogCmd(),
 		newCredentialsCmd(),
+		newAgentsCmd(),
 		newVersionCmd(),
 	)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1502,3 +1502,221 @@ alcove credentials delete 12345678-abcd-1234-abcd-123456789012
 # JSON output
 alcove credentials delete --output json 12345678-abcd-1234-abcd-123456789012
 ```
+
+---
+
+## alcove agents
+
+Manage agent definitions and agent repos. Agent definitions are synced from
+YAML files in registered agent repos (`.alcove/tasks/*.yml`). Use these
+commands to list, sync, run agents, and manage the repos they come from.
+
+```
+alcove agents <subcommand>
+```
+
+### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List synced agent definitions |
+| `sync` | Trigger agent definition sync |
+| `run` | Run an agent definition by name |
+| `repos` | List and manage configured agent repos |
+
+---
+
+## alcove agents list
+
+List synced agent definitions for the active team.
+
+```
+alcove agents list
+```
+
+### Flags
+
+No command-specific flags. Supports global `--output json`.
+
+### Description
+
+Displays all agent definitions that have been synced from registered agent
+repos. Each row shows the agent name, source repo, and other metadata.
+
+### Examples
+
+```bash
+# List all agent definitions
+alcove agents list
+
+# JSON output
+alcove agents list --output json
+```
+
+---
+
+## alcove agents sync
+
+Trigger an immediate agent definition sync.
+
+```
+alcove agents sync
+```
+
+### Flags
+
+No command-specific flags. Supports global `--output json`.
+
+### Description
+
+Requests the Bridge to sync agent definitions from all registered agent repos
+immediately, rather than waiting for the next automatic sync interval
+(default: 15 minutes). This is equivalent to clicking "Sync Now" in the
+dashboard.
+
+### Examples
+
+```bash
+# Trigger a sync
+alcove agents sync
+```
+
+---
+
+## alcove agents run
+
+Run an agent definition by name.
+
+```
+alcove agents run <name> [flags]
+```
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--watch` | bool | Stream the session transcript via SSE after dispatch |
+
+### Description
+
+Dispatches a session using a named agent definition. The agent definition must
+have been synced from an agent repo. The agent's prompt, repos, provider,
+model, timeout, budget, profiles, and tools are all taken from the definition.
+
+With `--watch`, the CLI streams the live transcript until the session completes
+(same behavior as `alcove run --watch`).
+
+### Examples
+
+```bash
+# Run an agent by name
+alcove agents run run-tests
+
+# Run and stream the transcript
+alcove agents run --watch run-tests
+
+# JSON output
+alcove agents run --output json run-tests
+```
+
+---
+
+## alcove agents repos
+
+List configured agent repos for the active team.
+
+```
+alcove agents repos
+```
+
+### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `add` | Add an agent repo |
+| `remove` | Remove an agent repo |
+
+### Flags
+
+No command-specific flags. Supports global `--output json`.
+
+### Description
+
+When run without a subcommand, lists all agent repos configured for the active
+team. Each row shows the repo name, URL, and ref (branch/tag).
+
+### Examples
+
+```bash
+# List agent repos
+alcove agents repos
+
+# JSON output
+alcove agents repos --output json
+```
+
+---
+
+## alcove agents repos add
+
+Add an agent repo.
+
+```
+alcove agents repos add [flags]
+```
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--url` | string | Repository URL (required) |
+| `--ref` | string | Branch, tag, or commit (default: `main`) |
+| `--name` | string | Display name for the repo |
+
+### Description
+
+Registers a new agent repo for the active team. Bridge will sync agent
+definitions from `.alcove/tasks/*.yml` in the repo on the next sync cycle.
+
+### Examples
+
+```bash
+# Add a repo with default branch
+alcove agents repos add --url https://github.com/org/my-agents.git
+
+# Add a repo with a specific branch and display name
+alcove agents repos add --url https://github.com/org/my-agents.git --ref develop --name "My Agents"
+```
+
+---
+
+## alcove agents repos remove
+
+Remove an agent repo.
+
+```
+alcove agents repos remove [flags]
+```
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--url` | string | Repository URL to remove |
+| `--name` | string | Name of the repo to remove |
+
+### Description
+
+Removes an agent repo from the active team. Provide either `--url` or `--name`
+to identify the repo to remove. Agent definitions previously synced from this
+repo will be removed on the next sync.
+
+### Examples
+
+```bash
+# Remove a repo by URL
+alcove agents repos remove --url https://github.com/org/my-agents.git
+
+# Remove a repo by name
+alcove agents repos remove --name "My Agents"
+```


### PR DESCRIPTION
## Summary
- `alcove agents list` — list synced agent definitions with LAST_SYNCED timestamps
- `alcove agents sync` — trigger sync with timestamp feedback
- `alcove agents repos` — list/add/remove agent repos
- `alcove agents run <name>` — dispatch by agent definition name
- CLI reference docs for all 7 commands

## Test plan
- [x] All commands tested against live dev environment (12 tests + 7 edge cases)
- [x] Help text verified for all subcommands
- [x] JSON output mode works
- [x] Error cases handled (missing flags, duplicates, not found)
- [x] `go build ./...` and `go test ./...` pass
- [x] CLI reference docs added

🤖 Generated with [Claude Code](https://claude.com/claude-code)