### PR TITLE
Add manual workflow trigger via API, CLI, and dashboard

### DIFF
--- a/cmd/alcove/main.go
+++ b/cmd/alcove/main.go
@@ -104,6 +104,7 @@ func main() {
 		newCatalogCmd(),
 		newCredentialsCmd(),
 		newAgentsCmd(),
+		newWorkflowsCmd(),
 		newVersionCmd(),
 	)
 

--- a/cmd/alcove/workflows.go
+++ b/cmd/alcove/workflows.go
@@ -1,0 +1,292 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// workflowInfo represents a workflow from the API.
+type workflowInfo struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	SourceRepo string `json:"source_repo"`
+	SourceFile string `json:"source_file"`
+	SyncError  string `json:"sync_error,omitempty"`
+	LastSynced string `json:"last_synced"`
+	TeamID     string `json:"team_id"`
+}
+
+// workflowsListResponse is the response from GET /api/v1/workflows.
+type workflowsListResponse struct {
+	Workflows []workflowInfo `json:"workflows"`
+	Count     int            `json:"count"`
+}
+
+// workflowRunInfo represents a workflow run from the API.
+type workflowRunInfo struct {
+	ID          string `json:"id"`
+	WorkflowID  string `json:"workflow_id"`
+	Status      string `json:"status"`
+	TriggerType string `json:"trigger_type,omitempty"`
+	TriggerRef  string `json:"trigger_ref,omitempty"`
+	CurrentStep string `json:"current_step,omitempty"`
+	StartedAt   string `json:"started_at,omitempty"`
+	FinishedAt  string `json:"finished_at,omitempty"`
+	TeamID      string `json:"team_id"`
+	CreatedAt   string `json:"created_at"`
+}
+
+// workflowRunsListResponse is the response from GET /api/v1/workflow-runs.
+type workflowRunsListResponse struct {
+	WorkflowRuns []workflowRunInfo `json:"workflow_runs"`
+	Count        int               `json:"count"`
+}
+
+func newWorkflowsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workflows",
+		Short: "Manage workflows and workflow runs",
+	}
+	cmd.AddCommand(
+		newWorkflowsListCmd(),
+		newWorkflowsRunCmd(),
+		newWorkflowsRunsCmd(),
+	)
+	return cmd
+}
+
+// ---------- workflows list ----------
+
+func newWorkflowsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all workflows",
+		RunE:  runWorkflowsList,
+	}
+}
+
+func runWorkflowsList(cmd *cobra.Command, _ []string) error {
+	resp, err := apiRequest(cmd, http.MethodGet, "/api/v1/workflows", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result workflowsListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(result)
+	}
+
+	if len(result.Workflows) == 0 {
+		fmt.Fprintln(os.Stderr, "No workflows found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tSOURCE\tLAST SYNCED\tERROR")
+	for _, wf := range result.Workflows {
+		lastSynced := wf.LastSynced
+		if t, err := time.Parse(time.RFC3339Nano, wf.LastSynced); err == nil {
+			lastSynced = t.Local().Format("2006-01-02 15:04")
+		}
+		syncError := wf.SyncError
+		if len(syncError) > 30 {
+			syncError = syncError[:27] + "..."
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			wf.ID, wf.Name, wf.SourceRepo, lastSynced, syncError)
+	}
+	return w.Flush()
+}
+
+// ---------- workflows run ----------
+
+func newWorkflowsRunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run <id-or-name>",
+		Short: "Trigger a workflow run",
+		Long:  "Start a new workflow run by workflow ID or name. If a name is provided, it will be resolved to a workflow ID.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runWorkflowsRun,
+	}
+	cmd.Flags().String("trigger-ref", "", "Optional trigger reference (e.g., branch name, PR number)")
+	return cmd
+}
+
+func runWorkflowsRun(cmd *cobra.Command, args []string) error {
+	idOrName := args[0]
+	triggerRef, _ := cmd.Flags().GetString("trigger-ref")
+
+	// Resolve name to ID if needed: first try to list workflows and match by name.
+	workflowID, err := resolveWorkflowID(cmd, idOrName)
+	if err != nil {
+		return err
+	}
+
+	reqBody := map[string]string{
+		"workflow_id": workflowID,
+	}
+	if triggerRef != "" {
+		reqBody["trigger_ref"] = triggerRef
+	}
+
+	resp, err := apiRequest(cmd, http.MethodPost, "/api/v1/workflow-runs", reqBody)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result workflowRunInfo
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(result)
+	}
+
+	fmt.Fprintf(os.Stderr, "Workflow run started: %s\n", result.ID)
+	fmt.Println(result.ID)
+	return nil
+}
+
+// resolveWorkflowID resolves a workflow ID or name to an ID.
+// If the argument looks like a UUID (contains hyphens), it is used directly.
+// Otherwise, workflows are listed and matched by name.
+func resolveWorkflowID(cmd *cobra.Command, idOrName string) (string, error) {
+	// If it looks like a UUID, use it directly.
+	if looksLikeUUID(idOrName) {
+		return idOrName, nil
+	}
+
+	// Otherwise, list workflows and match by name.
+	resp, err := apiRequest(cmd, http.MethodGet, "/api/v1/workflows", nil)
+	if err != nil {
+		return "", fmt.Errorf("listing workflows: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("listing workflows: bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result workflowsListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decoding workflows: %w", err)
+	}
+
+	for _, wf := range result.Workflows {
+		if wf.Name == idOrName {
+			return wf.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("workflow %q not found", idOrName)
+}
+
+// looksLikeUUID returns true if the string contains hyphens, suggesting it is a UUID.
+func looksLikeUUID(s string) bool {
+	hyphenCount := 0
+	for _, c := range s {
+		if c == '-' {
+			hyphenCount++
+		}
+	}
+	return hyphenCount >= 4 && len(s) >= 32
+}
+
+// ---------- workflows runs ----------
+
+func newWorkflowsRunsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runs",
+		Short: "List workflow runs",
+		RunE:  runWorkflowsRuns,
+	}
+	cmd.Flags().String("status", "", "Filter by status (pending, running, completed, failed, cancelled, awaiting_approval)")
+	return cmd
+}
+
+func runWorkflowsRuns(cmd *cobra.Command, _ []string) error {
+	path := "/api/v1/workflow-runs"
+	if status, _ := cmd.Flags().GetString("status"); status != "" {
+		path += "?status=" + status
+	}
+
+	resp, err := apiRequest(cmd, http.MethodGet, path, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result workflowRunsListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	if isJSONOutput(cmd) {
+		return outputJSON(result)
+	}
+
+	if len(result.WorkflowRuns) == 0 {
+		fmt.Fprintln(os.Stderr, "No workflow runs found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tWORKFLOW\tSTATUS\tTRIGGER\tCURRENT STEP\tCREATED")
+	for _, run := range result.WorkflowRuns {
+		created := run.CreatedAt
+		if t, err := time.Parse(time.RFC3339Nano, run.CreatedAt); err == nil {
+			created = t.Local().Format("2006-01-02 15:04")
+		}
+		trigger := run.TriggerType
+		if run.TriggerRef != "" {
+			trigger += ":" + run.TriggerRef
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			run.ID, run.WorkflowID, run.Status, trigger, run.CurrentStep, created)
+	}
+	return w.Flush()
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2220,6 +2220,58 @@ curl "http://localhost:8080/api/v1/workflow-runs?status=running" \
   -H "X-Alcove-Team: $TEAM_ID"
 ```
 
+### POST /api/v1/workflow-runs
+
+Trigger a new workflow run manually.
+
+**Request body:**
+
+```json
+{
+  "workflow_id": "b1c2d3e4-f5a6-7890-abcd-ef1234567890",
+  "trigger_ref": ""
+}
+```
+
+| Field          | Type   | Required | Description |
+|----------------|--------|----------|-------------|
+| `workflow_id`  | string | yes      | The workflow definition ID to run |
+| `trigger_ref`  | string | no       | Optional trigger reference (e.g., branch name, PR number) |
+
+**Response (201):**
+
+```json
+{
+  "id": "c2d3e4f5-a6b7-8901-bcde-f12345678901",
+  "workflow_id": "b1c2d3e4-f5a6-7890-abcd-ef1234567890",
+  "status": "running",
+  "trigger_type": "manual",
+  "trigger_ref": "",
+  "step_outputs": {},
+  "started_at": "2026-04-15T14:00:00Z",
+  "team_id": "550e8400-e29b-41d4-a716-446655440000",
+  "created_at": "2026-04-15T14:00:00Z"
+}
+```
+
+**Status codes:**
+
+| Code | Meaning |
+|------|---------|
+| 201  | Workflow run created and started |
+| 400  | Invalid body or missing `workflow_id` |
+| 500  | Failed to start workflow run |
+
+**curl example:**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/workflow-runs \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Alcove-Team: $TEAM_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"workflow_id": "b1c2d3e4-f5a6-7890-abcd-ef1234567890"}'
+```
+
 ### GET /api/v1/workflow-runs/{id}
 
 Get detailed information about a workflow run, including all step executions.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1720,3 +1720,123 @@ alcove agents repos remove --url https://github.com/org/my-agents.git
 # Remove a repo by name
 alcove agents repos remove --name "My Agents"
 ```
+
+---
+
+## alcove workflows
+
+Manage workflows and workflow runs. Workflows are multi-step execution graphs
+defined in YAML and synced from agent repos.
+
+```
+alcove workflows <subcommand>
+```
+
+### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List all workflow definitions |
+| `run` | Trigger a workflow run by ID or name |
+| `runs` | List workflow runs |
+
+---
+
+## alcove workflows list
+
+List all workflow definitions for the active team.
+
+```
+alcove workflows list
+```
+
+### Flags
+
+No command-specific flags. Supports global `--output json`.
+
+### Description
+
+Displays all workflow definitions in a table. Each row shows the workflow ID,
+name, source repo, last sync time, and any sync errors.
+
+### Examples
+
+```bash
+# List all workflows
+alcove workflows list
+
+# JSON output
+alcove workflows list --output json
+```
+
+---
+
+## alcove workflows run
+
+Trigger a workflow run manually.
+
+```
+alcove workflows run <id-or-name> [flags]
+```
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--trigger-ref` | string | Optional trigger reference (e.g., branch name, PR number) |
+
+### Description
+
+Starts a new workflow run by workflow ID or name. If a name is provided, it is
+resolved to a workflow ID by listing all workflows and matching by name. On
+success, prints the workflow run ID to stdout.
+
+### Examples
+
+```bash
+# Trigger by name
+alcove workflows run "Pulp Dependency Upgrade Pipeline"
+
+# Trigger by ID
+alcove workflows run b1c2d3e4-f5a6-7890-abcd-ef1234567890
+
+# With a trigger reference
+alcove workflows run "My Workflow" --trigger-ref "feature/new-api"
+
+# JSON output
+alcove workflows run --output json "My Workflow"
+```
+
+---
+
+## alcove workflows runs
+
+List workflow runs for the active team.
+
+```
+alcove workflows runs [flags]
+```
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--status` | string | Filter by status: `pending`, `running`, `completed`, `failed`, `cancelled`, `awaiting_approval` |
+
+### Description
+
+Displays workflow runs in a table. Each row shows the run ID, workflow ID,
+status, trigger type, current step, and creation time.
+
+### Examples
+
+```bash
+# List all workflow runs
+alcove workflows runs
+
+# Filter by status
+alcove workflows runs --status running
+
+# JSON output
+alcove workflows runs --output json
+```

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -2393,26 +2393,51 @@ func (a *API) handleWorkflows(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleWorkflowRuns(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
-		return
-	}
-
 	teamID := getActiveTeamID(r)
 
-	status := r.URL.Query().Get("status")
+	switch r.Method {
+	case http.MethodGet:
+		status := r.URL.Query().Get("status")
 
-	runs, err := a.workflowEngine.ListWorkflowRuns(r.Context(), status, teamID)
-	if err != nil {
-		log.Printf("error listing workflow runs: %v", err)
-		respondError(w, http.StatusInternalServerError, "failed to list workflow runs")
-		return
+		runs, err := a.workflowEngine.ListWorkflowRuns(r.Context(), status, teamID)
+		if err != nil {
+			log.Printf("error listing workflow runs: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to list workflow runs")
+			return
+		}
+
+		respondJSON(w, http.StatusOK, map[string]any{
+			"workflow_runs": runs,
+			"count":         len(runs),
+		})
+
+	case http.MethodPost:
+		var req struct {
+			WorkflowID string `json:"workflow_id"`
+			TriggerRef string `json:"trigger_ref"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+			return
+		}
+
+		if req.WorkflowID == "" {
+			respondError(w, http.StatusBadRequest, "workflow_id is required")
+			return
+		}
+
+		run, err := a.workflowEngine.StartWorkflowRun(r.Context(), req.WorkflowID, "manual", req.TriggerRef, teamID)
+		if err != nil {
+			log.Printf("error starting workflow run for workflow %s: %v", req.WorkflowID, err)
+			respondError(w, http.StatusInternalServerError, "failed to start workflow run: "+err.Error())
+			return
+		}
+
+		respondJSON(w, http.StatusCreated, run)
+
+	default:
+		respondError(w, http.StatusMethodNotAllowed, "method not allowed")
 	}
-
-	respondJSON(w, http.StatusOK, map[string]any{
-		"workflow_runs": runs,
-		"count":         len(runs),
-	})
 }
 
 func (a *API) handleWorkflowRunByID(w http.ResponseWriter, r *http.Request) {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5292,7 +5292,7 @@
                     '<div class="workflow-def-step-count">' + stepCount + ' step' + (stepCount === 1 ? '' : 's') + '</div>' +
                 '</div>' +
                 '<div class="workflow-def-actions">' +
-                    '<button class="btn btn-small btn-outline" disabled>Trigger Manually</button>' +
+                    '<button class="btn btn-small btn-outline workflow-trigger-btn" data-workflow-id="' + escapeHtml(workflow.id) + '">Trigger Manually</button>' +
                 '</div>' +
             '</div>' +
             dag +
@@ -5305,6 +5305,35 @@
             agentWarning;
 
         container.appendChild(card);
+
+        // Attach trigger button handler
+        var triggerBtn = card.querySelector('.workflow-trigger-btn');
+        if (triggerBtn) {
+            triggerBtn.addEventListener('click', async function() {
+                var workflowId = triggerBtn.getAttribute('data-workflow-id');
+                triggerBtn.disabled = true;
+                triggerBtn.textContent = 'Triggering...';
+                try {
+                    var resp = await api('POST', '/api/v1/workflow-runs', { workflow_id: workflowId });
+                    if (!resp.ok) {
+                        var data = await resp.json().catch(function() { return {}; });
+                        alert(data.error || data.message || 'Failed to trigger workflow.');
+                    } else {
+                        var run = await resp.json();
+                        var runId = run.id || '';
+                        // Navigate to the workflow run detail page
+                        navigate('workflow-run/' + runId);
+                        return;
+                    }
+                } catch (err) {
+                    if (err.message !== 'unauthorized' && err.message !== 'rh-identity-auth-error') {
+                        alert('Failed to trigger workflow.');
+                    }
+                }
+                triggerBtn.textContent = 'Trigger Manually';
+                triggerBtn.disabled = false;
+            });
+        }
     }
 
     function workflowStatusBadgeClass(status) {
@@ -5446,7 +5475,7 @@
     }
 
     function buildTriggerInfo(trigger) {
-        if (!trigger) return '🔧 Manual only';
+        if (!trigger) return '🔧 Manual';
 
         var info = [];
         if (trigger.events && trigger.events.length > 0) {
@@ -5462,7 +5491,7 @@
             info.push('⏰ Schedule: ' + trigger.schedule);
         }
 
-        return info.length > 0 ? info.join(' • ') : '🔧 Manual only';
+        return info.length > 0 ? info.join(' • ') : '🔧 Manual';
     }
 
     // Attach filter change handler


### PR DESCRIPTION
## Summary
- **API:** `POST /api/v1/workflow-runs` with `{"workflow_id": "..."}` creates a workflow run with `trigger_type: "manual"`
- **CLI:** `alcove workflows list`, `alcove workflows run <name-or-id>`, `alcove workflows runs [--status ...]`
- **Dashboard:** "Trigger Manually" button now functional (was disabled), navigates to run detail on success. Fixed "Manual Only" label to "Manual"
- **Docs:** API reference and CLI reference updated

## Test plan
- [x] API: curl POST creates run with trigger_type=manual, GET shows steps
- [x] CLI: list/run/runs all work, name resolution works, status filter works
- [x] UI: button not disabled, calls correct endpoint, "Manual Only" removed
- [x] Build and all tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)