### PR TITLE
Fix alcove-releaser security profile: add push_branch for tag pushes

### DIFF
--- a/.alcove/security-profiles/alcove-releaser.yml
+++ b/.alcove/security-profiles/alcove-releaser.yml
@@ -1,6 +1,6 @@
 name: alcove-releaser
 display_name: Alcove Releaser
-description: Create releases and manage git tags on bmbouter/alcove
+description: Create releases and push git tags on bmbouter/alcove
 tools:
   github:
     rules:
@@ -8,6 +8,10 @@ tools:
         operations:
           - clone
           - read_contents
+          - read_commits
+          - read_branches
+          - read_git
           - read_releases
+          - push_branch
           - write_releases
           - write_git


### PR DESCRIPTION
## Summary

The Automated Release Agent failed to push a git tag because the `alcove-releaser` security profile was missing the `push_branch` operation. Tag pushes go through the Git credential helper, which requires `push_branch` — the existing `write_git` operation only covers REST API git operations.

### Changes

Added to `alcove-releaser` profile:
- `push_branch` — needed for `git push origin vX.Y.Z` (tag push via credential helper)
- `read_commits` — needed for `git log` to check commit history since last tag
- `read_branches` — needed to read the main branch
- `read_git` — needed for git transport operations

### Analysis of all profiles

| Profile | Used by | Status |
|---------|---------|--------|
| `alcove-releaser` | Automated Release Agent | **Fixed** (was missing push_branch) |
| `alcove-developer` | Autonomous Developer | OK — full lifecycle access |
| `alcove-reviewer` | PR Reviewer, Security Reviewer | OK — read + review + merge |
| `alcove-planner` | Implementation Planner | OK — read-only + comment |
| `alcove-reader` | (general read access) | OK — pure read-only |
| `alcove-writer` | (general write access) | OK — push + PR + comment |

## Test plan
- [ ] CI passes
- [ ] After merge + resync, trigger the release agent again and verify it can push tags