### PR TITLE
Use ghcr.io dev container image for SDLC agents

### DIFF
--- a/.alcove/agents/autonomous-dev.yml
+++ b/.alcove/agents/autonomous-dev.yml
@@ -23,7 +23,7 @@ repos:
 timeout: 7200
 
 dev_container:
-  image: localhost/alcove-dev:latest
+  image: ghcr.io/bmbouter/alcove-dev:latest
 
 outputs:
   - summary

--- a/.alcove/agents/reviewer.yml
+++ b/.alcove/agents/reviewer.yml
@@ -17,7 +17,7 @@ repos:
 timeout: 1800
 
 dev_container:
-  image: localhost/alcove-dev:latest
+  image: ghcr.io/bmbouter/alcove-dev:latest
 
 outputs:
   - approved

--- a/.alcove/agents/security-reviewer.yml
+++ b/.alcove/agents/security-reviewer.yml
@@ -19,7 +19,7 @@ repos:
 timeout: 1800
 
 dev_container:
-  image: localhost/alcove-dev:latest
+  image: ghcr.io/bmbouter/alcove-dev:latest
 
 outputs:
   - approved


### PR DESCRIPTION
Switch dev_container.image from localhost/alcove-dev:latest to ghcr.io/bmbouter/alcove-dev:latest so SDLC agents work on staging/production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)