### PR TITLE
Update workflow actions to unified bridge names

### DIFF
--- a/.alcove/workflows/feature-pipeline.yml
+++ b/.alcove/workflows/feature-pipeline.yml
@@ -23,7 +23,7 @@ workflow:
 
   - id: create-pr
     type: bridge
-    action: create-pr
+    action: create-merge-request
     depends: "implement.Succeeded"
     inputs:
       repo: bmbouter/alcove
@@ -33,7 +33,7 @@ workflow:
 
   - id: await-ci
     type: bridge
-    action: await-ci
+    action: await-checks
     depends: "create-pr.Succeeded || ci-fix.Succeeded"
     max_iterations: 4
     inputs:
@@ -91,7 +91,7 @@ workflow:
 
   - id: merge
     type: bridge
-    action: merge-pr
+    action: merge
     depends: "code-review.Succeeded && security-review.Succeeded"
     inputs:
       repo: bmbouter/alcove

--- a/.alcove/workflows/release-pipeline.yml
+++ b/.alcove/workflows/release-pipeline.yml
@@ -24,7 +24,7 @@ workflow:
 
   - id: changelog-pr
     type: bridge
-    action: create-pr
+    action: create-merge-request
     depends: "changelog.Succeeded"
     inputs:
       repo: bmbouter/alcove
@@ -34,7 +34,7 @@ workflow:
 
   - id: changelog-ci
     type: bridge
-    action: await-ci
+    action: await-checks
     depends: "changelog-pr.Succeeded"
     max_iterations: 4
     inputs:
@@ -43,7 +43,7 @@ workflow:
 
   - id: changelog-merge
     type: bridge
-    action: merge-pr
+    action: merge
     depends: "changelog-ci.Succeeded"
     inputs:
       repo: bmbouter/alcove


### PR DESCRIPTION
## Summary
- Replaces deprecated bridge action aliases with unified names in workflow YAML files
- `create-pr` -> `create-merge-request`, `await-ci` -> `await-checks`, `merge-pr` -> `merge`
- Affects `feature-pipeline.yml` and `release-pipeline.yml`

## Test plan
- [ ] Verify workflows still trigger and execute correctly (old names are backward compatible aliases)
- [ ] Confirm only `action:` field values changed, no step IDs or depends expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)