### PR TITLE
Fix dev container workspace permissions for repo cloning

### DIFF
--- a/internal/runtime/podman.go
+++ b/internal/runtime/podman.go
@@ -219,6 +219,12 @@ func (p *PodmanRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHandle,
 			_, _ = p.run(ctx, "volume", "rm", workspaceVol)
 			return TaskHandle{}, fmt.Errorf("starting dev container: %w", err)
 		}
+
+		// Ensure /workspace is writable by UID 1001 (the skiff user).
+		// The dev container image may have created /workspace with root ownership.
+		if _, err := p.run(ctx, "exec", devName, "chmod", "777", "/workspace"); err != nil {
+			log.Printf("warning: could not chmod /workspace in dev container: %v", err)
+		}
 	}
 
 	// Start the main skiff container on the internal network ONLY.

--- a/internal/runtime/podman_test.go
+++ b/internal/runtime/podman_test.go
@@ -808,8 +808,8 @@ func TestRunTask_WithDevContainer(t *testing.T) {
 	}
 
 	// Expect 4 calls: gate start, volume create, dev container start, skiff start.
-	if len(*calls) != 4 {
-		t.Fatalf("expected 4 podman calls, got %d", len(*calls))
+	if len(*calls) != 5 {
+		t.Fatalf("expected 5 podman calls, got %d", len(*calls))
 	}
 
 	// Call 0: gate start.
@@ -845,8 +845,14 @@ func TestRunTask_WithDevContainer(t *testing.T) {
 		t.Errorf("dev call missing dev container image: %s", devArgs)
 	}
 
-	// Call 3: skiff start — should include workspace volume and NO_PROXY with dev container.
-	skiffArgs := strings.Join((*calls)[3], " ")
+	// Call 3: chmod workspace for UID 1001 writability.
+	chmodArgs := strings.Join((*calls)[3], " ")
+	if !strings.Contains(chmodArgs, "exec dev-task-dc chmod 777 /workspace") {
+		t.Errorf("expected chmod on workspace, got: %s", chmodArgs)
+	}
+
+	// Call 4: skiff start — should include workspace volume and NO_PROXY with dev container.
+	skiffArgs := strings.Join((*calls)[4], " ")
 	if !strings.Contains(skiffArgs, "--name skiff-task-dc") {
 		t.Errorf("skiff call missing --name skiff-task-dc: %s", skiffArgs)
 	}
@@ -966,8 +972,8 @@ func TestRunTask_WithDevContainerExternalNetwork(t *testing.T) {
 	}
 
 	// Expect 4 calls: gate start, volume create, dev container start, skiff start.
-	if len(*calls) != 4 {
-		t.Fatalf("expected 4 podman calls, got %d", len(*calls))
+	if len(*calls) != 5 {
+		t.Fatalf("expected 5 podman calls, got %d", len(*calls))
 	}
 
 	// Call 2: dev container start — should include BOTH internal and external networks.
@@ -1006,8 +1012,8 @@ func TestRunTask_WithDevContainerInternalNetwork(t *testing.T) {
 	}
 
 	// Expect 4 calls: gate start, volume create, dev container start, skiff start.
-	if len(*calls) != 4 {
-		t.Fatalf("expected 4 podman calls, got %d", len(*calls))
+	if len(*calls) != 5 {
+		t.Fatalf("expected 5 podman calls, got %d", len(*calls))
 	}
 
 	// Call 2: dev container start — should include ONLY internal network.


### PR DESCRIPTION
## Summary
- Fix "Permission denied" error when cloning repos into shared /workspace volume with dev containers
- After starting the dev container, `chmod 777 /workspace` ensures UID 1001 (skiff) can write to the shared volume
- Root cause: dev container image owns /workspace as root, but skiff-init runs as UID 1001

## Test plan
- [x] Local: Upgrade Pulp Dependencies agent runs successfully with dev container (120 transcript entries, 93 proxy log entries)
- [x] Local: repo clones to /workspace, CLAUDE.md injected, agent executes all phases
- [x] All unit tests pass (podman_test.go updated for new chmod call)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)