### PR TITLE
Remove standalone triggers from reviewer agents

### DIFF
--- a/.alcove/tasks/reviewer.yml
+++ b/.alcove/tasks/reviewer.yml
@@ -25,15 +25,3 @@ profiles:
 plugins:
   - name: code-review
     source: claude-plugins-official
-
-trigger:
-  github:
-    events:
-      - pull_request
-    actions:
-      - labeled
-    repos:
-      - bmbouter/alcove
-    labels:
-      - awaiting-review
-    delivery_mode: polling

--- a/.alcove/tasks/security-reviewer.yml
+++ b/.alcove/tasks/security-reviewer.yml
@@ -27,15 +27,3 @@ profiles:
 plugins:
   - name: code-review
     source: claude-plugins-official
-
-trigger:
-  github:
-    events:
-      - pull_request
-    actions:
-      - labeled
-    repos:
-      - bmbouter/alcove
-    labels:
-      - awaiting-review
-    delivery_mode: polling


### PR DESCRIPTION
## Summary
- Remove standalone `trigger:` blocks from `reviewer.yml` and `security-reviewer.yml`
- Reviewers are now invoked solely through the SDLC pipeline (`feature-pipeline.yml`)
- Eliminates duplicate review sessions that occurred when both the pipeline and standalone triggers fired for the same PR
- The `awaiting-review` label from GitHub Actions (`label-on-ci-pass.yml`) stays as a human-visible signal

## Test plan
- [x] Verified alcove-testing already works pipeline-only (no standalone reviewer triggers)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)