### PR TITLE
Add k3s local development workflow for Kubernetes backend testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Read these for full context:
 
 1. `docs/design/implementation-status.md` — **START HERE** — current state, what works, what's next
 2. `docs/design/architecture.md` — component design, deployment diagrams, network isolation, roadmap
-3. `docs/design/architecture-decisions.md` — 22 resolved decisions, CLI design, config format, repo layout
+3. `docs/design/architecture-decisions.md` — 23 resolved decisions, CLI design, config format, repo layout
 4. `docs/design/problem-statement.md` — why ephemeral agents
 5. `docs/design/credential-management.md` — credential storage, encryption, OAuth2 token flow
 6. `docs/design/auth-backends.md` — auth backend design (memory, postgres, rh-identity)
@@ -71,9 +71,10 @@ make dev-down                 # Stop everything
 make dev-reset                # Stop + remove volumes (clean slate)
 
 # k3s (Kubernetes backend) — test k8s runtime locally
+# Requires sudo for k3s install and image import. Stop podman infra first: make down
 make k3s-setup                # Install k3s, configure kubeconfig + firewalld (run once)
 make k3s-up                   # Build images, deploy NATS+PostgreSQL to k3s, start port-forwards
-make k3s-watch                # Hot-reload Bridge via Air with RUNTIME=kubernetes
+make k3s-watch                # Hot-reload Bridge with k3s backend (Air)
 make k3s-down                 # Stop port-forwards, delete k3s namespace
 make k3s-reset                # Full reset (namespace + imported images)
 make k3s-status               # Show pods, port-forwards, and jobs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Bridge → Hail (NATS) → Skiff Pod [skiff container + gate sidecar] → Gate �
 - Gate proxies ALL external traffic including LLM API calls (Skiff has no real credentials)
 - Optional dev container runs alongside Skiff with a shared `/workspace` volume, enabling agents to build/test code in project-specific environments; the shim binary is baked into the dev container image via s6-overlay (built with `make build-dev`)
 - On OpenShift, a static `alcove-allow-internal` NetworkPolicy restricts egress (per-task NetworkPolicy is disabled due to OVN-Kubernetes DNS resolution issues); dual-network isolation (`--internal` flag) on podman; no network isolation on Docker (see Key Decisions)
+- k3s is supported for local Kubernetes development (`make k3s-setup && make k3s-up && make k3s-watch`); Bridge runs on the host, NATS+PostgreSQL run as k8s pods with port-forwards, Skiff Jobs are dispatched into the same k3s cluster
 
 ## Design Documents
 
@@ -68,6 +69,14 @@ make dev-infra                # Start only NATS + PostgreSQL on podman
 make dev-up                   # Start full containerized environment
 make dev-down                 # Stop everything
 make dev-reset                # Stop + remove volumes (clean slate)
+
+# k3s (Kubernetes backend) — test k8s runtime locally
+make k3s-setup                # Install k3s, configure kubeconfig + firewalld (run once)
+make k3s-up                   # Build images, deploy NATS+PostgreSQL to k3s, start port-forwards
+make k3s-watch                # Hot-reload Bridge via Air with RUNTIME=kubernetes
+make k3s-down                 # Stop port-forwards, delete k3s namespace
+make k3s-reset                # Full reset (namespace + imported images)
+make k3s-status               # Show pods, port-forwards, and jobs
 
 # Run Bridge locally with Docker (after infrastructure setup)
 LEDGER_DATABASE_URL="postgres://alcove:alcove@localhost:5432/alcove?sslmode=disable" \
