### PR TITLE
Fix CI: set BRIDGE_URL for container-to-host transcript flushing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
         run: |
           LEDGER_DATABASE_URL="postgres://alcove:alcove@localhost:5432/alcove?sslmode=disable" \
           HAIL_URL="nats://localhost:4222" \
+          BRIDGE_URL="http://host.containers.internal:8080" \
           RUNTIME=podman \
           ALCOVE_NETWORK=alcove-internal \
           ALCOVE_EXTERNAL_NETWORK=alcove-external \
@@ -413,6 +414,7 @@ jobs:
         run: |
           LEDGER_DATABASE_URL="postgres://alcove:alcove@localhost:5432/alcove?sslmode=disable" \
           HAIL_URL="nats://localhost:4222" \
+          BRIDGE_URL="http://host.containers.internal:8080" \
           RUNTIME=kubernetes \
           ALCOVE_NAMESPACE=alcove \
           KUBECONFIG=$HOME/.kube/config \

--- a/scripts/test-executable-transcript.sh
+++ b/scripts/test-executable-transcript.sh
@@ -221,9 +221,6 @@ else
   fail "Session did not reach terminal state within 120s (last status: $STATUS)"
 fi
 
-# Wait for transcript flush to complete (batch flush interval is 5s)
-sleep 8
-
 # =====================================================================
 # Test 6: Verify transcript contains stdout content
 # =====================================================================


### PR DESCRIPTION
## Summary
- Set `BRIDGE_URL=http://host.containers.internal:8080` in CI Bridge startup so Skiff containers can reach Bridge for transcript flushing
- Fixes empty transcripts for executable agents in CI
- Removes 8s sleep hack from test-executable-transcript.sh

## Root cause
Bridge runs as a local process in CI, not containerized. Skiff containers defaulted to `http://alcove-bridge:8080` which doesn't exist on the container network. `host.containers.internal` is podman's built-in host gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)