### PR TITLE
Add CLAUDE.md injection and dev containers to SDLC pipeline

### DIFF
--- a/.alcove/tasks/autonomous-dev.yml
+++ b/.alcove/tasks/autonomous-dev.yml
@@ -14,8 +14,6 @@ prompt: |
 
   Follow existing code patterns and conventions. Include tests for new functionality. Update documentation when behavior changes.
 
-  Run `go build ./...` and `go vet ./...` before pushing -- these are non-negotiable.
-
   Use a team of specialist agents working in parallel for independent work streams.
 
   Output: {"summary": "what you implemented"}
@@ -23,6 +21,9 @@ prompt: |
 repos:
   - url: https://github.com/bmbouter/alcove.git
 timeout: 7200
+
+dev_container:
+  image: localhost/alcove-dev:latest
 
 outputs:
   - summary

--- a/.alcove/tasks/reviewer.yml
+++ b/.alcove/tasks/reviewer.yml
@@ -16,6 +16,9 @@ repos:
   - url: https://github.com/bmbouter/alcove.git
 timeout: 1800
 
+dev_container:
+  image: localhost/alcove-dev:latest
+
 outputs:
   - approved
   - comments

--- a/.alcove/tasks/security-reviewer.yml
+++ b/.alcove/tasks/security-reviewer.yml
@@ -18,6 +18,9 @@ repos:
   - url: https://github.com/bmbouter/alcove.git
 timeout: 1800
 
+dev_container:
+  image: localhost/alcove-dev:latest
+
 outputs:
   - approved
   - comments

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Read these for full context:
 
 1. `docs/design/implementation-status.md` — **START HERE** — current state, what works, what's next
 2. `docs/design/architecture.md` — component design, deployment diagrams, network isolation, roadmap
-3. `docs/design/architecture-decisions.md` — 21 resolved decisions, CLI design, config format, repo layout
+3. `docs/design/architecture-decisions.md` — 22 resolved decisions, CLI design, config format, repo layout
 4. `docs/design/problem-statement.md` — why ephemeral agents
 5. `docs/design/credential-management.md` — credential storage, encryption, OAuth2 token flow
 6. `docs/design/auth-backends.md` — auth backend design (memory, postgres, rh-identity)
@@ -105,5 +105,35 @@ RUNTIME=docker \
 - **YAML is the single source of truth for schedules, security profiles, and tools** — no API-based creation, update, or deletion; schedules are defined via `schedule:` in `.alcove/tasks/*.yml`; security profiles in `.alcove/security-profiles/*.yml`; tools come from catalog or builtin definitions; the API provides read-only access to synced data
 - **`alcove.yaml` for infrastructure settings** — config file search order: `ALCOVE_CONFIG_FILE` env var → `./alcove.yaml` → `/etc/alcove/alcove.yaml`; env vars always override; `database_encryption_key` is required (Bridge refuses to start without it); `make up` auto-generates the file for local dev; file is gitignored
 - **`.dev-credentials.yaml` for dev credentials** — single source of truth for local dev LLM provider and GitHub PAT; copy `.dev-credentials.yaml.example`, fill in values; `make dev-config` (run by `make up`) merges LLM settings into `alcove.yaml`; the dev-up process reads it to create API credentials in the database; file is gitignored
-- **Dev containers are optional sidecars** — agent definitions can declare `dev_container.image` to run a project-provided container alongside Skiff; dev container images are built with s6-overlay and the shim binary baked in (`make build-dev` builds the base image from `build/Containerfile.dev`); s6 manages PostgreSQL, NATS, and the shim as supervised services with proper dependencies; Podman creates a shared workspace volume at `/workspace` and mounts it in both containers; the shim provides bearer-auth-protected `POST /exec` for remote command execution with NDJSON streaming; `dev_container.network_access` controls network access (`internal` default, `external` joins both networks on Podman); on Kubernetes, the dev container runs as a native sidecar with emptyDir workspace volume (`DEV_CONTAINER_HOST=localhost:9090`); Docker rejects dev containers with a clear error; `--security-opt label=disable` handles SELinux compatibility on Podman; see architecture decision #20 in `docs/design/architecture-decisions.md` for the full design
+- **Dev containers are optional sidecars** — agent definitions can declare `dev_container.image` to run a project-provided container alongside Skiff; dev container images are built with s6-overlay and the shim binary baked in (`make build-dev` builds the base image from `build/Containerfile.dev`); `Containerfile.dev` is an all-in-one dev container image that includes PostgreSQL 16, NATS, Go 1.25, the shim binary, and s6-overlay for process supervision; s6 manages PostgreSQL, NATS, and the shim as supervised services with proper dependencies; Podman creates a shared workspace volume at `/workspace` and mounts it in both containers; the shim provides bearer-auth-protected `POST /exec` for remote command execution with NDJSON streaming; `dev_container.network_access` controls network access (`internal` default, `external` joins both networks on Podman); on Kubernetes, the dev container runs as a native sidecar with emptyDir workspace volume (`DEV_CONTAINER_HOST=localhost:9090`); Docker rejects dev containers with a clear error; `--security-opt label=disable` handles SELinux compatibility on Podman; see architecture decision #20 in `docs/design/architecture-decisions.md` for the full design
 - **Multi-repo support** — agent definitions use `repos:` (a list of `RepoSpec` with `name`, `url`, `ref` fields) instead of a single `repo:` string; Skiff receives a `REPOS` JSON env var and clones each repo into `/workspace/<name>/`; database migration `031_multi_repo.sql` replaces the `repo TEXT` column with `repos JSONB`; see architecture decision #21 in `docs/design/architecture-decisions.md` for the full design
