### PR TITLE
Fix dev container release build: disable Docker layer cache

### DIFF
--- a/.alcove/agents/autonomous-dev.yml
+++ b/.alcove/agents/autonomous-dev.yml
@@ -23,7 +23,7 @@ repos:
 timeout: 7200
 
 dev_container:
-  image: ghcr.io/bmbouter/alcove-dev:0.33.3
+  image: ghcr.io/bmbouter/alcove-dev:latest
 
 outputs:
   - summary

--- a/.alcove/agents/reviewer.yml
+++ b/.alcove/agents/reviewer.yml
@@ -17,7 +17,7 @@ repos:
 timeout: 1800
 
 dev_container:
-  image: ghcr.io/bmbouter/alcove-dev:0.33.3
+  image: ghcr.io/bmbouter/alcove-dev:latest
 
 outputs:
   - approved

--- a/.alcove/agents/security-reviewer.yml
+++ b/.alcove/agents/security-reviewer.yml
@@ -19,7 +19,7 @@ repos:
 timeout: 1800
 
 dev_container:
-  image: ghcr.io/bmbouter/alcove-dev:0.33.3
+  image: ghcr.io/bmbouter/alcove-dev:latest
 
 outputs:
   - approved

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,7 @@ jobs:
           context: .
           file: build/Containerfile.dev
           push: true
+          no-cache: true
           build-args: VERSION=${{ steps.version.outputs.version }}
           tags: |
             ${{ env.REGISTRY }}/alcove-dev:${{ steps.version.outputs.version }}


### PR DESCRIPTION
BuildKit layer caching caused stale dev container images. Adding `no-cache: true` to the dev container build step ensures Containerfile changes are reflected. Reverts version-pinned tag workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)