@@ -108,6 +117,7 @@ RUNTIME=docker \
 - **Dev containers are optional sidecars** — agent definitions can declare `dev_container.image` to run a project-provided container alongside Skiff; dev container images are built with s6-overlay and the shim binary baked in (`make build-dev` builds the base image from `build/Containerfile.dev`); `Containerfile.dev` is an all-in-one dev container image that includes PostgreSQL 16, NATS, Go 1.25, the shim binary, and s6-overlay for process supervision; s6 manages PostgreSQL, NATS, and the shim as supervised services with proper dependencies; Podman creates a shared workspace volume at `/workspace` and mounts it in both containers; the shim provides bearer-auth-protected `POST /exec` for remote command execution with NDJSON streaming; `dev_container.network_access` controls network access (`internal` default, `external` joins both networks on Podman); on Kubernetes, the dev container runs as a native sidecar with emptyDir workspace volume (`DEV_CONTAINER_HOST=localhost:9090`); Docker rejects dev containers with a clear error; `--security-opt label=disable` handles SELinux compatibility on Podman; see architecture decision #20 in `docs/design/architecture-decisions.md` for the full design
 - **Multi-repo support** — agent definitions use `repos:` (a list of `RepoSpec` with `name`, `url`, `ref` fields) instead of a single `repo:` string; Skiff receives a `REPOS` JSON env var and clones each repo into `/workspace/<name>/`; database migration `031_multi_repo.sql` replaces the `repo TEXT` column with `repos JSONB`; see architecture decision #21 in `docs/design/architecture-decisions.md` for the full design
 - **CLAUDE.md injection** — Claude Code runs with `--bare` which disables native CLAUDE.md discovery; skiff-init reads `CLAUDE.md` from cloned repos and prepends the content to the agent prompt, so project instructions are automatically available to agents without duplicating them in agent prompts; see architecture decision #22 in `docs/design/architecture-decisions.md` for the full design
+- **k3s for local Kubernetes testing** — `make k3s-setup` installs k3s with `--disable=traefik --disable=servicelb --bind-address=127.0.0.1`; `make k3s-up` builds images, imports them via `podman save | sudo k3s ctr images import`, deploys PostgreSQL+NATS as Deployments with PVC, creates a headless `alcove-bridge` Service with manual Endpoints pointing to the host IP; Bridge runs on the host with `RUNTIME=kubernetes` connecting via `~/.kube/k3s-config`; Skiff/Gate pods reach Bridge via the `alcove-bridge` k8s Service; port-forwards expose PostgreSQL (5432) and NATS (4222) to localhost; requires `sudo` for k3s install and image import; `make k3s-down` deletes the namespace but keeps k3s installed; see architecture decision #23 in `docs/design/architecture-decisions.md`
 
 ## Dev Container Usage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ make dev-reset                # Stop + remove volumes (clean slate)
 # Requires sudo for k3s install and image import. Stop podman infra first: make down
 make k3s-setup                # Install k3s, configure kubeconfig + firewalld (run once)
 make k3s-up                   # Build images, deploy NATS+PostgreSQL to k3s, start port-forwards
-make k3s-watch                # Hot-reload Bridge with k3s backend (Air)
+make k3s-watch                # Hot-reload Bridge with k8s runtime (Air)
 make k3s-down                 # Stop port-forwards, delete k3s namespace
 make k3s-reset                # Full reset (namespace + imported images)
 make k3s-status               # Show pods, port-forwards, and jobs

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ SKIFF_SOURCES := $(shell find cmd/skiff-init/ -name '*.go' -type f 2>/dev/null) 
 .PHONY: all build build-cli-all build-images build-image-bridge build-image-gate build-image-skiff-base build-skiff build-dev \
         test test-network test-ledger test-isolation test-schedules test-credentials test-security-profiles test-yaml-security-profiles test-gate-real lint clean clean-stamps \
         up down logs watch dev-config dev-up dev-down dev-logs dev-reset dev-infra help \
-        login-registry push pull up-pull build-tooling push-tooling
+        login-registry push pull up-pull build-tooling push-tooling \
+        k3s-setup k3s-up k3s-watch k3s-down k3s-reset k3s-status
 
 all: build
 
@@ -302,6 +303,77 @@ dev-reset: dev-down ## Stop containers and remove all volumes
 	-$(PODMAN) volume rm alcove-ledger-data 2>/dev/null
 	rm -rf $(STAMP_DIR)
 	@echo "Dev environment reset (volumes removed)."
