### PR TITLE
Fix release pipeline: explicit outputs and CI failure handling

### DIFF
--- a/.alcove/agents/changelog.yml
+++ b/.alcove/agents/changelog.yml
@@ -11,7 +11,8 @@ prompt: |
     LAST_TAG=$(git describe --tags --abbrev=0)
     git log $LAST_TAG..HEAD --oneline
 
-  If there are no new commits, output {"has_commits": false} and stop.
+  If there are no new commits, write this to /tmp/alcove-outputs.json and stop:
+    echo '{"has_commits": false}' > /tmp/alcove-outputs.json
 
   Determine the version bump from the commits:
   - patch: bug fixes only
@@ -27,7 +28,9 @@ prompt: |
   4. Each entry should be a concise one-line summary of the change
   5. Commit and push to the branch
 
-  Output: {"version": "vX.Y.Z", "has_commits": true}
+  IMPORTANT: Write your outputs to /tmp/alcove-outputs.json so the next
+  workflow step can use them:
+    echo '{"version": "vX.Y.Z", "has_commits": true}' > /tmp/alcove-outputs.json
 
 repos:
   - url: https://github.com/bmbouter/alcove.git

--- a/.alcove/agents/release.yml
+++ b/.alcove/agents/release.yml
@@ -22,10 +22,19 @@ prompt: |
   The tag push triggers a release build. Monitor it:
     gh run list --repo bmbouter/alcove --branch <version> --limit 5
 
-  Poll every 60 seconds until the "Release" workflow completes. If it fails,
-  output {"release_failed": true} and stop.
+  Poll every 60 seconds until the "Release" workflow completes.
 
-  Verify the release exists:
+  If the run FAILS, analyze the failure:
+    gh run view <run_id> --repo bmbouter/alcove --log-failed 2>&1 | tail -20
+
+  Determine if the failure is transient (registry 502, network timeout,
+  rate limit) or a real code/build error:
+  - Transient: re-run with `gh run rerun <run_id> --repo bmbouter/alcove`
+    and continue polling. Retry up to 3 times.
+  - Real error: write outputs and stop:
+    echo '{"release_failed": true, "error": "description"}' > /tmp/alcove-outputs.json
+
+  Once the run succeeds, verify the release:
     gh release view <version> --repo bmbouter/alcove
 
   ## Phase 3: Deploy to Staging via app-interface MR
@@ -66,12 +75,16 @@ prompt: |
       -H "Content-Type: application/json" \
       -d '{"body": "/lgtm"}'
 
+  If the MR pipeline fails, analyze the failure log. If transient, retry
+  by closing and re-opening the MR (which re-triggers the pipeline).
+
   ## Phase 5: Wait for MR to Merge
 
   Poll the MR state every 60 seconds until state is "merged".
-  If closed or pipeline fails, report error and stop.
+  If closed or pipeline fails after retries, report error and stop.
 
-  Output: {"version": "<version>", "deployed": true, "mr_merged": true}
+  IMPORTANT: Write your outputs to /tmp/alcove-outputs.json:
+    echo '{"version": "<version>", "deployed": true, "mr_merged": true}' > /tmp/alcove-outputs.json
 
 repos:
   - url: https://github.com/bmbouter/alcove.git


### PR DESCRIPTION
## Summary
- **Changelog Generator**: explicitly writes `/tmp/alcove-outputs.json` so the `version` template expands in downstream steps (was printing output instead of writing to file)
- **Release and Deploy**: analyzes CI failures, retries transient failures (registry 502, network timeout) up to 3 times via `gh run rerun`, also retries failed MR pipelines

## What was wrong
The first pipeline run worked end-to-end (changelog PR created, CI'd, merged, tag pushed) but:
1. `{{steps.changelog.outputs.version}}` wasn't expanded because the agent didn't write to `/tmp/alcove-outputs.json`
2. GH Actions release build failed with a transient 502 from registry.access.redhat.com and the agent just stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)