### PR TITLE
Strengthen release agent prompts for outputs and CI patience

### DIFF
--- a/.alcove/agents/changelog.yml
+++ b/.alcove/agents/changelog.yml
@@ -28,9 +28,10 @@ prompt: |
   4. Each entry should be a concise one-line summary of the change
   5. Commit and push to the branch
 
-  IMPORTANT: Write your outputs to /tmp/alcove-outputs.json so the next
-  workflow step can use them:
+  CRITICAL — YOUR VERY LAST ACTION must be writing outputs. The next
+  workflow step WILL FAIL if you skip this. Run this command:
     echo '{"version": "vX.Y.Z", "has_commits": true}' > /tmp/alcove-outputs.json
+  Replace vX.Y.Z with the actual version you determined. Do NOT skip this step.
 
 repos:
   - url: https://github.com/bmbouter/alcove.git

--- a/.alcove/agents/release.yml
+++ b/.alcove/agents/release.yml
@@ -19,10 +19,12 @@ prompt: |
 
   ## Phase 2: Wait for GitHub Actions
 
-  The tag push triggers a release build. Monitor it:
+  The tag push triggers a release build that takes 7-10 minutes. You MUST
+  wait for it. Do NOT exit early. Monitor it:
     gh run list --repo bmbouter/alcove --branch <version> --limit 5
 
-  Poll every 60 seconds until the "Release" workflow completes.
+  Poll every 60 seconds. Keep polling until the status is "completed".
+  This will take at least 7 minutes — that is normal. Do NOT give up.
 
   If the run FAILS, analyze the failure:
     gh run view <run_id> --repo bmbouter/alcove --log-failed 2>&1 | tail -20
@@ -83,8 +85,9 @@ prompt: |
   Poll the MR state every 60 seconds until state is "merged".
   If closed or pipeline fails after retries, report error and stop.
 
-  IMPORTANT: Write your outputs to /tmp/alcove-outputs.json:
+  CRITICAL — YOUR VERY LAST ACTION must be writing outputs:
     echo '{"version": "<version>", "deployed": true, "mr_merged": true}' > /tmp/alcove-outputs.json
+  Do NOT skip this step.
 
 repos:
   - url: https://github.com/bmbouter/alcove.git


### PR DESCRIPTION
## Problem
1. Changelog Generator doesn't write /tmp/alcove-outputs.json, causing {{steps.changelog.outputs.version}} to remain literal in downstream steps
2. Release and Deploy agent exits after ~4 min without waiting for GH Actions CI (~7 min)

## Fix
Prompt-level changes (zero code risk):
- Made output writing "CRITICAL — YOUR VERY LAST ACTION" instead of "IMPORTANT"
- Added explicit "takes 7-10 minutes, do NOT exit early" to CI wait instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)