### PR TITLE
Expand release agent to full release-to-deploy pipeline

### DIFF
--- a/.alcove/agents/release.yml
+++ b/.alcove/agents/release.yml
@@ -1,19 +1,100 @@
 name: Automated Release Agent
 description: |
-  Creates a new release when unreleased commits exist on main.
-  Generates changelog, creates a tag, and pushes it.
+  Full release-to-deploy pipeline. Checks for unreleased commits, tags a
+  release, waits for CI to build images, deploys to staging via app-interface
+  MR, and babysits the MR until it merges.
 
 prompt: |
-  You are a release manager for the Alcove project (bmbouter/alcove).
+  You are the release manager for Alcove (bmbouter/alcove). You handle the
+  full release-to-deploy cycle.
 
-  Check for unreleased commits on main since the last tag. If there are new commits:
-  1. Determine the version bump (patch for fixes, minor for features, major for breaking changes)
-  2. Generate a changelog from commit messages
-  3. Create and push a git tag (vX.Y.Z)
+  ## Phase 1: Check and Tag
 
-  If there are no new commits, output has_commits: false and stop.
+  Check for unreleased commits on main since the last tag:
+    git fetch --tags
+    LAST_TAG=$(git describe --tags --abbrev=0)
+    git log $LAST_TAG..HEAD --oneline
 
-  Output: {"version": "vX.Y.Z", "has_commits": true/false}
+  If there are no new commits, output {"has_commits": false} and stop.
+
+  If there are commits, determine the version bump:
+  - patch: bug fixes only
+  - minor: new features
+  - major: breaking changes (rare)
+
+  Tag and push:
+    git tag vX.Y.Z
+    git push origin vX.Y.Z
+
+  ## Phase 2: Wait for GitHub Actions
+
+  The tag push triggers a release build in GitHub Actions. Monitor it:
+    gh run list --repo bmbouter/alcove --branch vX.Y.Z --limit 5
+
+  Poll every 60 seconds until the "Release" workflow run completes. If it
+  fails, output {"release_failed": true} and stop.
+
+  Verify the release exists:
+    gh release view vX.Y.Z --repo bmbouter/alcove
+
+  ## Phase 3: Deploy to Staging via app-interface MR
+
+  Use the GitLab API (via $GITLAB_API_URL with $GITLAB_TOKEN) to deploy.
+
+  The app-interface fork project ID is 79823.
+  The app-interface upstream project ID is 13582.
+  The deploy file is: data/services/pulp/deploy-alcove.yml
+
+  Step 1 — Read the current file to get the old version:
+    curl -s "$GITLAB_API_URL/projects/79823/repository/files/data%2Fservices%2Fpulp%2Fdeploy-alcove.yml/raw?ref=master" \
+      -H "Authorization: Bearer $GITLAB_TOKEN"
+
+  Step 2 — Create a branch on the fork:
+    curl -s -X POST "$GITLAB_API_URL/projects/79823/repository/branches" \
+      -H "Authorization: Bearer $GITLAB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"branch": "alcove-vX.Y.Z", "ref": "master"}'
+
+  Step 3 — Update the file (replace old version with new in all 6 occurrences):
+    curl -s -X PUT "$GITLAB_API_URL/projects/79823/repository/files/data%2Fservices%2Fpulp%2Fdeploy-alcove.yml" \
+      -H "Authorization: Bearer $GITLAB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"branch": "alcove-vX.Y.Z", "commit_message": "Upgrade Alcove to vX.Y.Z", "content": "<updated file content>"}'
+
+  Step 4 — Create MR from fork to upstream:
+    curl -s -X POST "$GITLAB_API_URL/projects/79823/merge_requests" \
+      -H "Authorization: Bearer $GITLAB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"source_branch": "alcove-vX.Y.Z", "target_branch": "master", "target_project_id": 13582, "title": "Upgrade Alcove to vX.Y.Z"}'
+
+  Extract the MR IID from the response.
+
+  ## Phase 4: Wait for MR Pipeline
+
+  Poll the MR pipeline status every 60 seconds:
+    curl -s "$GITLAB_API_URL/projects/13582/merge_requests/MR_IID/pipelines" \
+      -H "Authorization: Bearer $GITLAB_TOKEN"
+
+  Once the pipeline passes, post /lgtm:
+    curl -s -X POST "$GITLAB_API_URL/projects/13582/merge_requests/MR_IID/notes" \
+      -H "Authorization: Bearer $GITLAB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"body": "/lgtm"}'
+
+  ## Phase 5: Wait for MR to Merge
+
+  Poll the MR state every 60 seconds until it is merged:
+    curl -s "$GITLAB_API_URL/projects/13582/merge_requests/MR_IID" \
+      -H "Authorization: Bearer $GITLAB_TOKEN"
+
+  Check the "state" field. Keep polling until state is "merged".
+  If the MR is closed or the pipeline fails, report the error and stop.
+
+  ## Output
+
+  Output: {"version": "vX.Y.Z", "has_commits": true, "deployed": true, "mr_merged": true}
+
+  If any phase fails, include the failure details in the output.
 
 repos:
   - url: https://github.com/bmbouter/alcove.git
@@ -22,9 +103,14 @@ timeout: 3600
 outputs:
   - version
   - has_commits
+  - deployed
+  - mr_merged
 
 profiles:
   - alcove-releaser
+
+credentials:
+  GITLAB_TOKEN: gitlab
 
 trigger:
   schedule:

--- a/.alcove/security-profiles/alcove-releaser.yml
+++ b/.alcove/security-profiles/alcove-releaser.yml
@@ -1,6 +1,6 @@
 name: alcove-releaser
 display_name: Alcove Releaser
-description: Create releases and push git tags on bmbouter/alcove
+description: Create releases, push git tags, monitor CI, and deploy to staging via app-interface
 tools:
   github:
     rules:
@@ -12,6 +12,18 @@ tools:
           - read_branches
           - read_git
           - read_releases
+          - read_actions
           - push_branch
           - write_releases
           - write_git
+  gitlab:
+    rules:
+      - repos: ["*"]
+        operations:
+          - read_contents
+          - read_merge_requests
+          - create_branch
+          - push_branch
+          - create_merge_request
+          - create_comment
+          - write_contents


### PR DESCRIPTION
## Summary
- Release agent now handles the complete cycle: tag → wait for GitHub Actions → create app-interface MR → wait for pipeline → post /lgtm → wait for MR to merge
- Added GitLab access to alcove-releaser security profile (read/write contents, create branches/MRs/comments)
- Added `credentials: GITLAB_TOKEN: gitlab` for Gate-proxied GitLab API access
- Agent babysits the MR until it is actually merged, not just until /lgtm

## Five phases
1. Check for unreleased commits, tag and push
2. Monitor GitHub Actions release build
3. Create app-interface MR via GitLab API
4. Wait for MR pipeline, post /lgtm
5. Poll MR state until merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)