### PR TITLE
Fix: set imagePullPolicy Always on dev container sidecar

### DIFF
--- a/internal/runtime/kubernetes.go
+++ b/internal/runtime/kubernetes.go
@@ -309,6 +309,7 @@ func (k *KubernetesRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHan
 		devContainer := corev1.Container{
 			Name:            "dev",
 			Image:           spec.DevContainerImage,
+			ImagePullPolicy: corev1.PullAlways,
 			Env:             devContainerEnvVars,
 			SecurityContext: securityContext,
 			RestartPolicy:   &sidecarRestart,


### PR DESCRIPTION
## Problem

Dev container images use mutable tags like `:main`. Without `imagePullPolicy: Always`, Kubernetes defaults to `IfNotPresent` for non-`:latest` tags, causing stale cached images on nodes. This caused the rootless dev container fix (pulp/pulp-service#1075) to not take effect on OpenShift — the node had the old root-requiring image cached and kept using it.

## Fix

One line: add `ImagePullPolicy: corev1.PullAlways` to the dev container spec in `kubernetes.go`.

## Test plan
- [ ] CI passes
- [ ] `go test ./internal/runtime/` passes (existing k8s tests verify container spec)