+- **CLAUDE.md injection** — Claude Code runs with `--bare` which disables native CLAUDE.md discovery; skiff-init reads `CLAUDE.md` from cloned repos and prepends the content to the agent prompt, so project instructions are automatically available to agents without duplicating them in agent prompts; see architecture decision #22 in `docs/design/architecture-decisions.md` for the full design
+
+## Dev Container Usage
+
+When a dev container is available (`$DEV_CONTAINER_HOST` is set), use it for all build, test, and lint commands instead of running them directly. The dev container has the full project toolchain.
+
+```bash
+# Check dev container health
+curl -s http://$DEV_CONTAINER_HOST/healthz
+
+# Run tests
+curl -s -X POST http://$DEV_CONTAINER_HOST/exec \
+  -H "Authorization: Bearer $DEV_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"cmd":"cd /workspace && make test","timeout":300}'
+
+# Build
+curl -s -X POST http://$DEV_CONTAINER_HOST/exec \
+  -H "Authorization: Bearer $DEV_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"cmd":"cd /workspace && go build ./...","timeout":120}'
+
+# Run go vet
+curl -s -X POST http://$DEV_CONTAINER_HOST/exec \
+  -H "Authorization: Bearer $DEV_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"cmd":"cd /workspace && go vet ./...","timeout":120}'
+```
+
+Do not run build/test commands directly when a dev container is available -- always use the dev container via `POST /exec`.

--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -178,6 +178,11 @@ func main() {
 		os.Chdir("/workspace")
 	}
 
+	// --- Inject CLAUDE.md from cloned repos ---
+	// Claude Code runs with --bare which disables native CLAUDE.md discovery.
+	// We read it explicitly and prepend it to the prompt.
+	task.Prompt = injectClaudeMD(task.Repos, task.Prompt)
+
 	// --- Install lola modules (must run after cloneRepo so cwd is correct) ---
 	installLolaModules()
 
