### PR TITLE
Use version-tagged dev container image

### DIFF
--- a/.alcove/agents/autonomous-dev.yml
+++ b/.alcove/agents/autonomous-dev.yml
@@ -23,7 +23,7 @@ repos:
 timeout: 7200
 
 dev_container:
-  image: ghcr.io/bmbouter/alcove-dev:latest
+  image: ghcr.io/bmbouter/alcove-dev:0.33.3
 
 outputs:
   - summary

--- a/.alcove/agents/reviewer.yml
+++ b/.alcove/agents/reviewer.yml
@@ -17,7 +17,7 @@ repos:
 timeout: 1800
 
 dev_container:
-  image: ghcr.io/bmbouter/alcove-dev:latest
+  image: ghcr.io/bmbouter/alcove-dev:0.33.3
 
 outputs:
   - approved

--- a/.alcove/agents/security-reviewer.yml
+++ b/.alcove/agents/security-reviewer.yml
@@ -19,7 +19,7 @@ repos:
 timeout: 1800
 
 dev_container:
-  image: ghcr.io/bmbouter/alcove-dev:latest
+  image: ghcr.io/bmbouter/alcove-dev:0.33.3
 
 outputs:
   - approved


### PR DESCRIPTION
CRI-O caches :latest despite PullAlways. Use explicit version tag.