### PR TITLE
Fix dev container: use /tmp for PostgreSQL state

### DIFF
--- a/build/dev-entrypoint.sh
+++ b/build/dev-entrypoint.sh
@@ -1,18 +1,24 @@
 #!/bin/sh
 set -e
 
-PGDATA=/var/lib/postgresql/data
+# Use /tmp for all PostgreSQL state — it's always writable regardless of UID.
+# /var/lib/postgresql and /var/run/postgresql are on the overlay filesystem
+# and not reliably writable by OpenShift's random UIDs.
+PGDATA=/tmp/pgdata
+PGRUN=/tmp/pgrun
+mkdir -p "$PGRUN"
 
 # Initialize PostgreSQL if not already done.
 # Running initdb at startup (not build time) ensures the data directory
 # is owned by the current UID, which is required by PostgreSQL and
 # varies on OpenShift (random UID assignment).
 if [ ! -f "$PGDATA/PG_VERSION" ]; then
-  # PostgreSQL requires the data directory to be mode 0700.
-  chmod 700 "$PGDATA" 2>/dev/null || true
+  mkdir -p "$PGDATA"
   /usr/lib/postgresql/16/bin/initdb -D "$PGDATA"
   echo "host all all 0.0.0.0/0 trust" >> "$PGDATA/pg_hba.conf"
   echo "local all all trust" >> "$PGDATA/pg_hba.conf"
+  # Use /tmp/pgrun for the Unix socket
+  sed -i "s|#unix_socket_directories.*|unix_socket_directories = '$PGRUN'|" "$PGDATA/postgresql.conf"
 fi
 
 # Start PostgreSQL
@@ -22,12 +28,12 @@ fi
 
 # Wait for PostgreSQL to be ready
 for i in $(seq 1 30); do
-  /usr/lib/postgresql/16/bin/pg_isready -h /var/run/postgresql -q 2>/dev/null && break
+  /usr/lib/postgresql/16/bin/pg_isready -h "$PGRUN" -q 2>/dev/null && break
   sleep 1
 done
 
 # Create the alcove database if it doesn't exist
-/usr/lib/postgresql/16/bin/createdb -h /var/run/postgresql alcove 2>/dev/null || true
+/usr/lib/postgresql/16/bin/createdb -h "$PGRUN" alcove 2>/dev/null || true
 
 # Start NATS in the background
 nats-server -p 4222 &


### PR DESCRIPTION
OpenShift overlay FS not writable by random UIDs. Use /tmp.