+
+##@ k3s Local Development
+
+K3S_KUBECONFIG := $(HOME)/.kube/k3s-config
+
+k3s-setup: ## Install and configure k3s (run once)
+	@bash scripts/k3s-setup.sh
+
+k3s-up: dev-config build-images ## Deploy infra to k3s, import images, start port-forwards
+	@test -f $(K3S_KUBECONFIG) || (echo "ERROR: Run 'make k3s-setup' first."; exit 1)
+	@for port in 5432 4222 8222; do \
+		if ss -tlnp 2>/dev/null | grep -q ":$${port} "; then \
+			echo "ERROR: Port $${port} is already in use. Run 'make down' first."; \
+			exit 1; \
+		fi; \
+	done
+	@bash scripts/k3s-import-images.sh $(VERSION)
+	@KUBECONFIG=$(K3S_KUBECONFIG) kubectl apply -f deploy/k3s/infra.yaml
+	@echo "Waiting for deployments..."
+	@KUBECONFIG=$(K3S_KUBECONFIG) kubectl -n alcove wait --for=condition=available --timeout=120s deployment/alcove-ledger deployment/alcove-hail
+	@bash scripts/k3s-bridge-endpoint.sh $(K3S_KUBECONFIG)
+	@echo "Starting port-forwards..."
+	@KUBECONFIG=$(K3S_KUBECONFIG) kubectl -n alcove port-forward svc/alcove-ledger 5432:5432 &>/dev/null &
+	@echo "$$!" > /tmp/alcove-k3s-pf-ledger.pid
+	@KUBECONFIG=$(K3S_KUBECONFIG) kubectl -n alcove port-forward svc/alcove-hail 4222:4222 8222:8222 &>/dev/null &
+	@echo "$$!" > /tmp/alcove-k3s-pf-hail.pid
+	@sleep 2
+	@echo ""
+	@echo "=== k3s infrastructure ready ==="
+	@echo "PostgreSQL:  localhost:5432"
+	@echo "NATS:        localhost:4222 (monitoring: localhost:8222)"
+	@echo ""
+	@echo "Start Bridge: make k3s-watch"
+
+k3s-watch: dev-config build-images ## Hot-reload Bridge with k3s backend (Air)
+	@test -f $(K3S_KUBECONFIG) || (echo "ERROR: Run 'make k3s-setup && make k3s-up' first."; exit 1)
+	@bash scripts/k3s-import-images.sh $(VERSION)
+	@bash scripts/k3s-bridge-endpoint.sh $(K3S_KUBECONFIG)
+	KUBECONFIG=$(K3S_KUBECONFIG) \
+	LEDGER_DATABASE_URL="postgres://alcove:alcove@localhost:5432/alcove?sslmode=disable" \
+	HAIL_URL="nats://localhost:4222" \
+	RUNTIME=kubernetes \
+	ALCOVE_NAMESPACE=alcove \
+	SKIFF_IMAGE=localhost/alcove-skiff-base:$(VERSION) \
+	GATE_IMAGE=localhost/alcove-gate:$(VERSION) \
+	air
+
+k3s-down: ## Stop port-forwards and delete k3s alcove namespace
+	@echo "Stopping k3s dev environment..."
+	-@kill $$(cat /tmp/alcove-k3s-pf-ledger.pid 2>/dev/null) 2>/dev/null; rm -f /tmp/alcove-k3s-pf-ledger.pid
+	-@kill $$(cat /tmp/alcove-k3s-pf-hail.pid 2>/dev/null) 2>/dev/null; rm -f /tmp/alcove-k3s-pf-hail.pid
+	-@pkill -f 'kubectl.*port-forward.*alcove' 2>/dev/null || true
+	-@KUBECONFIG=$(K3S_KUBECONFIG) kubectl delete namespace alcove --timeout=60s 2>/dev/null || true
+	@echo "k3s dev environment stopped."
+
+k3s-reset: k3s-down ## Full reset including imported images
+	@echo "Removing images from k3s..."
+	-@for img in bridge gate skiff-base; do \
+		sudo k3s ctr images rm "localhost/alcove-$${img}:$(VERSION)" 2>/dev/null || true; \
+	done
+	@echo "k3s environment reset."
+
+k3s-status: ## Show k3s Alcove pods, port-forwards, and jobs
+	@echo "=== k3s Pods ==="
+	@KUBECONFIG=$(K3S_KUBECONFIG) kubectl -n alcove get pods 2>/dev/null || echo "  Namespace 'alcove' not found."
+	@echo ""
+	@echo "=== Port-Forwards ==="
+	@ps aux | grep '[k]ubectl.*port-forward.*alcove' || echo "  None running."
+	@echo ""
+	@echo "=== Jobs ==="
+	@KUBECONFIG=$(K3S_KUBECONFIG) kubectl -n alcove get jobs 2>/dev/null || true
 
 ##@ Quality
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ validation, and per-task NetworkPolicy enforcement on Kubernetes. See
 - **podman** (rootless)
 - **make**
 - An LLM provider (Anthropic API key or Google Vertex AI credentials)
