### PR TITLE
Capture executable agent stderr in transcripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,9 @@ jobs:
           ADMIN_PASSWORD=admin ./scripts/test-fixture-sync.sh
 
       - name: 'Batch 4: Session lifecycle (needs container runtime)'
-        run: ADMIN_PASSWORD=admin ./scripts/test-session-lifecycle.sh
+        run: |
+          ADMIN_PASSWORD=admin ./scripts/test-session-lifecycle.sh
+          ADMIN_PASSWORD=admin ./scripts/test-executable-transcript.sh
 
       - name: 'Batch 5: Error handling tests'
         run: |
@@ -497,7 +499,9 @@ jobs:
           ADMIN_PASSWORD=admin ./scripts/test-fixture-sync.sh
 
       - name: 'Batch 4: Session lifecycle (needs container runtime)'
-        run: ADMIN_PASSWORD=admin ./scripts/test-session-lifecycle.sh
+        run: |
+          ADMIN_PASSWORD=admin ./scripts/test-session-lifecycle.sh
+          ADMIN_PASSWORD=admin ./scripts/test-executable-transcript.sh
 
       - name: 'Batch 5: Error handling tests'
         run: |

--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -280,13 +280,16 @@ func runExecutable(
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	// Capture stderr to a buffer so we can log it
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
-
+	// Create pipes for both stdout and stderr
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		log.Printf("error creating stdout pipe: %v", err)
+		return 1, "error", nil, nil
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		log.Printf("error creating stderr pipe: %v", err)
 		return 1, "error", nil, nil
 	}
 
@@ -307,9 +310,43 @@ func runExecutable(
 		}
 	}()
 
-	// Read stdout line-by-line
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024) // 1MB line buffer
+	// Shared channel for stdout and stderr lines
+	type outputLine struct {
+		text   string
+		stream string // "stdout" or "stderr"
+	}
+	ch := make(chan outputLine, 256)
+
+	// Scan stdout and stderr in separate goroutines, both feeding ch
+	var scanWg sync.WaitGroup
+	scanWg.Add(2)
+
+	go func() {
+		defer scanWg.Done()
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024) // 1MB line buffer
+		for scanner.Scan() {
+			ch <- outputLine{text: scanner.Text(), stream: "stdout"}
+		}
+	}()
+
+	go func() {
+		defer scanWg.Done()
+		scanner := bufio.NewScanner(stderr)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024) // 1MB line buffer
+		for scanner.Scan() {
+			line := scanner.Text()
+			// Echo stderr to os.Stderr for container-level debugging (oc logs)
+			fmt.Fprintln(os.Stderr, line)
+			ch <- outputLine{text: line, stream: "stderr"}
+		}
+	}()
+
+	// Close ch when both scanners are done
+	go func() {
+		scanWg.Wait()
+		close(ch)
+	}()
 
 	var (
 		batch      []json.RawMessage
@@ -355,18 +392,21 @@ func runExecutable(
 		}
 	}()
 
