### PR TITLE
Fix dev container: remove S6_READ_ONLY_ROOT

### DIFF
--- a/build/Containerfile.dev
+++ b/build/Containerfile.dev
@@ -23,7 +23,6 @@ LABEL io.alcove.init="s6"
 
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=30000
-ENV S6_READ_ONLY_ROOT=1
 
 # Install xz-utils (needed to extract s6-overlay tarballs)
 RUN apt-get update && apt-get install -y --no-install-recommends xz-utils && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Removes S6_READ_ONLY_ROOT=1 which causes s6-overlay to test /run writability. On OpenShift /run is a root-owned tmpfs, not writable by UID 1001. The previous fix (chown /run) didn't work because /run is mounted fresh at container start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)