+- **k3s** (optional — for local Kubernetes development)
 
 ## Quick Start
 
@@ -70,6 +71,17 @@ make up
 ```
 
 For the full setup walkthrough, see the [Getting Started](docs/getting-started.md) guide.
+
+### Local Kubernetes Development (k3s)
+
+To develop against a real Kubernetes runtime locally instead of podman:
+
+```bash
+make k3s-setup                # Install k3s (one-time)
+make k3s-up                   # Deploy NATS + PostgreSQL to k3s, start port-forwards
+make k3s-watch                # Hot-reload Bridge with k8s runtime (Air)
+make k3s-down                 # Stop port-forwards and delete namespace
+```
 
 ## CLI Installation
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ alcove logs <session-id> --follow
 | [Development Guide](docs/development-guide.md) | Building, testing, adding features |
 | [Architecture](docs/design/architecture.md) | Component design, deployment diagrams, roadmap |
 | [Security Principles](docs/design/security-principles.md) | Five north-star security principles with implementation details |
-| [Architecture Decisions](docs/design/architecture-decisions.md) | Resolved design choices (18 decisions) |
+| [Architecture Decisions](docs/design/architecture-decisions.md) | Resolved design choices (23 decisions) |
 | [Implementation Status](docs/design/implementation-status.md) | Current state, what works, what is next |
 | [Problem Statement](docs/design/problem-statement.md) | Why ephemeral agents |
 | [Credential Management](docs/design/credential-management.md) | How Bridge manages credentials and passes tokens to Gate |

--- a/deploy/k3s/infra.yaml
+++ b/deploy/k3s/infra.yaml
@@ -1,0 +1,157 @@
+# Infrastructure for local k3s development.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: alcove
+  labels:
+    app.kubernetes.io/part-of: alcove
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alcove-ledger
+  namespace: alcove
+  labels:
+    app.kubernetes.io/name: ledger
+    app.kubernetes.io/part-of: alcove
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ledger
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ledger
+        app.kubernetes.io/part-of: alcove
+    spec:
+      containers:
+        - name: postgres
+          image: docker.io/library/postgres:16
+          env:
+            - name: POSTGRES_USER
+              value: alcove
+            - name: POSTGRES_PASSWORD
+              value: alcove
+            - name: POSTGRES_DB
+              value: alcove
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: alcove-ledger-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: alcove-ledger-data
+  namespace: alcove
+  labels:
+    app.kubernetes.io/part-of: alcove
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alcove-ledger
+  namespace: alcove
+  labels:
+    app.kubernetes.io/part-of: alcove
+spec:
+  selector:
+    app.kubernetes.io/name: ledger
+  ports:
+    - port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alcove-hail
+  namespace: alcove
+  labels:
+    app.kubernetes.io/name: hail
+    app.kubernetes.io/part-of: alcove
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hail
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hail
+        app.kubernetes.io/part-of: alcove
+    spec:
+      containers:
+        - name: nats
+          image: docker.io/library/nats:latest
+          ports:
+            - containerPort: 4222
+            - containerPort: 8222
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alcove-hail
+  namespace: alcove
+  labels:
+    app.kubernetes.io/part-of: alcove
+spec:
+  selector:
+    app.kubernetes.io/name: hail
+  ports:
+    - name: client
+      port: 4222
+      targetPort: 4222
+    - name: monitoring
+      port: 8222
+      targetPort: 8222
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alcove-bridge
+  namespace: alcove
+  labels:
+    app.kubernetes.io/part-of: alcove
+spec:
+  clusterIP: None
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alcove-allow-internal
+  namespace: alcove
+  labels:
+    app.kubernetes.io/part-of: alcove
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: alcove
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: alcove
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+  egress:
+    - {}

--- a/docs/design/architecture-decisions.md
+++ b/docs/design/architecture-decisions.md
@@ -424,6 +424,25 @@ safety. Keeping project instructions in `CLAUDE.md` (which is
 version-controlled with the repo) rather than in agent prompts avoids
 duplication and keeps agent definitions minimal.
 
+### 23. k3s for Local Kubernetes Development
+
+**Decision**: Provide `make k3s-setup`, `make k3s-up`, `make k3s-watch`, and `make k3s-down` targets that install k3s on the developer's workstation and run the full Kubernetes runtime path locally.
+
+**How it works**:
+- `make k3s-setup` installs k3s (if not already installed) with `--disable=traefik --disable=servicelb --bind-address=127.0.0.1 --write-kubeconfig-mode=600`. On Fedora, it installs `k3s-selinux` and configures firewalld to allow traffic from the k3s pod CIDR (10.42.0.0/16) and service CIDR (10.43.0.0/16). The kubeconfig is copied to `~/.kube/k3s-config` with user ownership.
+- `make k3s-up` builds container images via podman, imports them into k3s containerd (`podman save | sudo k3s ctr images import`), deploys PostgreSQL (with PVC for data persistence) and NATS as Deployments in the `alcove` namespace, creates a headless `alcove-bridge` Service with manual Endpoints pointing to the k3s node's InternalIP, and starts `kubectl port-forward` background processes for PostgreSQL (5432) and NATS (4222).
+- `make k3s-watch` starts Bridge via Air with `RUNTIME=kubernetes`, `KUBECONFIG=~/.kube/k3s-config`, and `ALCOVE_NAMESPACE=alcove`. Bridge connects to PostgreSQL and NATS via port-forwards on localhost, dispatches Skiff Jobs into k3s, and Skiff/Gate pods reach Bridge via the `alcove-bridge` k8s Service.
+- `make k3s-down` kills port-forward processes and deletes the `alcove` namespace (cascading to all pods, services, jobs, and PVCs). k3s itself stays installed.
+
+**Rationale**: The Kubernetes runtime (`internal/runtime/kubernetes.go`) was only testable in CI (via ephemeral k3s on GitHub Actions) or in production (OpenShift). Developers could not iterate on k8s-specific behavior locally. The `make k3s-*` targets mirror the existing `make watch` / `make up` / `make down` podman workflow, so switching between backends is natural. Bridge runs on the host (not in-cluster) to enable Air hot-reload without image rebuild cycles. The headless `alcove-bridge` Service with manual Endpoints avoids the need to set `BRIDGE_URL` — pods use the same `http://alcove-bridge:8080` default as production. k3s was chosen over k3d/minikube/kind because the CI already uses bare k3s (PR #357), so the local setup matches CI exactly.
+
+**Files**:
+- `scripts/k3s-setup.sh` — k3s installation, kubeconfig, firewalld, SELinux
+- `scripts/k3s-import-images.sh` — podman save → k3s ctr images import
+- `scripts/k3s-bridge-endpoint.sh` — headless Service Endpoints for host Bridge
+- `deploy/k3s/infra.yaml` — Namespace, Deployments, Services, PVC, NetworkPolicy
+- `Makefile` — k3s-setup, k3s-up, k3s-watch, k3s-down, k3s-reset, k3s-status targets
+
 
 ## CLI Design
 