@@ -1045,6 +1050,45 @@ func cloneRepoToDir(repo, ref, targetDir string) error {
 func repoNameFromURL(rawURL string) string {
 	base := filepath.Base(strings.TrimRight(rawURL, "/"))
 	return strings.TrimSuffix(base, ".git")
+}
+
+// injectClaudeMD reads CLAUDE.md from cloned repos and prepends it to the prompt.
+// For single-repo clones, it reads /workspace/CLAUDE.md.
+// For multi-repo clones, it reads /workspace/<name>/CLAUDE.md from each repo.
+func injectClaudeMD(repos []internal.RepoSpec, prompt string) string {
+	var claudeMDs []string
+
+	if len(repos) == 0 {
+		return prompt
+	}
+
+	if len(repos) == 1 {
+		content, err := os.ReadFile("/workspace/CLAUDE.md")
+		if err == nil && len(content) > 0 {
+			log.Printf("injected CLAUDE.md from /workspace/CLAUDE.md (%d bytes)", len(content))
+			claudeMDs = append(claudeMDs, string(content))
+		}
+	} else {
+		for _, r := range repos {
+			dir := r.Name
+			if dir == "" {
+				dir = repoNameFromURL(r.URL)
+			}
+			path := filepath.Join("/workspace", dir, "CLAUDE.md")
+			content, err := os.ReadFile(path)
+			if err == nil && len(content) > 0 {
+				log.Printf("injected CLAUDE.md from %s (%d bytes)", path, len(content))
+				claudeMDs = append(claudeMDs, string(content))
+			}
+		}
+	}
+
+	if len(claudeMDs) == 0 {
+		return prompt
+	}
+
+	// Prepend CLAUDE.md content to the prompt
+	return strings.Join(claudeMDs, "\n\n---\n\n") + "\n\n---\n\n" + prompt
 }
 
 // requireEnv returns the value of an environment variable or exits fatally.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -746,13 +746,21 @@ Skiff clones each repo into `/workspace/<name>/`. If a single `repo:` string
 is provided (legacy), it is converted to a single-element `repos` list
 internally. The `REPOS` JSON env var is injected into Skiff with the full list.
 
+**CLAUDE.md injection:** When a repo contains a `CLAUDE.md` file, skiff-init
+automatically reads it and prepends the content to the agent prompt. This means
+dev container usage instructions (e.g., how to build and test via `POST /exec`)
+should be documented in the project's `CLAUDE.md` rather than duplicated in
+agent definition prompts.
+
 **How it works:**
 
 - Podman creates a shared workspace volume and mounts it at `/workspace` in both
   Skiff and the dev container.
 - The shim binary (`cmd/shim`) is baked into the dev container image at build
   time via s6-overlay. The dev container image is built with `make build-dev`
-  from `build/Containerfile.dev`. `--security-opt label=disable` is set on the
+  from `build/Containerfile.dev`. `Containerfile.dev` is an all-in-one image
+  that includes PostgreSQL 16, NATS, Go 1.25, the shim binary, and s6-overlay
+  for process supervision. `--security-opt label=disable` is set on the
   dev container for SELinux compatibility on Podman.
 - The shim exposes `GET /healthz` and `POST /exec` (NDJSON streaming) on port
   9090, protected by bearer auth (`SHIM_TOKEN`).

--- a/docs/design/architecture-decisions.md
+++ b/docs/design/architecture-decisions.md
@@ -398,6 +398,33 @@ lets agents work across repo boundaries without manual workarounds. The
 `/workspace/<name>/` layout keeps each clone isolated and predictable.
 
 
+### 22. CLAUDE.md Injection into Agent Prompts
+
+**Decision**: skiff-init reads `CLAUDE.md` from cloned repositories and
+prepends the content to the agent prompt before invoking Claude Code.
+
+**How it works**:
+- Claude Code runs with `--bare`, which disables native CLAUDE.md file
+  discovery, hooks, plugins, and keychain access.
+- After cloning repositories, skiff-init checks for `CLAUDE.md` at the
+  workspace root. For single-repo clones, it reads `/workspace/CLAUDE.md`.
+  For multi-repo clones, it reads `/workspace/<name>/CLAUDE.md` from each
+  repo and concatenates them.
+- The CLAUDE.md content is prepended to the agent prompt, so the agent
+  receives project-specific instructions (coding conventions, build
+  commands, dev container usage patterns) automatically.
+- This means dev container instructions, build commands, and project
+  conventions should be documented in `CLAUDE.md` rather than duplicated
+  in agent definition prompts.
+
+**Rationale**: The `--bare` flag is necessary for sandboxed execution (no
+hooks, no plugins, no keychain), but it also disables CLAUDE.md discovery.
+Explicit injection restores project context while maintaining sandbox
+safety. Keeping project instructions in `CLAUDE.md` (which is
+version-controlled with the repo) rather than in agent prompts avoids
+duplication and keeps agent definitions minimal.
+
+
 ## CLI Design
 
 ### Phase 1 Commands
@@ -507,6 +534,7 @@ alcove/
 │   └── auth/           # Authentication, session management
 ├── build/
 │   ├── Containerfile.bridge
+│   ├── Containerfile.dev
 │   ├── Containerfile.gate
 │   ├── Containerfile.skiff-base
 │   └── Containerfile.skiff-example

--- a/docs/design/implementation-status.md
+++ b/docs/design/implementation-status.md
@@ -93,13 +93,14 @@ alcove/
 │   ├── Containerfile.bridge    ✅ Multi-stage (golang:1.25 → ubi9/ubi)
 │   ├── Containerfile.gate      ✅ Multi-stage (golang:1.25 → ubi9-minimal)
 │   ├── alcove-credential-helper ✅ Git credential helper binary (used by Skiff for HTTPS git auth via Gate)
-│   └── Containerfile.skiff-base ✅ Multi-stage (golang:1.25 → ubi9/ubi + nodejs + claude-code + gh + glab + credential helper)
+│   ├── Containerfile.skiff-base ✅ Multi-stage (golang:1.25 → ubi9/ubi + nodejs + claude-code + gh + glab + credential helper)
+│   └── Containerfile.dev        ✅ All-in-one dev container (golang:1.25 + PostgreSQL 16 + NATS + shim + s6-overlay)
 ├── docs/
 │   ├── getting-started.md      ✅ 5-minute quick start guide
 │   └── design/
 │       ├── implementation-status.md    ✅ This file
 │       ├── architecture.md             ✅ Full component design
-│       ├── architecture-decisions.md   ✅ 21 resolved decisions
+│       ├── architecture-decisions.md   ✅ 22 resolved decisions
 │       ├── problem-statement.md        ✅ Why ephemeral agents
 │       ├── credential-management.md    ✅ Credential storage and token flow design
 │       ├── auth-backends.md            ✅ Dual auth backend design
@@ -116,6 +117,7 @@ alcove/
 - `localhost/alcove-bridge:dev` ✅ (Bridge controller + dashboard)
 - `localhost/alcove-gate:dev` ✅
 - `localhost/alcove-skiff-base:dev` ✅ (includes Claude Code CLI via npm)
+- `localhost/alcove-dev:dev` ✅ (all-in-one dev container: PostgreSQL 16 + NATS + Go 1.25 + shim + s6-overlay; built with `make build-dev`)
 
 ### Infrastructure Tested
 
@@ -362,7 +364,10 @@ alcove/
     workspace volume; `DEV_CONTAINER_HOST` is overridden to `localhost:9090`
     since K8s pod containers share a network namespace. Docker rejects dev
     containers with a clear error. Dev container images are built with
-    `make build-dev` from `build/Containerfile.dev`.
+    `make build-dev` from `build/Containerfile.dev`. `Containerfile.dev` is an
+    all-in-one image that includes PostgreSQL 16, NATS, Go 1.25, the shim
+    binary, and s6-overlay for process supervision. Project `CLAUDE.md` files
+    are automatically injected into agent prompts by skiff-init (see item 31).
 
 30. **Multi-Repo Support** — Agent definitions use a `repos:` list (each entry
     is a `RepoSpec` with `name`, `url`, and optional `ref` fields) instead of
@@ -371,6 +376,15 @@ alcove/
     omitted, it is derived from the URL. Database migration
     `031_multi_repo.sql` replaces the `repo TEXT` column with `repos JSONB`
     on both `sessions` and `schedules` tables, migrating existing data.
+
+31. **CLAUDE.md Injection** — Claude Code runs with `--bare` which disables
+    native CLAUDE.md file discovery. After cloning repositories, skiff-init
+    reads `CLAUDE.md` from the workspace root (single-repo) or from each
+    `/workspace/<name>/CLAUDE.md` (multi-repo) and prepends the content to
+    the agent prompt. This means project instructions (coding conventions,
+    build commands, dev container usage patterns) are automatically available
+    to agents without duplicating them in agent definition prompts. See
+    architecture decision #22.
 
 ## How to Run (Developer Workflow)
 
@@ -443,7 +457,7 @@ See the full roadmap in [architecture-decisions.md](architecture-decisions.md#ro
 ## Key Design Documents
 
 - [architecture.md](architecture.md) — full component design, deployment diagrams, network isolation
-- [architecture-decisions.md](architecture-decisions.md) — 21 resolved decisions, CLI design, config format, repo layout, revised roadmap
+- [architecture-decisions.md](architecture-decisions.md) — 22 resolved decisions, CLI design, config format, repo layout, revised roadmap
 - [problem-statement.md](problem-statement.md) — why ephemeral agents (context contamination, credential drift, filesystem poisoning, credential exposure)
 - [credential-management.md](credential-management.md) — credential storage, encryption, OAuth2 token flow, token refresh design
 - [auth-backends.md](auth-backends.md) — auth backend design (memory, postgres, rh-identity)

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -82,6 +82,30 @@ make build-images     # Fast overlay builds (~30s with pre-built tooling)
 make -j3 build-images
 ```
 
+### Building the dev container image
+
+```bash
+make build-dev
+```
+
+Builds `localhost/alcove-dev:<version>` from `build/Containerfile.dev`. This is
+an all-in-one dev container image that includes PostgreSQL 16, NATS, Go 1.25,
+the shim binary, and s6-overlay for process supervision. Agent definitions that
+declare `dev_container.image` can reference this image (or any project-specific
+image built on top of it). The shim, PostgreSQL, and NATS are managed as s6
+supervised services with proper startup dependencies.
+
+### CLAUDE.md injection
+
+Claude Code runs with `--bare` inside Skiff, which disables native CLAUDE.md
+file discovery. To restore project context, skiff-init reads `CLAUDE.md` from
+cloned repos after checkout and prepends the content to the agent prompt. For
+single-repo sessions it reads `/workspace/CLAUDE.md`; for multi-repo sessions
+it reads `/workspace/<name>/CLAUDE.md` from each repo. This means project
+instructions (coding conventions, build commands, dev container usage patterns)
+are automatically available to agents without duplicating them in agent
+definition prompts.
+
 ### Running tests
 
 ```bash
@@ -841,3 +865,4 @@ All Containerfiles live in `build/`:
 | `Containerfile.bridge` | `alcove-bridge` | Base: `ubi9/ubi` (needs podman for spawning Skiff+Gate) |
 | `Containerfile.gate` | `alcove-gate` | Base: `ubi9-minimal` (lightweight proxy binary) |
 | `Containerfile.skiff-base` | `alcove-skiff-base` | Base: `ubi9/ubi` (Claude Code worker environment; includes `gh`, `glab`, `alcove-credential-helper`, and git config forcing HTTPS) |
+| `Containerfile.dev` | `alcove-dev` | Base: `golang:1.25` (all-in-one dev container with PostgreSQL 16, NATS, shim binary, s6-overlay; built with `make build-dev`) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -451,7 +451,11 @@ with `direct_outbound: true` in the agent definition. See
 Agents that need to build or test code in a project-specific environment can
 declare a `dev_container.image` in their agent definition. This starts an
 additional container alongside Skiff with a shared `/workspace` volume and an
-execution shim for running commands remotely. Agents can also work across
+execution shim for running commands remotely. Alcove provides
+`build/Containerfile.dev`, an all-in-one dev container image with PostgreSQL,
+NATS, Go, and the shim (built with `make build-dev`). The project's `CLAUDE.md`
+is automatically injected into agent prompts, so dev container instructions do
+not need to be repeated in agent definitions. Agents can also work across
 multiple repositories using the `repos:` list in their definition -- each
 repo is cloned into `/workspace/<name>/`. See `docs/configuration.md` for
 the full `dev_container` and `repos` field references.

--- a/docs/workflow-authoring.md
+++ b/docs/workflow-authoring.md
@@ -442,6 +442,9 @@ on the task alone:
 
 - **Keep prompts under 100 words.** Shorter prompts produce better results and
   cost less.
+- **Do not duplicate CLAUDE.md content in prompts.** The project's `CLAUDE.md`
+  is automatically injected into the prompt by skiff-init. Put dev container
+  instructions, build commands, and coding conventions there instead.
 - **Focus on what to do, not how to interact with infrastructure.** Bridge
   actions handle PR creation, CI monitoring, and merging.
 - **`$BRANCH` is set by the workflow engine.** Agents push to it automatically.
@@ -474,16 +477,26 @@ with a shared `/workspace` volume. The agent can then build and test code
 inside the dev container via the execution shim. This is configured in the
 agent definition, not in the workflow step itself.
 
+**CLAUDE.md is automatically injected:** skiff-init reads `CLAUDE.md` from
+cloned repos and prepends it to the agent prompt. Dev container usage
+instructions (how to call `POST /exec`, which tools are available) should be
+documented in the project's `CLAUDE.md` rather than duplicated in agent
+definition prompts. This keeps prompts minimal and ensures all agents working
+on the repo receive the same project context.
+
 ```yaml
 # In .alcove/tasks/go-dev.yml
 name: go-dev
 prompt: |
-  Implement the feature, then run `go test ./...` in the dev container.
+  Implement the feature and run tests before pushing.
 repos:
   - url: https://github.com/org/myproject.git
 dev_container:
   image: golang:1.25
 ```
+
+The prompt does not need to explain how to use the dev container -- that
+information comes from the repo's `CLAUDE.md` automatically.
 
 See `docs/configuration.md` for the full `dev_container` field reference and
 runtime support matrix.


### PR DESCRIPTION
## Summary
- **CLAUDE.md injection**: skiff-init reads CLAUDE.md from cloned repos and prepends to agent prompt (since `--bare` disables native discovery)
- **SDLC dev containers**: Autonomous Developer, PR Reviewer, Security Reviewer now declare `dev_container.image: localhost/alcove-dev:latest`
- **Single source of truth**: Dev container instructions live in CLAUDE.md, not duplicated in agent prompts
- **Docs**: Decision #22, updated implementation-status, configuration, development-guide, workflow-authoring, getting-started

## Test plan
- [x] `go build ./...` and `go test ./...` pass
- [x] Agent definitions have `dev_container` block but zero curl instructions in prompts
- [x] CLAUDE.md has "Dev Container Usage" section
- [x] Decision count (22) consistent across all docs
- [x] No stale `repo:` references in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)