-	// Process output lines - convert raw text to transcript format
-	for scanner.Scan() {
-		line := scanner.Text()
+	// Process output lines from both stdout and stderr
+	for ol := range ch {
 		lastEvent = time.Now()
 		lineNumber++
 
 		// Create transcript event for this line
 		transcriptEvent := map[string]any{
 			"type":      "text",
-			"content":   line,
+			"content":   ol.text,
 			"timestamp": time.Now().UTC().Format(time.RFC3339),
 			"source":    "executable",
+		}
+		// Add stream field only for stderr (backward compatibility)
+		if ol.stream == "stderr" {
+			transcriptEvent["stream"] = "stderr"
 		}
 
 		eventJSON, err := json.Marshal(transcriptEvent)
@@ -420,9 +460,6 @@ func runExecutable(
 		}
 	}
 
-	if stderrStr := stderrBuf.String(); stderrStr != "" {
-		log.Printf("executable stderr:\n%s", stderrStr)
-	}
 	log.Printf("executable completed: exit=%d lines=%d", exitCode, lineNumber)
 
 	// Determine outcome from exit code

--- a/cmd/test-agent/main.go
+++ b/cmd/test-agent/main.go
@@ -29,6 +29,16 @@ func main() {
 		fmt.Println(string(b))
 	}
 
+	// Write to stderr so transcript captures both streams
+	stderrEvents := []map[string]any{
+		{"type": "text", "content": "test-agent: stderr-line-1", "timestamp": time.Now().UTC().Format(time.RFC3339)},
+		{"type": "text", "content": "test-agent: STDERR_MARKER", "timestamp": time.Now().UTC().Format(time.RFC3339)},
+	}
+	for _, e := range stderrEvents {
+		b, _ := json.Marshal(e)
+		fmt.Fprintln(os.Stderr, string(b))
+	}
+
 	outputs := map[string]string{"test_status": "passed", "agent_version": "1.0.0"}
 	data, _ := json.Marshal(outputs)
 	_ = os.WriteFile("/tmp/alcove-outputs.json", data, 0644)

--- a/scripts/test-executable-transcript.sh
+++ b/scripts/test-executable-transcript.sh
@@ -74,7 +74,7 @@ timeout: 120
 YAML
 
 # Initialize a bare git repo so Bridge can clone it via file:// URL
-(cd "$REPO_DIR" && git init -b main && git add -A && git commit -m "Add executable agent definition" --quiet)
+(cd "$REPO_DIR" && git init -b main && git config user.email "test@test.com" && git config user.name "Test" && git add -A && git commit -m "Add executable agent definition" --quiet)
 
 REPO_URL="file://$REPO_DIR"
 log "  Local repo: $REPO_URL"

--- a/scripts/test-executable-transcript.sh
+++ b/scripts/test-executable-transcript.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# test-executable-transcript.sh — Verify executable agents capture stdout and stderr in transcripts.
+#
+# Creates a local git repo with an agent definition YAML that uses the
+# test-agent binary (baked into skiff-base), syncs it as an agent repo,
+# dispatches a session, and verifies the transcript contains both stdout
+# and stderr content with proper stream annotations.
+#
+# Prerequisites:
+#   - Bridge running at BRIDGE_URL (default http://localhost:8080)
+#   - AUTH_BACKEND=postgres with PostgreSQL accessible
+#   - ADMIN_PASSWORD set in the environment
+#   - Container runtime with skiff-base image containing test-agent binary
+#
+# Usage:
+#   ADMIN_PASSWORD=<pw> ./scripts/test-executable-transcript.sh
+
+set -euo pipefail
+
+BRIDGE_URL="${BRIDGE_URL:-http://localhost:8080}"
+PASS=0
+FAIL=0
+
+log() { echo ">>> $*"; }
+pass() { echo "  PASS: $*"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $*"; FAIL=$((FAIL+1)); }
+
+# --- Setup ---
+log "Setting up..."
+ADMIN_TOKEN=$(curl -s -X POST "$BRIDGE_URL/api/v1/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"admin\",\"password\":\"${ADMIN_PASSWORD}\"}" | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); t=d.get('token',''); print(t) if t else sys.exit('Login failed: ' + json.dumps(d))")
+
+# Create test user
+curl -s -X POST "$BRIDGE_URL/api/v1/users" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"transcript-tester","password":"transcript123","is_admin":false}' > /dev/null 2>&1 || true
+
+USER_TOKEN=$(curl -s -X POST "$BRIDGE_URL/api/v1/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"transcript-tester","password":"transcript123"}' | \
+  python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")
+
+TEAM_ID=$(curl -s "$BRIDGE_URL/api/v1/teams" \
+  -H "Authorization: Bearer $USER_TOKEN" | \
+  python3 -c "import json,sys; teams=json.load(sys.stdin).get('teams',[]); print(next((t['id'] for t in teams if t.get('is_personal')), ''))")
+
+log "  User token: ${USER_TOKEN:0:10}..."
+log "  Team ID: ${TEAM_ID:0:10}..."
+
+# =====================================================================
+# Step 1: Create a local git repo with an executable agent definition
+# =====================================================================
+log "Step 1: Create local git repo with executable agent definition"
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+REPO_DIR="$TMPDIR/test-exec-repo"
+mkdir -p "$REPO_DIR/.alcove/agents"
+
+cat > "$REPO_DIR/.alcove/agents/test-executable.yml" <<'YAML'
+name: Executable Transcript Test
+description: |
+  Test agent that writes to both stdout and stderr.
+  Used to verify transcript capture of both output streams.
+
+executable:
+  url: "file:///usr/local/bin/test-agent"
+
+timeout: 120
+YAML
+
+# Initialize a bare git repo so Bridge can clone it via file:// URL
+(cd "$REPO_DIR" && git init -b main && git add -A && git commit -m "Add executable agent definition" --quiet)
+
+REPO_URL="file://$REPO_DIR"
+log "  Local repo: $REPO_URL"
+
+# =====================================================================
+# Step 2: Configure agent repo and sync
+# =====================================================================
+log "Step 2: Configure agent repo and sync"
+
+REPO_RESP=$(curl -s -w "\n%{http_code}" -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Alcove-Team: $TEAM_ID" \
+  -d "{\"repos\":[{\"url\":\"$REPO_URL\",\"name\":\"test-exec\"}]}")
+REPO_CODE=$(echo "$REPO_RESP" | tail -1)
+
+if [ "$REPO_CODE" = "200" ] || [ "$REPO_CODE" = "204" ]; then
+  pass "Agent repo configured (HTTP $REPO_CODE)"
+else
+  fail "Agent repo configuration failed (HTTP $REPO_CODE)"
+fi
+
+curl -s -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "X-Alcove-Team: $TEAM_ID" > /dev/null
+
+# Wait for sync to complete
+SYNC_COUNT=0
+for attempt in $(seq 1 10); do
+  sleep 2
+  SYNC_COUNT=$(curl -s "$BRIDGE_URL/api/v1/agent-definitions" \
+    -H "Authorization: Bearer $USER_TOKEN" \
+    -H "X-Alcove-Team: $TEAM_ID" | \
+    python3 -c "import json,sys; print(len(json.load(sys.stdin).get('agent_definitions',[])))" 2>/dev/null || echo "0")
+  if [ "$SYNC_COUNT" -gt 0 ]; then break; fi
+done
+
+if [ "$SYNC_COUNT" -gt 0 ]; then
+  pass "Synced $SYNC_COUNT agent definitions"
+else
+  fail "No agent definitions synced"
+  echo ""
+  log "=== Test Summary ==="
+  echo "  Total: $((PASS+FAIL))  Passed: $PASS  Failed: $FAIL"
+  exit 1
+fi
+
+# =====================================================================
+# Test 3: Verify the executable agent definition was parsed correctly
+# =====================================================================
+log "Test 3: Verify executable agent definition"
+
+DEFS=$(curl -s "$BRIDGE_URL/api/v1/agent-definitions" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "X-Alcove-Team: $TEAM_ID")
+
+EXEC_DEF=$(echo "$DEFS" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for d in data.get('agent_definitions', []):
+    if d.get('name') == 'Executable Transcript Test':
+        print(json.dumps(d))
+        sys.exit()
+print('')
+")
+
+if [ -n "$EXEC_DEF" ]; then
+  pass "Found 'Executable Transcript Test' agent definition"
+
+  EXEC_URL=$(echo "$EXEC_DEF" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+e = d.get('executable', {})
+print(e.get('url', '') if e else '')
+")
+  if [ "$EXEC_URL" = "file:///usr/local/bin/test-agent" ]; then
+    pass "Executable URL correct: $EXEC_URL"
+  else
+    fail "Executable URL wrong: $EXEC_URL (expected file:///usr/local/bin/test-agent)"
+  fi
+else
+  fail "Executable Transcript Test agent definition not found after sync"
+fi
+
+# =====================================================================
+# Test 4: Dispatch session using the executable agent
+# =====================================================================
+log "Test 4: Dispatch executable agent session"
+
+SESSION_RESP=$(curl -s -w "\n%{http_code}" -X POST "$BRIDGE_URL/api/v1/sessions" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Alcove-Team: $TEAM_ID" \
+  -d '{
+    "prompt": "executable transcript test",
+    "executable": {"url": "file:///usr/local/bin/test-agent"},
+    "timeout": 120
+  }')
+SESSION_CODE=$(echo "$SESSION_RESP" | tail -1)
+SESSION_BODY=$(echo "$SESSION_RESP" | sed '$d')
+
+if [ "$SESSION_CODE" = "200" ] || [ "$SESSION_CODE" = "201" ]; then
+  pass "Session created (HTTP $SESSION_CODE)"
+else
+  fail "Session creation failed (HTTP $SESSION_CODE): $SESSION_BODY"
+  echo ""
+  log "=== Test Summary ==="
+  echo "  Total: $((PASS+FAIL))  Passed: $PASS  Failed: $FAIL"
+  exit 1
+fi
+
+SESSION_ID=$(echo "$SESSION_BODY" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('id', d.get('task_id', '')))")
+log "  Session ID: $SESSION_ID"
+
+# =====================================================================
+# Test 5: Poll session until completion
+# =====================================================================
+log "Test 5: Poll session until completion"
+
+FINAL_STATUS=""
+for i in $(seq 1 60); do
+  sleep 2
+  STATUS_RESP=$(curl -s "$BRIDGE_URL/api/v1/sessions/$SESSION_ID" \
+    -H "Authorization: Bearer $USER_TOKEN" \
+    -H "X-Alcove-Team: $TEAM_ID")
+  STATUS=$(echo "$STATUS_RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('status','unknown'))" 2>/dev/null || echo "unknown")
+
+  if [ "$STATUS" = "completed" ] || [ "$STATUS" = "error" ] || [ "$STATUS" = "timed_out" ]; then
+    FINAL_STATUS="$STATUS"
+    log "  Session reached terminal state: $STATUS (after $((i*2))s)"
+    break
+  fi
+
+  if [ "$((i % 5))" = "0" ]; then
+    log "  Still waiting... status=$STATUS ($((i*2))s elapsed)"
+  fi
+done
+
+if [ "$FINAL_STATUS" = "completed" ]; then
+  pass "Session completed successfully"
+elif [ -n "$FINAL_STATUS" ]; then
+  fail "Session ended with status: $FINAL_STATUS (expected: completed)"
+else
+  fail "Session did not reach terminal state within 120s (last status: $STATUS)"
+fi
+
+# =====================================================================
+# Test 6: Verify transcript contains stdout content
+# =====================================================================
+log "Test 6: Verify transcript stdout content"
+
+if [ "$FINAL_STATUS" = "completed" ] || [ "$FINAL_STATUS" = "error" ]; then
+  TRANSCRIPT=$(curl -s "$BRIDGE_URL/api/v1/sessions/$SESSION_ID/transcript" \
+    -H "Authorization: Bearer $USER_TOKEN" \
+    -H "X-Alcove-Team: $TEAM_ID")
+
+  if echo "$TRANSCRIPT" | grep -q "ALCOVE_TEST_MARKER"; then
+    pass "Transcript contains ALCOVE_TEST_MARKER (stdout captured)"
+  else
+    fail "Transcript does not contain ALCOVE_TEST_MARKER (stdout not captured)"
+  fi
+else
+  log "  Skipping transcript check (session did not complete)"
+fi
+
+# =====================================================================
+# Test 7: Verify transcript contains stderr content
+# =====================================================================
+log "Test 7: Verify transcript stderr content"
+
+if [ "$FINAL_STATUS" = "completed" ] || [ "$FINAL_STATUS" = "error" ]; then
+  if echo "$TRANSCRIPT" | grep -q "STDERR_MARKER"; then
+    pass "Transcript contains STDERR_MARKER (stderr captured)"
+  else
+    fail "Transcript does not contain STDERR_MARKER (stderr not captured)"
+  fi
+else
+  log "  Skipping stderr check (session did not complete)"
+fi
+
+# =====================================================================
+# Test 8: Verify stderr events have "stream": "stderr" JSON field
+# =====================================================================
+log "Test 8: Verify stderr stream annotation in transcript JSON"
+
+if [ "$FINAL_STATUS" = "completed" ] || [ "$FINAL_STATUS" = "error" ]; then
+  STDERR_STREAM_COUNT=$(echo "$TRANSCRIPT" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+events = data if isinstance(data, list) else data.get('events', data.get('transcript', []))
+stderr_events = [e for e in events if isinstance(e, dict) and e.get('stream') == 'stderr']
+print(len(stderr_events))
+" 2>/dev/null || echo "0")
+
+  if [ "$STDERR_STREAM_COUNT" -gt 0 ]; then
+    pass "Found $STDERR_STREAM_COUNT transcript events with \"stream\": \"stderr\""
+  else
+    fail "No transcript events have \"stream\": \"stderr\" field"
+  fi
+
+  # Verify stdout events do NOT have the stream field (backward compatibility)
+  STDOUT_STREAM_CHECK=$(echo "$TRANSCRIPT" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+events = data if isinstance(data, list) else data.get('events', data.get('transcript', []))
+stdout_with_stream = [e for e in events if isinstance(e, dict)
+                      and 'ALCOVE_TEST_MARKER' in e.get('content', '')
+                      and 'stream' in e]
+print(len(stdout_with_stream))
+" 2>/dev/null || echo "0")
+
+  if [ "$STDOUT_STREAM_CHECK" = "0" ]; then
+    pass "Stdout events do not have \"stream\" field (backward compatible)"
+  else
+    fail "Stdout events unexpectedly have \"stream\" field ($STDOUT_STREAM_CHECK events)"
+  fi
+else
+  log "  Skipping stream annotation check (session did not complete)"
+fi
+
+# =====================================================================
+# Cleanup
+# =====================================================================
+log "Cleanup..."
+curl -s -X DELETE "$BRIDGE_URL/api/v1/sessions/$SESSION_ID?action=delete" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "X-Alcove-Team: $TEAM_ID" > /dev/null 2>&1 || true
+curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Alcove-Team: $TEAM_ID" \
+  -d '{"repos":[]}' > /dev/null
+curl -s -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "X-Alcove-Team: $TEAM_ID" > /dev/null
+
+# --- Summary ---
+echo ""
+log "=== Test Summary ==="
+echo "  Total: $((PASS+FAIL))  Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then exit 1; else echo "  All tests passed."; fi

--- a/scripts/test-executable-transcript.sh
+++ b/scripts/test-executable-transcript.sh
@@ -221,6 +221,9 @@ else
   fail "Session did not reach terminal state within 120s (last status: $STATUS)"
 fi
 
+# Wait for transcript flush to complete (batch flush interval is 5s)
+sleep 8
+
 # =====================================================================
 # Test 6: Verify transcript contains stdout content
 # =====================================================================

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -3304,6 +3304,11 @@ details[open] > .tx-tool-expand-toggle::before {
     margin-top: 4px;
 }
 .tx-exec-line { color: var(--text-muted); padding: 1px 0; white-space: pre; }
+.tx-exec-line-stderr {
+    border-left: 3px solid var(--status-error, #e74c3c);
+    padding-left: 8px;
+    background: rgba(231, 76, 60, 0.06);
+}
 .tx-exec-blank { height: 8px; }
 .tx-exec-badge {
     display: inline-block;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2717,7 +2717,7 @@
                 continue;
             }
             if (type === 'text' && ev.source === 'executable') {
-                lines.push(ev.content || '');
+                lines.push({content: ev.content || '', stream: ev.stream || ''});
             }
         }
         if (lines.length > 0) {
@@ -2736,7 +2736,9 @@
         container.appendChild(div);
     }
 
-    function renderExecutableLine(line) {
+    function renderExecutableLine(lineObj) {
+        var line = typeof lineObj === 'string' ? lineObj : lineObj.content;
+        var stream = typeof lineObj === 'string' ? '' : (lineObj.stream || '');
         var escaped = escapeHtml(line);
 
         // Section headers: === Category Name ===
@@ -2763,7 +2765,8 @@
         escaped = escaped.replace(/\[OK\]\s*/g, '<span class="tx-exec-ok">[OK]</span> ');
         escaped = escaped.replace(/\[MISS\]/g, '<span class="tx-exec-miss">[MISS]</span>');
 
-        return '<div class="tx-exec-line">' + escaped + '</div>';
+        var cls = stream === 'stderr' ? 'tx-exec-line tx-exec-line-stderr' : 'tx-exec-line';
+        return '<div class="' + cls + '">' + escaped + '</div>';
     }
 
     // Simple markdown-like rendering (no library needed)


### PR DESCRIPTION
## Summary
- Executable agents now capture stderr in session transcripts (previously only stdout was captured)
- Stderr events tagged with `"stream": "stderr"` in transcript JSON
- Dashboard renders stderr with red left border, interleaved with stdout
- Backward compatible: old transcripts without stream field unchanged

## Test plan
- [x] test-agent binary produces both stdout and stderr
- [x] Local e2e: session transcript contains all 5 events (3 stdout + 2 stderr)
- [x] Stderr events have `"stream": "stderr"`, stdout events have no stream field
- [x] Dashboard renders stderr with red left border
- [x] `make build && make test` pass
- [x] New CI test: `test-executable-transcript.sh`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)