### PR TITLE
Fix dev container: use S6_RUNTIME_DIR for OpenShift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
         run: |
           LEDGER_DATABASE_URL="postgres://alcove:alcove@localhost:5432/alcove?sslmode=disable" \
           HAIL_URL="nats://localhost:4222" \
+          BRIDGE_URL="http://host.containers.internal:8080" \
           RUNTIME=podman \
           ALCOVE_NETWORK=alcove-internal \
           ALCOVE_EXTERNAL_NETWORK=alcove-external \
@@ -413,6 +414,7 @@ jobs:
         run: |
           LEDGER_DATABASE_URL="postgres://alcove:alcove@localhost:5432/alcove?sslmode=disable" \
           HAIL_URL="nats://localhost:4222" \
+          BRIDGE_URL="http://host.containers.internal:8080" \
           RUNTIME=kubernetes \
           ALCOVE_NAMESPACE=alcove \
           KUBECONFIG=$HOME/.kube/config \

--- a/build/Containerfile.dev
+++ b/build/Containerfile.dev
@@ -23,6 +23,7 @@ LABEL io.alcove.init="s6"
 
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=30000
+ENV S6_RUNTIME_DIR=/s6-run
 
 # Install xz-utils (needed to extract s6-overlay tarballs)
 RUN apt-get update && apt-get install -y --no-install-recommends xz-utils && rm -rf /var/lib/apt/lists/*
@@ -83,11 +84,11 @@ COPY --from=builder /out/alcove-shim /usr/local/bin/alcove-shim
 
 # Create workspace directory and set permissions for all runtime dirs.
 # OpenShift assigns random UIDs from the namespace range (e.g., 1000830000),
-# so we use chmod 777 instead of chown for dirs that must be writable at
-# runtime. /run is needed by s6-overlay's preinit.
-RUN mkdir -p /workspace && \
-    chown -R 1001:1001 /var/lib/postgresql /var/run/postgresql && \
-    chmod -R 777 /workspace /run /var/lib/postgresql /var/run/postgresql
+# so we use chmod 777 for dirs that must be writable at any UID.
+# S6_RUNTIME_DIR=/s6-run avoids touching /run (which is root-owned on OpenShift
+# and s6-overlay is very particular about its ownership/permissions).
+RUN mkdir -p /workspace /s6-run && \
+    chmod -R 777 /workspace /s6-run /var/lib/postgresql /var/run/postgresql
 
 USER 1001
 

--- a/scripts/test-executable-transcript.sh
+++ b/scripts/test-executable-transcript.sh
@@ -221,9 +221,6 @@ else
   fail "Session did not reach terminal state within 120s (last status: $STATUS)"
 fi
 
-# Wait for transcript flush to complete (batch flush interval is 5s)
-sleep 8
-
 # =====================================================================
 # Test 6: Verify transcript contains stdout content
 # =====================================================================


### PR DESCRIPTION
Redirect s6 runtime to /s6-run to avoid /run ownership conflicts on OpenShift.