@@ -539,7 +558,8 @@ alcove/
 │   ├── Containerfile.skiff-base
 │   └── Containerfile.skiff-example
 ├── deploy/
-│   ├── k8s/            # Kubernetes manifests (Jobs, Deployments, Services, RBAC)
+│   ├── k3s/            # Local dev k3s manifests (infra, NetworkPolicy)
+│   ├── k8s/            # Production Kubernetes manifests (Jobs, Deployments, Services, RBAC)
 │   └── podman/         # Makefile targets, dev setup
 ├── web/                # Dashboard frontend
 ├── docs/

--- a/scripts/k3s-bridge-endpoint.sh
+++ b/scripts/k3s-bridge-endpoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# k3s-bridge-endpoint.sh — Create Endpoints for alcove-bridge Service.
+# Lets in-cluster pods reach Bridge running on the host.
+set -euo pipefail
+
+export KUBECONFIG="${1:-${HOME}/.kube/k3s-config}"
+
+HOST_IP=$(kubectl get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+
+if [ -z "${HOST_IP}" ]; then
+    echo "ERROR: Could not detect host IP from k3s node."
+    exit 1
+fi
+
+echo "Creating alcove-bridge endpoint -> ${HOST_IP}:8080"
+
+kubectl apply -n alcove -f - <<EOF
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: alcove-bridge
+  namespace: alcove
+  labels:
+    app.kubernetes.io/part-of: alcove
+subsets:
+  - addresses:
+      - ip: "${HOST_IP}"
+    ports:
+      - port: 8080
+        protocol: TCP
+        name: http
+EOF

--- a/scripts/k3s-import-images.sh
+++ b/scripts/k3s-import-images.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# k3s-import-images.sh — Import podman-built images into k3s containerd.
+set -euo pipefail
+
+VERSION="${1:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
+
+echo "Importing Alcove images into k3s (version: ${VERSION})..."
+
+for img in bridge gate skiff-base; do
+    LOCAL_TAG="localhost/alcove-${img}:${VERSION}"
+    if ! podman image exists "${LOCAL_TAG}" 2>/dev/null; then
+        echo "ERROR: Image ${LOCAL_TAG} not found. Run 'make build-images' first."
+        exit 1
+    fi
+    echo "  ${LOCAL_TAG}..."
+    podman save "${LOCAL_TAG}" | sudo k3s ctr images import -
+done
+
+echo "Images imported."

--- a/scripts/k3s-setup.sh
+++ b/scripts/k3s-setup.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# k3s-setup.sh — Install and configure k3s for local Alcove development.
+# Idempotent: safe to run multiple times.
+set -euo pipefail
+
+K3S_CONFIG_DIR="${HOME}/.kube"
+K3S_KUBECONFIG="${K3S_CONFIG_DIR}/k3s-config"
+
+echo "=== Alcove k3s Setup ==="
+
+# --- Prerequisite checks ---
+echo "Checking prerequisites..."
+
+if ! command -v curl &>/dev/null; then
+    echo "ERROR: curl is required."
+    exit 1
+fi
+
+if ! command -v podman &>/dev/null; then
+    echo "ERROR: podman is required to build images."
+    exit 1
+fi
+
+if ! command -v kubectl &>/dev/null; then
+    echo "NOTE: kubectl not found. Will use 'sudo k3s kubectl' after install."
+fi
+
+# --- Install k3s if not present ---
+if ! command -v k3s &>/dev/null; then
+    echo "Installing k3s..."
+
+    # Install k3s-selinux on Fedora/RHEL if SELinux is enforcing
+    if command -v getenforce &>/dev/null && [ "$(getenforce)" = "Enforcing" ]; then
+        echo "SELinux is enforcing. Installing k3s-selinux..."
+        if command -v dnf &>/dev/null; then
+            sudo dnf install -y k3s-selinux 2>/dev/null || echo "WARNING: k3s-selinux not found in repos; k3s may handle this."
+        fi
+    fi
+
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server \
+        --write-kubeconfig-mode=600 \
+        --bind-address=127.0.0.1 \
+        --disable=traefik \
+        --disable=servicelb" \
+        sh -
+else
+    echo "k3s already installed."
+    if ! systemctl is-active --quiet k3s 2>/dev/null; then
+        echo "Starting k3s service..."
+        sudo systemctl start k3s
+    fi
+fi
+
+# --- Wait for k3s node to be ready ---
+echo "Waiting for k3s node..."
+for i in $(seq 1 30); do
+    if sudo k3s kubectl get nodes 2>/dev/null | grep -q ' Ready'; then
+        echo "k3s node is Ready."
+        break
+    fi
+    echo "  Waiting... ($i/30)"
+    sleep 2
+done
+
+if ! sudo k3s kubectl get nodes 2>/dev/null | grep -q ' Ready'; then
+    echo "ERROR: k3s node did not become ready. Check: sudo journalctl -u k3s"
+    exit 1
+fi
+
+# --- Copy kubeconfig ---
+mkdir -p "${K3S_CONFIG_DIR}"
+sudo cp /etc/rancher/k3s/k3s.yaml "${K3S_KUBECONFIG}"
+sudo chown "$(id -u):$(id -g)" "${K3S_KUBECONFIG}"
+chmod 600 "${K3S_KUBECONFIG}"
+echo "Kubeconfig written to ${K3S_KUBECONFIG}"
+
+# --- Firewall rules for pod and service CIDRs ---
+if command -v firewall-cmd &>/dev/null && systemctl is-active --quiet firewalld 2>/dev/null; then
+    echo "Configuring firewalld for k3s traffic..."
+    if ! sudo firewall-cmd --permanent --zone=trusted --list-sources 2>/dev/null | grep -q "10.42.0.0/16"; then
+        sudo firewall-cmd --permanent --zone=trusted --add-source=10.42.0.0/16
+    fi
+    if ! sudo firewall-cmd --permanent --zone=trusted --list-sources 2>/dev/null | grep -q "10.43.0.0/16"; then
+        sudo firewall-cmd --permanent --zone=trusted --add-source=10.43.0.0/16
+    fi
+    sudo firewall-cmd --reload
+    echo "Firewalld configured (10.42.0.0/16 and 10.43.0.0/16 in trusted zone)."
+fi
+
+echo ""
+echo "k3s setup complete."
+echo "  KUBECONFIG=${K3S_KUBECONFIG}"
+echo "  Run 'make k3s-up' to deploy Alcove infrastructure."

--- a/scripts/k3s-setup.sh
+++ b/scripts/k3s-setup.sh
@@ -8,6 +8,10 @@ K3S_KUBECONFIG="${K3S_CONFIG_DIR}/k3s-config"
 
 echo "=== Alcove k3s Setup ==="
 
+# --- Acquire sudo early so all subsequent sudo calls succeed ---
+echo "This script requires sudo for k3s installation and configuration."
+sudo -v || { echo "ERROR: sudo access is required. Run this in a terminal: ! make k3s-setup"; exit 1; }
+
 # --- Prerequisite checks ---
 echo "Checking prerequisites..."
 


### PR DESCRIPTION
## Summary

- Adds `make k3s-setup`, `k3s-up`, `k3s-watch`, `k3s-down`, `k3s-reset`, `k3s-status` targets for testing the Kubernetes runtime locally
- Bridge runs on the host with `RUNTIME=kubernetes`, NATS+PostgreSQL run as k8s Deployments with PVC, port-forwards expose services to localhost
- Headless `alcove-bridge` Service with manual Endpoints lets in-cluster Skiff/Gate pods reach the host Bridge
- Images built with podman and imported via `podman save | sudo k3s ctr images import`
- k3s installed with `--disable=traefik --disable=servicelb --bind-address=127.0.0.1 --write-kubeconfig-mode=600`
- Firewalld configured for pod (10.42.0.0/16) and service (10.43.0.0/16) CIDRs on Fedora

### New files
| File | Purpose |
|------|---------|
| `scripts/k3s-setup.sh` | Idempotent k3s installation, kubeconfig, firewalld, SELinux |
| `scripts/k3s-import-images.sh` | Import podman images into k3s containerd |
| `scripts/k3s-bridge-endpoint.sh` | Create Endpoints for host-side Bridge |
| `deploy/k3s/infra.yaml` | Namespace, Deployments, Services, PVC, NetworkPolicy |

### Documentation
- CLAUDE.md: k3s Quick Commands, Key Decision, Architecture note, decision count update
- README.md: k3s section in Local Development, decision count update
- Architecture decision #23 with full rationale

## Test plan
- [ ] CI passes (existing tests unaffected — no Go code changes)
- [ ] `make k3s-setup` installs k3s and configures kubeconfig
- [ ] `make k3s-up` deploys infra and starts port-forwards
- [ ] `make k3s-watch` starts Bridge with k8s runtime via Air
- [ ] `make k3s-down` cleans up namespace and port-forwards