### PR TITLE
Add GitLab bridge actions, JIRA triggers, and unified SCM abstraction

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -219,6 +219,11 @@ func main() {
 	}
 	log.Println("workflow engine initialized")
 
+	// Start JIRA poller for JIRA-triggered workflows.
+	jiraPoller := bridge.NewJiraPoller(dbpool, credStore, workflowEngine, defStore)
+	go jiraPoller.Start(context.Background())
+	log.Println("JIRA poller started")
+
 	// Create and start the scheduler.
 	scheduler := bridge.NewScheduler(dbpool, dispatcher, cfg, credStore, defStore, settingsStore)
 	scheduler.SetWorkflowEngine(workflowEngine)

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -2419,8 +2419,10 @@ func (a *API) handleWorkflowRuns(w http.ResponseWriter, r *http.Request) {
 
 	case http.MethodPost:
 		var req struct {
-			WorkflowID string `json:"workflow_id"`
-			TriggerRef string `json:"trigger_ref"`
+			WorkflowID     string                 `json:"workflow_id"`
+			TriggerType    string                 `json:"trigger_type"`
+			TriggerRef     string                 `json:"trigger_ref"`
+			TriggerContext map[string]interface{} `json:"trigger_context"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
@@ -2432,7 +2434,12 @@ func (a *API) handleWorkflowRuns(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		run, err := a.workflowEngine.StartWorkflowRun(r.Context(), req.WorkflowID, "manual", req.TriggerRef, teamID)
+		triggerType := req.TriggerType
+		if triggerType == "" {
+			triggerType = "manual"
+		}
+
+		run, err := a.workflowEngine.StartWorkflowRun(r.Context(), req.WorkflowID, triggerType, req.TriggerRef, teamID, req.TriggerContext)
 		if err != nil {
 			log.Printf("error starting workflow run for workflow %s: %v", req.WorkflowID, err)
 			respondError(w, http.StatusInternalServerError, "failed to start workflow run: "+err.Error())

--- a/internal/bridge/bridge_actions.go
+++ b/internal/bridge/bridge_actions.go
@@ -15,16 +15,10 @@
 package bridge
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"log"
-	"net/http"
 	"strconv"
-	"strings"
-	"time"
 )
 
 // BridgeActionResult is the result of executing a bridge action.
@@ -48,15 +42,96 @@ type BridgeActionSchema struct {
 // RegisterBridgeActions returns a map of all built-in bridge actions.
 func RegisterBridgeActions() map[string]BridgeActionHandler {
 	return map[string]BridgeActionHandler{
+		// Unified actions (auto-detect SCM from inputs).
+		"create-merge-request": bridgeActionUnifiedCreateMR,
+		"await-checks":         bridgeActionUnifiedAwaitChecks,
+		"merge":                bridgeActionUnifiedMerge,
+		"comment":              bridgeActionUnifiedComment,
+
+		// GitHub-specific aliases.
 		"create-pr": bridgeActionCreatePR,
 		"await-ci":  bridgeActionAwaitCI,
 		"merge-pr":  bridgeActionMergePR,
+
+		// GitLab-specific aliases.
+		"create-mr":      bridgeActionCreateMR,
+		"await-pipeline": bridgeActionAwaitPipeline,
+		"merge-mr":       bridgeActionMergeMR,
+		"post-note":      bridgeActionPostNote,
 	}
 }
 
 // ListBridgeActionSchemas returns the schemas for all bridge actions.
 func ListBridgeActionSchemas() []BridgeActionSchema {
 	return []BridgeActionSchema{
+		{
+			Name:        "create-merge-request",
+			Description: "Create a pull request (GitHub) or merge request (GitLab). Auto-detects SCM from inputs.",
+			Inputs: map[string]string{
+				"repo":          "string (GitHub) - Repository in owner/repo format",
+				"project":       "string (GitLab) - Project ID or URL-encoded path",
+				"branch":        "string (GitHub) - Source branch name",
+				"source_branch": "string (GitLab) - Source branch name",
+				"base":          "string (GitHub) - Target branch name",
+				"target_branch": "string (GitLab) - Target branch name",
+				"title":         "string (required) - MR/PR title",
+				"body":          "string (GitHub, optional) - PR body/description",
+				"description":   "string (GitLab, optional) - MR description",
+				"draft":         "bool (GitHub, optional) - Create as draft PR",
+			},
+			Outputs: map[string]string{
+				"pr_number": "int - Pull request number (GitHub)",
+				"pr_url":    "string - Pull request URL (GitHub)",
+				"mr_iid":    "int - Merge request IID (GitLab)",
+				"mr_url":    "string - Merge request URL (GitLab)",
+			},
+		},
+		{
+			Name:        "await-checks",
+			Description: "Wait for CI checks (GitHub) or pipeline (GitLab) to complete. Auto-detects SCM from inputs.",
+			Inputs: map[string]string{
+				"repo":    "string (GitHub) - Repository in owner/repo format",
+				"project": "string (GitLab) - Project ID or URL-encoded path",
+				"pr":      "int (GitHub) - Pull request number",
+				"mr_iid":  "int (GitLab) - Merge request IID",
+				"timeout": "int (optional) - Timeout in seconds (default 900)",
+			},
+			Outputs: map[string]string{
+				"status":        "string - CI result: 'passed' or 'failed'",
+				"failure_logs":  "string - Concatenated failure logs (GitHub, if failed)",
+				"failed_checks": "[]string - Names of failed checks (GitHub)",
+				"pipeline_url":  "string - Pipeline URL (GitLab)",
+			},
+		},
+		{
+			Name:        "merge",
+			Description: "Merge a pull request (GitHub) or merge request (GitLab). Auto-detects SCM from inputs.",
+			Inputs: map[string]string{
+				"repo":          "string (GitHub) - Repository in owner/repo format",
+				"project":       "string (GitLab) - Project ID or URL-encoded path",
+				"pr":            "int (GitHub) - Pull request number",
+				"mr_iid":        "int (GitLab) - Merge request IID",
+				"method":        "string (GitHub, optional) - Merge method: merge, squash, rebase (default merge)",
+				"delete_branch": "bool (optional) - Delete source branch after merge (default true)",
+			},
+			Outputs: map[string]string{
+				"merge_sha": "string - The SHA of the merge commit",
+			},
+		},
+		{
+			Name:        "comment",
+			Description: "Post a comment on a pull request (GitHub) or merge request note (GitLab). Auto-detects SCM from inputs.",
+			Inputs: map[string]string{
+				"repo":    "string (GitHub) - Repository in owner/repo format",
+				"project": "string (GitLab) - Project ID or URL-encoded path",
+				"pr":      "int (GitHub) - Pull request number",
+				"mr_iid":  "int (GitLab) - Merge request IID",
+				"body":    "string (required) - Comment body text",
+			},
+			Outputs: map[string]string{
+				"posted": "bool - Whether the comment was posted",
+			},
+		},
 		{
 			Name:        "create-pr",
 			Description: "Create a pull request on GitHub",
@@ -103,409 +178,106 @@ func ListBridgeActionSchemas() []BridgeActionSchema {
 	}
 }
 
-// bridgeActionCreatePR creates a pull request on GitHub.
-func bridgeActionCreatePR(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+// detectSCM determines whether inputs are for GitHub or GitLab.
+// Returns "github", "gitlab", or "" if ambiguous.
+func detectSCM(inputs map[string]interface{}) string {
+	if _, ok := inputs["project"]; ok {
+		return "gitlab"
+	}
+	if _, ok := inputs["repo"]; ok {
+		return "github"
+	}
+	if _, ok := inputs["mr_iid"]; ok {
+		return "gitlab"
+	}
+	if _, ok := inputs["pr"]; ok {
+		return "github"
+	}
+	return ""
+}
+
+// Unified bridge actions — auto-detect SCM from inputs.
+
+func bridgeActionUnifiedCreateMR(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	scm := detectSCM(inputs)
+	switch scm {
+	case "gitlab":
+		return bridgeActionCreateMR(ctx, inputs, credStore, teamID)
+	case "github":
+		return bridgeActionCreatePR(ctx, inputs, credStore, teamID)
+	default:
+		return &BridgeActionResult{Status: "failed", Error: "cannot detect SCM: provide 'repo' (GitHub) or 'project' (GitLab)"}, nil
+	}
+}
+
+func bridgeActionUnifiedAwaitChecks(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	scm := detectSCM(inputs)
+	switch scm {
+	case "gitlab":
+		return bridgeActionAwaitPipeline(ctx, inputs, credStore, teamID)
+	case "github":
+		return bridgeActionAwaitCI(ctx, inputs, credStore, teamID)
+	default:
+		return &BridgeActionResult{Status: "failed", Error: "cannot detect SCM: provide 'repo' (GitHub) or 'project' (GitLab)"}, nil
+	}
+}
+
+func bridgeActionUnifiedMerge(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	scm := detectSCM(inputs)
+	switch scm {
+	case "gitlab":
+		return bridgeActionMergeMR(ctx, inputs, credStore, teamID)
+	case "github":
+		return bridgeActionMergePR(ctx, inputs, credStore, teamID)
+	default:
+		return &BridgeActionResult{Status: "failed", Error: "cannot detect SCM: provide 'repo' (GitHub) or 'project' (GitLab)"}, nil
+	}
+}
+
+func bridgeActionUnifiedComment(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	scm := detectSCM(inputs)
+	switch scm {
+	case "gitlab":
+		return bridgeActionPostNote(ctx, inputs, credStore, teamID)
+	case "github":
+		return bridgeActionGitHubComment(ctx, inputs, credStore, teamID)
+	default:
+		return &BridgeActionResult{Status: "failed", Error: "cannot detect SCM: provide 'repo' (GitHub) or 'project' (GitLab)"}, nil
+	}
+}
+
+// bridgeActionGitHubComment posts a comment on a GitHub pull request.
+func bridgeActionGitHubComment(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
 	repo := getStringInput(inputs, "repo")
-	branch := getStringInput(inputs, "branch")
-	base := getStringInput(inputs, "base")
-	title := getStringInput(inputs, "title")
+	pr := getIntInput(inputs, "pr")
 	body := getStringInput(inputs, "body")
-	draft := getBoolInput(inputs, "draft")
 
-	if repo == "" || branch == "" || base == "" || title == "" {
-		return &BridgeActionResult{
-			Status: "failed",
-			Error:  "missing required inputs: repo, branch, base, title",
-		}, nil
+	if repo == "" || pr == 0 || body == "" {
+		return &BridgeActionResult{Status: "failed", Error: "missing required inputs: repo, pr, body"}, nil
 	}
 
 	token, apiHost, err := credStore.AcquireSCMTokenForOwner(ctx, "github", teamID)
 	if err != nil {
-		return &BridgeActionResult{
-			Status: "failed",
-			Error:  fmt.Sprintf("failed to acquire GitHub token: %v", err),
-		}, nil
+		return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("failed to acquire GitHub token: %v", err)}, nil
 	}
-
 	if apiHost == "" {
 		apiHost = "https://api.github.com"
 	}
 
-	// Create the pull request.
-	prBody := map[string]interface{}{
-		"head":  branch,
-		"base":  base,
-		"title": title,
-	}
-	if body != "" {
-		prBody["body"] = body
-	}
-	if draft {
-		prBody["draft"] = true
-	}
-
-	bodyJSON, err := json.Marshal(prBody)
+	commentBody, _ := json.Marshal(map[string]interface{}{"body": body})
+	url := fmt.Sprintf("%s/repos/%s/issues/%d/comments", apiHost, repo, pr)
+	_, err = githubRequest(ctx, token, "POST", url, commentBody)
 	if err != nil {
-		return nil, fmt.Errorf("marshaling PR body: %w", err)
-	}
-
-	url := fmt.Sprintf("%s/repos/%s/pulls", apiHost, repo)
-	respBody, err := githubRequest(ctx, token, "POST", url, bodyJSON)
-	if err != nil {
-		return &BridgeActionResult{
-			Status: "failed",
-			Error:  fmt.Sprintf("GitHub API error creating PR: %v", err),
-		}, nil
-	}
-
-	var prResp struct {
-		Number  int    `json:"number"`
-		HTMLURL string `json:"html_url"`
-	}
-	if err := json.Unmarshal(respBody, &prResp); err != nil {
-		return &BridgeActionResult{
-			Status: "failed",
-			Error:  fmt.Sprintf("failed to parse GitHub PR response: %v", err),
-		}, nil
-	}
-
-	log.Printf("bridge-action create-pr: created PR #%d at %s", prResp.Number, prResp.HTMLURL)
-
-	return &BridgeActionResult{
-		Status: "succeeded",
-		Outputs: map[string]interface{}{
-			"pr_number": prResp.Number,
-			"pr_url":    prResp.HTMLURL,
-		},
-	}, nil
-}
-
-// bridgeActionAwaitCI waits for CI checks to complete on a pull request.
-func bridgeActionAwaitCI(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
-	repo := getStringInput(inputs, "repo")
-	pr := getIntInput(inputs, "pr")
-	timeout := getIntInput(inputs, "timeout")
-
-	if repo == "" || pr == 0 {
-		return &BridgeActionResult{
-			Status: "failed",
-			Error:  "missing required inputs: repo, pr",
-		}, nil
-	}
-
-	if timeout <= 0 {
-		timeout = 900
-	}
-
-	token, apiHost, err := credStore.AcquireSCMTokenForOwner(ctx, "github", teamID)
-	if err != nil {
-		return &BridgeActionResult{
-			Status: "failed",
-			Error:  fmt.Sprintf("failed to acquire GitHub token: %v", err),
-		}, nil
-	}
-
-	if apiHost == "" {
-		apiHost = "https://api.github.com"
-	}
-
-	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
-	pollInterval := 30 * time.Second
-
-	for time.Now().Before(deadline) {
-		// Check for context cancellation.
-		select {
-		case <-ctx.Done():
-			return &BridgeActionResult{
-				Status: "failed",
-				Error:  "context cancelled",
-			}, nil
-		default:
-		}
-
-		// Get PR to find head SHA.
-		prURL := fmt.Sprintf("%s/repos/%s/pulls/%d", apiHost, repo, pr)
-		prData, err := githubRequest(ctx, token, "GET", prURL, nil)
-		if err != nil {
-			log.Printf("bridge-action await-ci: error fetching PR %s#%d: %v", repo, pr, err)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		var prInfo struct {
-			Head struct {
-				SHA string `json:"sha"`
-			} `json:"head"`
-			State  string `json:"state"`
-			Merged bool   `json:"merged"`
-		}
-		if err := json.Unmarshal(prData, &prInfo); err != nil {
-			log.Printf("bridge-action await-ci: error parsing PR response: %v", err)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		if prInfo.State != "open" || prInfo.Merged {
-			return &BridgeActionResult{
-				Status: "succeeded",
-				Outputs: map[string]interface{}{
-					"status":        "passed",
-					"failure_logs":  "",
-					"failed_checks": []string{},
-				},
-			}, nil
-		}
-
-		// Check CI status.
-		checksURL := fmt.Sprintf("%s/repos/%s/commits/%s/check-runs", apiHost, repo, prInfo.Head.SHA)
-		checksData, err := githubRequest(ctx, token, "GET", checksURL, nil)
-		if err != nil {
-			log.Printf("bridge-action await-ci: error fetching checks: %v", err)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		var checks struct {
-			CheckRuns []struct {
-				ID         int64  `json:"id"`
-				Name       string `json:"name"`
-				Status     string `json:"status"`
-				Conclusion string `json:"conclusion"`
-			} `json:"check_runs"`
-		}
-		if err := json.Unmarshal(checksData, &checks); err != nil {
-			log.Printf("bridge-action await-ci: error parsing checks response: %v", err)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		if len(checks.CheckRuns) == 0 {
-			// If no checks after 90s, treat as passed (repo has no CI configured).
-			if time.Since(deadline.Add(-time.Duration(timeout)*time.Second)) > 90*time.Second {
-				log.Printf("bridge-action await-ci: no check runs found after 90s for %s#%d, treating as passed", repo, pr)
-				return &BridgeActionResult{
-					Status: "succeeded",
-					Outputs: map[string]interface{}{
-						"status":        "passed",
-						"failure_logs":  "",
-						"failed_checks": []string{},
-					},
-				}, nil
-			}
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		allComplete := true
-		anyFailed := false
-		var failedCheckNames []string
-		var failedCheckIDs []int64
-
-		for _, cr := range checks.CheckRuns {
-			if cr.Status != "completed" {
-				allComplete = false
-				break
-			}
-			if cr.Conclusion != "success" && cr.Conclusion != "skipped" {
-				anyFailed = true
-				failedCheckNames = append(failedCheckNames, cr.Name)
-				failedCheckIDs = append(failedCheckIDs, cr.ID)
-			}
-		}
-
-		if !allComplete {
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		if !anyFailed {
-			log.Printf("bridge-action await-ci: CI passed for %s#%d", repo, pr)
-			return &BridgeActionResult{
-				Status: "succeeded",
-				Outputs: map[string]interface{}{
-					"status":        "passed",
-					"failure_logs":  "",
-					"failed_checks": []string{},
-				},
-			}, nil
-		}
-
-		// CI failed — fetch failure logs.
-		log.Printf("bridge-action await-ci: CI failed for %s#%d: %v", repo, pr, failedCheckNames)
-		var failureLogs strings.Builder
-		for i, checkID := range failedCheckIDs {
-			logURL := fmt.Sprintf("%s/repos/%s/actions/jobs/%d/logs", apiHost, repo, checkID)
-			logData, err := githubRequest(ctx, token, "GET", logURL, nil)
-			if err != nil {
-				failureLogs.WriteString(fmt.Sprintf("\n### %s\nCould not fetch logs: %v\n", failedCheckNames[i], err))
-				continue
-			}
-			logStr := string(logData)
-			if len(logStr) > 3000 {
-				logStr = logStr[len(logStr)-3000:]
-			}
-			failureLogs.WriteString(fmt.Sprintf("\n### %s\n```\n%s\n```\n", failedCheckNames[i], logStr))
-		}
-
-		return &BridgeActionResult{
-			Status: "succeeded", // The action itself succeeded; the CI status is in the outputs.
-			Outputs: map[string]interface{}{
-				"status":        "failed",
-				"failure_logs":  failureLogs.String(),
-				"failed_checks": failedCheckNames,
-			},
-		}, nil
-	}
-
-	// Timeout.
-	log.Printf("bridge-action await-ci: timed out waiting for CI on %s#%d", repo, pr)
-	return &BridgeActionResult{
-		Status: "failed",
-		Error:  fmt.Sprintf("timed out after %d seconds waiting for CI checks", timeout),
-	}, nil
-}
-
-// bridgeActionMergePR merges a pull request on GitHub.
-func bridgeActionMergePR(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
-	repo := getStringInput(inputs, "repo")
-	pr := getIntInput(inputs, "pr")
-	method := getStringInput(inputs, "method")
-	deleteBranch := true
-	if v, ok := inputs["delete_branch"]; ok {
-		if b, ok := v.(bool); ok {
-			deleteBranch = b
-		}
-	}
-
-	if repo == "" || pr == 0 {
-		return &BridgeActionResult{
-			Status: "failed",
-			Error:  "missing required inputs: repo, pr",
-		}, nil
-	}
-
-	if method == "" {
-		method = "merge"
-	}
-
-	token, apiHost, err := credStore.AcquireSCMTokenForOwner(ctx, "github", teamID)
-	if err != nil {
-		return &BridgeActionResult{
-			Status: "failed",
-			Error:  fmt.Sprintf("failed to acquire GitHub token: %v", err),
-		}, nil
-	}
-
-	if apiHost == "" {
-		apiHost = "https://api.github.com"
-	}
-
-	// Merge the PR.
-	mergeBody := map[string]interface{}{
-		"merge_method": method,
-	}
-	bodyJSON, err := json.Marshal(mergeBody)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling merge body: %w", err)
-	}
-
-	mergeURL := fmt.Sprintf("%s/repos/%s/pulls/%d/merge", apiHost, repo, pr)
-	respBody, err := githubRequest(ctx, token, "PUT", mergeURL, bodyJSON)
-	if err != nil {
-		return &BridgeActionResult{
-			Status: "failed",
-			Error:  fmt.Sprintf("GitHub API error merging PR: %v", err),
-		}, nil
-	}
-
-	var mergeResp struct {
-		SHA     string `json:"sha"`
-		Merged  bool   `json:"merged"`
-		Message string `json:"message"`
-	}
-	if err := json.Unmarshal(respBody, &mergeResp); err != nil {
-		return &BridgeActionResult{
-			Status: "failed",
-			Error:  fmt.Sprintf("failed to parse merge response: %v", err),
-		}, nil
-	}
-
-	if !mergeResp.Merged {
-		return &BridgeActionResult{
-			Status: "failed",
-			Error:  fmt.Sprintf("merge failed: %s", mergeResp.Message),
-		}, nil
-	}
-
-	log.Printf("bridge-action merge-pr: merged PR #%d in %s (sha: %s)", pr, repo, mergeResp.SHA)
-
-	// Delete the branch if requested.
-	if deleteBranch {
-		// Get the PR to find the branch name.
-		prURL := fmt.Sprintf("%s/repos/%s/pulls/%d", apiHost, repo, pr)
-		prData, err := githubRequest(ctx, token, "GET", prURL, nil)
-		if err == nil {
-			var prInfo struct {
-				Head struct {
-					Ref string `json:"ref"`
-				} `json:"head"`
-			}
-			if json.Unmarshal(prData, &prInfo) == nil && prInfo.Head.Ref != "" {
-				deleteURL := fmt.Sprintf("%s/repos/%s/git/refs/heads/%s", apiHost, repo, prInfo.Head.Ref)
-				_, err := githubRequest(ctx, token, "DELETE", deleteURL, nil)
-				if err != nil {
-					log.Printf("bridge-action merge-pr: warning: failed to delete branch %s: %v", prInfo.Head.Ref, err)
-				} else {
-					log.Printf("bridge-action merge-pr: deleted branch %s", prInfo.Head.Ref)
-				}
-			}
-		}
+		return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("GitHub API error posting comment: %v", err)}, nil
 	}
 
 	return &BridgeActionResult{
-		Status: "succeeded",
-		Outputs: map[string]interface{}{
-			"merge_sha": mergeResp.SHA,
-		},
+		Status:  "succeeded",
+		Outputs: map[string]interface{}{"posted": true},
 	}, nil
 }
 
-// githubRequest performs an authenticated HTTP request to the GitHub API.
-func githubRequest(ctx context.Context, token, method, url string, body []byte) ([]byte, error) {
-	var reqBody io.Reader
-	if body != nil {
-		reqBody = bytes.NewReader(body)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "token "+token)
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-	req.Header.Set("User-Agent", "alcove-bridge-action")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	return respBody, nil
-}
+// Helper functions
 
 // getStringInput safely extracts a string input value.
 func getStringInput(inputs map[string]interface{}, key string) string {

--- a/internal/bridge/bridge_actions_github.go
+++ b/internal/bridge/bridge_actions_github.go
@@ -1,0 +1,431 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// bridgeActionCreatePR creates a pull request on GitHub.
+func bridgeActionCreatePR(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	repo := getStringInput(inputs, "repo")
+	branch := getStringInput(inputs, "branch")
+	base := getStringInput(inputs, "base")
+	title := getStringInput(inputs, "title")
+	body := getStringInput(inputs, "body")
+	draft := getBoolInput(inputs, "draft")
+
+	if repo == "" || branch == "" || base == "" || title == "" {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  "missing required inputs: repo, branch, base, title",
+		}, nil
+	}
+
+	token, apiHost, err := credStore.AcquireSCMTokenForOwner(ctx, "github", teamID)
+	if err != nil {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  fmt.Sprintf("failed to acquire GitHub token: %v", err),
+		}, nil
+	}
+
+	if apiHost == "" {
+		apiHost = "https://api.github.com"
+	}
+
+	// Create the pull request.
+	prBody := map[string]interface{}{
+		"head":  branch,
+		"base":  base,
+		"title": title,
+	}
+	if body != "" {
+		prBody["body"] = body
+	}
+	if draft {
+		prBody["draft"] = true
+	}
+
+	bodyJSON, err := json.Marshal(prBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling PR body: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/repos/%s/pulls", apiHost, repo)
+	respBody, err := githubRequest(ctx, token, "POST", url, bodyJSON)
+	if err != nil {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  fmt.Sprintf("GitHub API error creating PR: %v", err),
+		}, nil
+	}
+
+	var prResp struct {
+		Number  int    `json:"number"`
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.Unmarshal(respBody, &prResp); err != nil {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  fmt.Sprintf("failed to parse GitHub PR response: %v", err),
+		}, nil
+	}
+
+	log.Printf("bridge-action create-pr: created PR #%d at %s", prResp.Number, prResp.HTMLURL)
+
+	return &BridgeActionResult{
+		Status: "succeeded",
+		Outputs: map[string]interface{}{
+			"pr_number": prResp.Number,
+			"pr_url":    prResp.HTMLURL,
+		},
+	}, nil
+}
+
+// bridgeActionAwaitCI waits for CI checks to complete on a pull request.
+func bridgeActionAwaitCI(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	repo := getStringInput(inputs, "repo")
+	pr := getIntInput(inputs, "pr")
+	timeout := getIntInput(inputs, "timeout")
+
+	if repo == "" || pr == 0 {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  "missing required inputs: repo, pr",
+		}, nil
+	}
+
+	if timeout <= 0 {
+		timeout = 900
+	}
+
+	token, apiHost, err := credStore.AcquireSCMTokenForOwner(ctx, "github", teamID)
+	if err != nil {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  fmt.Sprintf("failed to acquire GitHub token: %v", err),
+		}, nil
+	}
+
+	if apiHost == "" {
+		apiHost = "https://api.github.com"
+	}
+
+	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
+	pollInterval := 30 * time.Second
+
+	for time.Now().Before(deadline) {
+		// Check for context cancellation.
+		select {
+		case <-ctx.Done():
+			return &BridgeActionResult{
+				Status: "failed",
+				Error:  "context cancelled",
+			}, nil
+		default:
+		}
+
+		// Get PR to find head SHA.
+		prURL := fmt.Sprintf("%s/repos/%s/pulls/%d", apiHost, repo, pr)
+		prData, err := githubRequest(ctx, token, "GET", prURL, nil)
+		if err != nil {
+			log.Printf("bridge-action await-ci: error fetching PR %s#%d: %v", repo, pr, err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		var prInfo struct {
+			Head struct {
+				SHA string `json:"sha"`
+			} `json:"head"`
+			State  string `json:"state"`
+			Merged bool   `json:"merged"`
+		}
+		if err := json.Unmarshal(prData, &prInfo); err != nil {
+			log.Printf("bridge-action await-ci: error parsing PR response: %v", err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		if prInfo.State != "open" || prInfo.Merged {
+			return &BridgeActionResult{
+				Status: "succeeded",
+				Outputs: map[string]interface{}{
+					"status":        "passed",
+					"failure_logs":  "",
+					"failed_checks": []string{},
+				},
+			}, nil
+		}
+
+		// Check CI status.
+		checksURL := fmt.Sprintf("%s/repos/%s/commits/%s/check-runs", apiHost, repo, prInfo.Head.SHA)
+		checksData, err := githubRequest(ctx, token, "GET", checksURL, nil)
+		if err != nil {
+			log.Printf("bridge-action await-ci: error fetching checks: %v", err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		var checks struct {
+			CheckRuns []struct {
+				ID         int64  `json:"id"`
+				Name       string `json:"name"`
+				Status     string `json:"status"`
+				Conclusion string `json:"conclusion"`
+			} `json:"check_runs"`
+		}
+		if err := json.Unmarshal(checksData, &checks); err != nil {
+			log.Printf("bridge-action await-ci: error parsing checks response: %v", err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		if len(checks.CheckRuns) == 0 {
+			// If no checks after 90s, treat as passed (repo has no CI configured).
+			if time.Since(deadline.Add(-time.Duration(timeout)*time.Second)) > 90*time.Second {
+				log.Printf("bridge-action await-ci: no check runs found after 90s for %s#%d, treating as passed", repo, pr)
+				return &BridgeActionResult{
+					Status: "succeeded",
+					Outputs: map[string]interface{}{
+						"status":        "passed",
+						"failure_logs":  "",
+						"failed_checks": []string{},
+					},
+				}, nil
+			}
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		allComplete := true
+		anyFailed := false
+		var failedCheckNames []string
+		var failedCheckIDs []int64
+
+		for _, cr := range checks.CheckRuns {
+			if cr.Status != "completed" {
+				allComplete = false
+				break
+			}
+			if cr.Conclusion != "success" && cr.Conclusion != "skipped" {
+				anyFailed = true
+				failedCheckNames = append(failedCheckNames, cr.Name)
+				failedCheckIDs = append(failedCheckIDs, cr.ID)
+			}
+		}
+
+		if !allComplete {
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		if !anyFailed {
+			log.Printf("bridge-action await-ci: CI passed for %s#%d", repo, pr)
+			return &BridgeActionResult{
+				Status: "succeeded",
+				Outputs: map[string]interface{}{
+					"status":        "passed",
+					"failure_logs":  "",
+					"failed_checks": []string{},
+				},
+			}, nil
+		}
+
+		// CI failed — fetch failure logs.
+		log.Printf("bridge-action await-ci: CI failed for %s#%d: %v", repo, pr, failedCheckNames)
+		var failureLogs strings.Builder
+		for i, checkID := range failedCheckIDs {
+			logURL := fmt.Sprintf("%s/repos/%s/actions/jobs/%d/logs", apiHost, repo, checkID)
+			logData, err := githubRequest(ctx, token, "GET", logURL, nil)
+			if err != nil {
+				failureLogs.WriteString(fmt.Sprintf("\n### %s\nCould not fetch logs: %v\n", failedCheckNames[i], err))
+				continue
+			}
+			logStr := string(logData)
+			if len(logStr) > 3000 {
+				logStr = logStr[len(logStr)-3000:]
+			}
+			failureLogs.WriteString(fmt.Sprintf("\n### %s\n```\n%s\n```\n", failedCheckNames[i], logStr))
+		}
+
+		return &BridgeActionResult{
+			Status: "succeeded", // The action itself succeeded; the CI status is in the outputs.
+			Outputs: map[string]interface{}{
+				"status":        "failed",
+				"failure_logs":  failureLogs.String(),
+				"failed_checks": failedCheckNames,
+			},
+		}, nil
+	}
+
+	// Timeout.
+	log.Printf("bridge-action await-ci: timed out waiting for CI on %s#%d", repo, pr)
+	return &BridgeActionResult{
+		Status: "failed",
+		Error:  fmt.Sprintf("timed out after %d seconds waiting for CI checks", timeout),
+	}, nil
+}
+
+// bridgeActionMergePR merges a pull request on GitHub.
+func bridgeActionMergePR(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	repo := getStringInput(inputs, "repo")
+	pr := getIntInput(inputs, "pr")
+	method := getStringInput(inputs, "method")
+	deleteBranch := true
+	if v, ok := inputs["delete_branch"]; ok {
+		if b, ok := v.(bool); ok {
+			deleteBranch = b
+		}
+	}
+
+	if repo == "" || pr == 0 {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  "missing required inputs: repo, pr",
+		}, nil
+	}
+
+	if method == "" {
+		method = "merge"
+	}
+
+	token, apiHost, err := credStore.AcquireSCMTokenForOwner(ctx, "github", teamID)
+	if err != nil {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  fmt.Sprintf("failed to acquire GitHub token: %v", err),
+		}, nil
+	}
+
+	if apiHost == "" {
+		apiHost = "https://api.github.com"
+	}
+
+	// Merge the PR.
+	mergeBody := map[string]interface{}{
+		"merge_method": method,
+	}
+	bodyJSON, err := json.Marshal(mergeBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling merge body: %w", err)
+	}
+
+	mergeURL := fmt.Sprintf("%s/repos/%s/pulls/%d/merge", apiHost, repo, pr)
+	respBody, err := githubRequest(ctx, token, "PUT", mergeURL, bodyJSON)
+	if err != nil {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  fmt.Sprintf("GitHub API error merging PR: %v", err),
+		}, nil
+	}
+
+	var mergeResp struct {
+		SHA     string `json:"sha"`
+		Merged  bool   `json:"merged"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(respBody, &mergeResp); err != nil {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  fmt.Sprintf("failed to parse merge response: %v", err),
+		}, nil
+	}
+
+	if !mergeResp.Merged {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  fmt.Sprintf("merge failed: %s", mergeResp.Message),
+		}, nil
+	}
+
+	log.Printf("bridge-action merge-pr: merged PR #%d in %s (sha: %s)", pr, repo, mergeResp.SHA)
+
+	// Delete the branch if requested.
+	if deleteBranch {
+		// Get the PR to find the branch name.
+		prURL := fmt.Sprintf("%s/repos/%s/pulls/%d", apiHost, repo, pr)
+		prData, err := githubRequest(ctx, token, "GET", prURL, nil)
+		if err == nil {
+			var prInfo struct {
+				Head struct {
+					Ref string `json:"ref"`
+				} `json:"head"`
+			}
+			if json.Unmarshal(prData, &prInfo) == nil && prInfo.Head.Ref != "" {
+				deleteURL := fmt.Sprintf("%s/repos/%s/git/refs/heads/%s", apiHost, repo, prInfo.Head.Ref)
+				_, err := githubRequest(ctx, token, "DELETE", deleteURL, nil)
+				if err != nil {
+					log.Printf("bridge-action merge-pr: warning: failed to delete branch %s: %v", prInfo.Head.Ref, err)
+				} else {
+					log.Printf("bridge-action merge-pr: deleted branch %s", prInfo.Head.Ref)
+				}
+			}
+		}
+	}
+
+	return &BridgeActionResult{
+		Status: "succeeded",
+		Outputs: map[string]interface{}{
+			"merge_sha": mergeResp.SHA,
+		},
+	}, nil
+}
+
+// githubRequest performs an authenticated HTTP request to the GitHub API.
+func githubRequest(ctx context.Context, token, method, url string, body []byte) ([]byte, error) {
+	var reqBody io.Reader
+	if body != nil {
+		reqBody = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "alcove-bridge-action")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}

--- a/internal/bridge/bridge_actions_gitlab.go
+++ b/internal/bridge/bridge_actions_gitlab.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// bridgeActionCreateMR creates a merge request on GitLab.
+func bridgeActionCreateMR(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	project := getStringInput(inputs, "project") // GitLab project ID or URL-encoded path
+	sourceBranch := getStringInput(inputs, "source_branch")
+	targetBranch := getStringInput(inputs, "target_branch")
+	title := getStringInput(inputs, "title")
+	description := getStringInput(inputs, "description")
+
+	if project == "" || sourceBranch == "" || targetBranch == "" || title == "" {
+		return &BridgeActionResult{Status: "failed", Error: "missing required inputs: project, source_branch, target_branch, title"}, nil
+	}
+
+	token, apiHost, err := credStore.AcquireSCMTokenForOwner(ctx, "gitlab", teamID)
+	if err != nil {
+		return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("failed to acquire GitLab token: %v", err)}, nil
+	}
+	if apiHost == "" {
+		apiHost = "https://gitlab.cee.redhat.com"
+	}
+
+	mrBody := map[string]interface{}{
+		"source_branch": sourceBranch,
+		"target_branch": targetBranch,
+		"title":         title,
+	}
+	if description != "" {
+		mrBody["description"] = description
+	}
+
+	bodyJSON, _ := json.Marshal(mrBody)
+	// URL-encode the project path for the API URL
+	encodedProject := strings.ReplaceAll(project, "/", "%2F")
+	apiURL := fmt.Sprintf("%s/api/v4/projects/%s/merge_requests", apiHost, encodedProject)
+
+	respBody, err := gitlabRequest(ctx, token, "POST", apiURL, bodyJSON)
+	if err != nil {
+		return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("GitLab API error creating MR: %v", err)}, nil
+	}
+
+	var mrResp struct {
+		IID    int    `json:"iid"`
+		WebURL string `json:"web_url"`
+	}
+	if err := json.Unmarshal(respBody, &mrResp); err != nil {
+		return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("failed to parse GitLab MR response: %v", err)}, nil
+	}
+
+	log.Printf("bridge-action create-mr: created MR !%d at %s", mrResp.IID, mrResp.WebURL)
+	return &BridgeActionResult{
+		Status: "succeeded",
+		Outputs: map[string]interface{}{
+			"mr_iid": mrResp.IID,
+			"mr_url": mrResp.WebURL,
+		},
+	}, nil
+}
+
+// bridgeActionPostNote posts a note (comment) on a GitLab merge request.
+func bridgeActionPostNote(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	project := getStringInput(inputs, "project")
+	mrIID := getIntInput(inputs, "mr_iid")
+	body := getStringInput(inputs, "body")
+
+	if project == "" || mrIID == 0 {
+		return &BridgeActionResult{Status: "failed", Error: "missing required inputs: project, mr_iid"}, nil
+	}
+	if body == "" {
+		body = "/lgtm"
+	}
+
+	token, apiHost, err := credStore.AcquireSCMTokenForOwner(ctx, "gitlab", teamID)
+	if err != nil {
+		return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("failed to acquire GitLab token: %v", err)}, nil
+	}
+	if apiHost == "" {
+		apiHost = "https://gitlab.cee.redhat.com"
+	}
+
+	noteBody := map[string]interface{}{"body": body}
+	bodyJSON, _ := json.Marshal(noteBody)
+	encodedProject := strings.ReplaceAll(project, "/", "%2F")
+	apiURL := fmt.Sprintf("%s/api/v4/projects/%s/merge_requests/%d/notes", apiHost, encodedProject, mrIID)
+
+	_, err = gitlabRequest(ctx, token, "POST", apiURL, bodyJSON)
+	if err != nil {
+		return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("GitLab API error posting note: %v", err)}, nil
+	}
+
+	log.Printf("bridge-action post-note: posted note on MR !%d in %s", mrIID, project)
+	return &BridgeActionResult{
+		Status: "succeeded",
+		Outputs: map[string]interface{}{"posted": true},
+	}, nil
+}
+
+// bridgeActionAwaitPipeline polls a GitLab MR's pipelines until the latest one reaches a terminal state.
+func bridgeActionAwaitPipeline(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	project := getStringInput(inputs, "project")
+	mrIID := getIntInput(inputs, "mr_iid")
+	timeout := getIntInput(inputs, "timeout")
+
+	if project == "" || mrIID == 0 {
+		return &BridgeActionResult{Status: "failed", Error: "missing required inputs: project, mr_iid"}, nil
+	}
+	if timeout <= 0 {
+		timeout = 900
+	}
+
+	token, apiHost, err := credStore.AcquireSCMTokenForOwner(ctx, "gitlab", teamID)
+	if err != nil {
+		return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("failed to acquire GitLab token: %v", err)}, nil
+	}
+	if apiHost == "" {
+		apiHost = "https://gitlab.cee.redhat.com"
+	}
+
+	encodedProject := strings.ReplaceAll(project, "/", "%2F")
+	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
+	pollInterval := 30 * time.Second
+
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return &BridgeActionResult{Status: "failed", Error: "context cancelled"}, nil
+		default:
+		}
+
+		apiURL := fmt.Sprintf("%s/api/v4/projects/%s/merge_requests/%d/pipelines", apiHost, encodedProject, mrIID)
+		data, err := gitlabRequest(ctx, token, "GET", apiURL, nil)
+		if err != nil {
+			log.Printf("bridge-action await-pipeline: error fetching pipelines: %v", err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		var pipelines []struct {
+			ID     int    `json:"id"`
+			Status string `json:"status"`
+			WebURL string `json:"web_url"`
+		}
+		if err := json.Unmarshal(data, &pipelines); err != nil {
+			log.Printf("bridge-action await-pipeline: error parsing pipelines: %v", err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		if len(pipelines) == 0 {
+			// No pipeline yet — check again after a bit
+			if time.Since(deadline.Add(-time.Duration(timeout)*time.Second)) > 90*time.Second {
+				log.Printf("bridge-action await-pipeline: no pipelines after 90s, treating as passed")
+				return &BridgeActionResult{Status: "succeeded", Outputs: map[string]interface{}{"status": "passed"}}, nil
+			}
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		latest := pipelines[0] // GitLab returns most recent first
+		switch latest.Status {
+		case "success":
+			log.Printf("bridge-action await-pipeline: pipeline %d passed for MR !%d", latest.ID, mrIID)
+			return &BridgeActionResult{Status: "succeeded", Outputs: map[string]interface{}{"status": "passed", "pipeline_url": latest.WebURL}}, nil
+		case "failed", "canceled":
+			log.Printf("bridge-action await-pipeline: pipeline %d %s for MR !%d", latest.ID, latest.Status, mrIID)
+			return &BridgeActionResult{Status: "succeeded", Outputs: map[string]interface{}{"status": "failed", "pipeline_url": latest.WebURL}}, nil
+		}
+		// Still running/pending
+		time.Sleep(pollInterval)
+	}
+
+	return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("timed out after %d seconds", timeout)}, nil
+}
+
+// bridgeActionMergeMR merges a merge request on GitLab.
+func bridgeActionMergeMR(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	project := getStringInput(inputs, "project")
+	mrIID := getIntInput(inputs, "mr_iid")
+	deleteBranch := true
+	if v, ok := inputs["delete_branch"]; ok {
+		if b, ok := v.(bool); ok {
+			deleteBranch = b
+		}
+	}
+
+	if project == "" || mrIID == 0 {
+		return &BridgeActionResult{Status: "failed", Error: "missing required inputs: project, mr_iid"}, nil
+	}
+
+	token, apiHost, err := credStore.AcquireSCMTokenForOwner(ctx, "gitlab", teamID)
+	if err != nil {
+		return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("failed to acquire GitLab token: %v", err)}, nil
+	}
+	if apiHost == "" {
+		apiHost = "https://gitlab.cee.redhat.com"
+	}
+
+	mergeBody := map[string]interface{}{
+		"should_remove_source_branch": deleteBranch,
+	}
+	bodyJSON, _ := json.Marshal(mergeBody)
+	encodedProject := strings.ReplaceAll(project, "/", "%2F")
+	apiURL := fmt.Sprintf("%s/api/v4/projects/%s/merge_requests/%d/merge", apiHost, encodedProject, mrIID)
+
+	respBody, err := gitlabRequest(ctx, token, "PUT", apiURL, bodyJSON)
+	if err != nil {
+		return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("GitLab API error merging MR: %v", err)}, nil
+	}
+
+	var mergeResp struct {
+		State          string `json:"state"`
+		MergeCommitSHA string `json:"merge_commit_sha"`
+	}
+	json.Unmarshal(respBody, &mergeResp)
+
+	log.Printf("bridge-action merge-mr: merged MR !%d in %s (sha: %s)", mrIID, project, mergeResp.MergeCommitSHA)
+	return &BridgeActionResult{
+		Status: "succeeded",
+		Outputs: map[string]interface{}{"merge_sha": mergeResp.MergeCommitSHA},
+	}, nil
+}
+
+// gitlabRequest performs an authenticated HTTP request to the GitLab API.
+func gitlabRequest(ctx context.Context, token, method, url string, body []byte) ([]byte, error) {
+	var reqBody io.Reader
+	if body != nil {
+		reqBody = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("PRIVATE-TOKEN", token)
+	req.Header.Set("User-Agent", "alcove-bridge-action")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+	return respBody, nil
+}

--- a/internal/bridge/jira_poller.go
+++ b/internal/bridge/jira_poller.go
@@ -1,0 +1,285 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// JiraPoller polls JIRA for recently updated issues and triggers workflows
+// whose definitions include a jira trigger that matches.
+type JiraPoller struct {
+	db             *pgxpool.Pool
+	credStore      *CredentialStore
+	workflowEngine *WorkflowEngine
+	defStore       *AgentDefStore
+	baseURL        string // e.g., "https://redhat.atlassian.net"
+	pollInterval   time.Duration
+	lastPollTime   time.Time
+}
+
+// NewJiraPoller creates a JiraPoller with the given dependencies.
+func NewJiraPoller(db *pgxpool.Pool, credStore *CredentialStore, we *WorkflowEngine, defStore *AgentDefStore) *JiraPoller {
+	return &JiraPoller{
+		db:             db,
+		credStore:      credStore,
+		workflowEngine: we,
+		defStore:       defStore,
+		baseURL:        "https://redhat.atlassian.net",
+		pollInterval:   2 * time.Minute,
+		lastPollTime:   time.Now().Add(-5 * time.Minute),
+	}
+}
+
+// Start begins the JIRA polling loop in the current goroutine. It blocks until
+// the context is cancelled.
+func (jp *JiraPoller) Start(ctx context.Context) {
+	ticker := time.NewTicker(jp.pollInterval)
+	defer ticker.Stop()
+
+	// Initial poll after 30 seconds
+	time.Sleep(30 * time.Second)
+	jp.PollAll(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			jp.PollAll(ctx)
+		}
+	}
+}
+
+// jiraPollTarget holds the information needed to match and dispatch a JIRA-
+// triggered workflow.
+type jiraPollTarget struct {
+	workflowID string
+	teamID     string
+	trigger    *JiraTrigger
+}
+
+// PollAll queries all workflows with JIRA triggers and polls JIRA for matching
+// recently-updated issues.
+func (jp *JiraPoller) PollAll(ctx context.Context) {
+	rows, err := jp.db.Query(ctx, `
+		SELECT w.id, w.name, w.parsed, w.team_id
+		FROM workflows w
+		WHERE w.parsed IS NOT NULL
+	`)
+	if err != nil {
+		log.Printf("jira-poller: error querying workflows: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	var targets []jiraPollTarget
+
+	for rows.Next() {
+		var wfID, wfName, teamID string
+		var parsedJSON []byte
+		if err := rows.Scan(&wfID, &wfName, &parsedJSON, &teamID); err != nil {
+			continue
+		}
+
+		var wd WorkflowDefinition
+		if err := json.Unmarshal(parsedJSON, &wd); err != nil {
+			continue
+		}
+
+		if wd.Trigger != nil && wd.Trigger.Jira != nil {
+			targets = append(targets, jiraPollTarget{
+				workflowID: wfID,
+				teamID:     teamID,
+				trigger:    wd.Trigger.Jira,
+			})
+		}
+	}
+
+	if len(targets) == 0 {
+		return
+	}
+
+	// Group by team to minimize credential lookups.
+	teamTargets := make(map[string][]jiraPollTarget)
+	for _, t := range targets {
+		teamTargets[t.teamID] = append(teamTargets[t.teamID], t)
+	}
+
+	for teamID, tgts := range teamTargets {
+		jp.pollForTeam(ctx, teamID, tgts)
+	}
+
+	jp.lastPollTime = time.Now()
+}
+
+func (jp *JiraPoller) pollForTeam(ctx context.Context, teamID string, targets []jiraPollTarget) {
+	token, _, err := jp.credStore.AcquireSCMTokenForOwner(ctx, "jira", teamID)
+	if err != nil {
+		log.Printf("jira-poller: no jira credential for team %s: %v", teamID, err)
+		return
+	}
+
+	// Collect all projects from targets.
+	projectSet := make(map[string]bool)
+	for _, t := range targets {
+		for _, p := range t.trigger.Projects {
+			projectSet[strings.ToUpper(p)] = true
+		}
+	}
+
+	// Build JQL for recently updated issues.
+	var projects []string
+	for p := range projectSet {
+		projects = append(projects, p)
+	}
+
+	minutesSinceLastPoll := int(time.Since(jp.lastPollTime).Minutes()) + 1
+	jql := fmt.Sprintf("project IN (%s) AND updated >= \"-%dm\" ORDER BY updated DESC",
+		strings.Join(projects, ","), minutesSinceLastPoll)
+
+	// Search JIRA.
+	searchURL := fmt.Sprintf("%s/rest/api/2/search?jql=%s&maxResults=50&fields=key,summary,status,labels,components,description,issuetype",
+		jp.baseURL, url.QueryEscape(jql))
+
+	data, err := jp.jiraRequest(ctx, token, "GET", searchURL, nil)
+	if err != nil {
+		log.Printf("jira-poller: search error: %v", err)
+		return
+	}
+
+	var searchResult struct {
+		Issues []struct {
+			Key    string `json:"key"`
+			Fields struct {
+				Summary     string `json:"summary"`
+				Description string `json:"description"`
+				Status      struct {
+					Name string `json:"name"`
+				} `json:"status"`
+				Labels     []string `json:"labels"`
+				Components []struct {
+					Name string `json:"name"`
+				} `json:"components"`
+				IssueType struct {
+					Name string `json:"name"`
+				} `json:"issuetype"`
+			} `json:"fields"`
+		} `json:"issues"`
+	}
+	if err := json.Unmarshal(data, &searchResult); err != nil {
+		log.Printf("jira-poller: error parsing search results: %v", err)
+		return
+	}
+
+	log.Printf("jira-poller: found %d recently updated issues in %v", len(searchResult.Issues), projects)
+
+	// Check each issue against each target's trigger.
+	for _, issue := range searchResult.Issues {
+		issueProject := strings.Split(issue.Key, "-")[0]
+		var issueComponents []string
+		for _, c := range issue.Fields.Components {
+			issueComponents = append(issueComponents, c.Name)
+		}
+
+		for _, target := range targets {
+			if target.trigger.Matches(issueProject, issueComponents, issue.Fields.Labels) {
+				// Check dedup — don't dispatch the same issue twice for the same workflow.
+				var count int
+				jp.db.QueryRow(ctx, `
+					SELECT COUNT(*) FROM workflow_runs
+					WHERE workflow_id = $1 AND trigger_ref = $2
+					AND created_at > NOW() - INTERVAL '24 hours'
+				`, target.workflowID, issue.Key).Scan(&count)
+
+				if count > 0 {
+					continue // Already dispatched recently
+				}
+
+				log.Printf("jira-poller: triggering workflow %s for issue %s", target.workflowID, issue.Key)
+
+				triggerContext := map[string]interface{}{
+					"issue_key":    issue.Key,
+					"issue_title":  issue.Fields.Summary,
+					"issue_body":   issue.Fields.Description,
+					"issue_url":    fmt.Sprintf("%s/browse/%s", jp.baseURL, issue.Key),
+					"issue_status": issue.Fields.Status.Name,
+					"issue_labels": issue.Fields.Labels,
+					"issue_type":   issue.Fields.IssueType.Name,
+				}
+
+				_, err := jp.workflowEngine.StartWorkflowRun(ctx, target.workflowID, "jira", issue.Key, target.teamID, triggerContext)
+				if err != nil {
+					log.Printf("jira-poller: error starting workflow for %s: %v", issue.Key, err)
+				}
+			}
+		}
+	}
+}
+
+func (jp *JiraPoller) jiraRequest(ctx context.Context, credential, method, reqURL string, body []byte) ([]byte, error) {
+	var reqBody io.Reader
+	if body != nil {
+		reqBody = strings.NewReader(string(body))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// JIRA Cloud uses Basic auth: email:api_token
+	// The credential is stored as the raw API token; we need the email prefix.
+	// Convention: credential stored as "email:token" or just "token".
+	if strings.Contains(credential, ":") {
+		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(credential)))
+	} else {
+		req.Header.Set("Authorization", "Bearer "+credential)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "alcove-jira-poller")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}

--- a/internal/bridge/webhook.go
+++ b/internal/bridge/webhook.go
@@ -22,6 +22,66 @@ import (
 // EventTrigger defines when a task should be triggered by external events.
 type EventTrigger struct {
 	GitHub *GitHubTrigger `json:"github,omitempty" yaml:"github"`
+	Jira   *JiraTrigger   `json:"jira,omitempty" yaml:"jira"`
+}
+
+// JiraTrigger defines JIRA issue matching criteria for workflow triggers.
+type JiraTrigger struct {
+	Projects   []string `json:"projects" yaml:"projects"`                       // JIRA project keys (e.g., "RHCLOUD", "AAP")
+	Components []string `json:"components,omitempty" yaml:"components,omitempty"` // component filters (empty = all)
+	Labels     []string `json:"labels,omitempty" yaml:"labels,omitempty"`         // label filters (empty = all)
+}
+
+// Matches checks if a JIRA issue matches this trigger config.
+func (t *JiraTrigger) Matches(issueProject string, issueComponents, issueLabels []string) bool {
+	if t == nil {
+		return false
+	}
+
+	// Issue project must be in t.Projects.
+	if !stringInSlice(issueProject, t.Projects) {
+		return false
+	}
+
+	// If t.Components is non-empty, at least one must match.
+	if len(t.Components) > 0 {
+		matched := false
+		for _, required := range t.Components {
+			for _, have := range issueComponents {
+				if strings.EqualFold(required, have) {
+					matched = true
+					break
+				}
+			}
+			if matched {
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	// If t.Labels is non-empty, at least one must match.
+	if len(t.Labels) > 0 {
+		matched := false
+		for _, required := range t.Labels {
+			for _, have := range issueLabels {
+				if strings.EqualFold(required, have) {
+					matched = true
+					break
+				}
+			}
+			if matched {
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	return true
 }
 
 // GitHubTrigger defines GitHub webhook event matching criteria.

--- a/internal/bridge/workflow.go
+++ b/internal/bridge/workflow.go
@@ -100,9 +100,20 @@ func ParseWorkflowDefinition(data []byte) (*WorkflowDefinition, error) {
 
 // validBridgeActions lists the allowed bridge action names.
 var validBridgeActions = map[string]bool{
+	// GitHub-specific aliases.
 	"create-pr": true,
 	"await-ci":  true,
 	"merge-pr":  true,
+	// Unified actions.
+	"create-merge-request": true,
+	"await-checks":         true,
+	"merge":                true,
+	"comment":              true,
+	// GitLab-specific aliases.
+	"create-mr":      true,
+	"await-pipeline": true,
+	"merge-mr":       true,
+	"post-note":      true,
 }
 
 // validateWorkflowSteps performs comprehensive validation on workflow steps.
@@ -133,7 +144,11 @@ func validateWorkflowSteps(steps []WorkflowStep) error {
 				return fmt.Errorf("workflow step '%s' of type 'bridge' missing required field: action", step.ID)
 			}
 			if !validBridgeActions[step.Action] {
-				return fmt.Errorf("workflow step '%s' has invalid bridge action '%s' (must be one of: create-pr, await-ci, merge-pr)", step.ID, step.Action)
+				var valid []string
+				for k := range validBridgeActions {
+					valid = append(valid, k)
+				}
+				return fmt.Errorf("workflow step '%s' has invalid bridge action '%s' (valid actions: %s)", step.ID, step.Action, strings.Join(valid, ", "))
 			}
 		default:
 			return fmt.Errorf("workflow step '%s' has invalid type '%s' (must be 'agent' or 'bridge')", step.ID, step.Type)
@@ -404,11 +419,7 @@ func validateInputsTemplateSyntax(inputs map[string]interface{}) error {
 		if str, ok := value.(string); ok {
 			// Check for template syntax like "{{steps.implement.outputs.summary}}" or "{{trigger.issue_number}}"
 			if strings.Contains(str, "{{") && strings.Contains(str, "}}") {
-				if !strings.Contains(str, "steps.") &&
-				   !strings.Contains(str, "trigger.issue_number") &&
-				   !strings.Contains(str, "trigger.issue_title") &&
-				   !strings.Contains(str, "trigger.issue_body") &&
-				   !strings.Contains(str, "trigger.issue_url") {
+				if !strings.Contains(str, "steps.") && !strings.Contains(str, "trigger.") {
 					return fmt.Errorf("input '%s' contains invalid template syntax: %s", key, str)
 				}
 			}

--- a/internal/bridge/workflow_engine.go
+++ b/internal/bridge/workflow_engine.go
@@ -865,8 +865,9 @@ func (we *WorkflowEngine) processInputValue(value interface{}, stepOutputs map[s
 }
 
 // expandTemplate expands template variables in a string.
-// Supports {{steps.stepName.outputs.outputName}}, {{trigger.issue_number}},
-// {{trigger.issue_title}}, {{trigger.issue_body}}, and {{trigger.issue_url}}.
+// Supports {{steps.stepName.outputs.outputName}} and {{trigger.FIELD}} where
+// FIELD is any key stored in _trigger_context. The special field
+// {{trigger.issue_number}} is also extracted from triggerRef ("owner/repo#42").
 func (we *WorkflowEngine) expandTemplateWithContext(template string, stepOutputs map[string]interface{}, triggerRef string) (string, error) {
 	result := template
 
@@ -879,28 +880,22 @@ func (we *WorkflowEngine) expandTemplateWithContext(template string, stepOutputs
 		result = strings.ReplaceAll(result, "{{trigger.issue_number}}", issueNumber)
 	}
 
-	// Pattern: {{trigger.issue_title}}, {{trigger.issue_body}}, {{trigger.issue_url}}
-	// These are extracted from the workflow run context rather than the triggerRef string.
-	// When a workflow is triggered by a GitHub issue event, these values are available
-	// in the workflow run's trigger context and should be passed through the execution chain.
-	// For now, we retrieve them from the workflow run's step outputs where they are stored
-	// when the workflow is initiated by the GitHub event handler.
-	if strings.Contains(result, "{{trigger.issue_title}}") ||
-	   strings.Contains(result, "{{trigger.issue_body}}") ||
-	   strings.Contains(result, "{{trigger.issue_url}}") {
-
-		// Look for trigger context in step outputs under a special "_trigger_context" key
+	// Generic {{trigger.FIELD}} resolution — resolve any field from _trigger_context.
+	triggerPattern := regexp.MustCompile(`\{\{trigger\.([\w_]+)\}\}`)
+	if triggerPattern.MatchString(result) {
 		if triggerContext, exists := stepOutputs["_trigger_context"]; exists {
 			if contextMap, ok := triggerContext.(map[string]interface{}); ok {
-				if issueTitle, ok := contextMap["issue_title"].(string); ok {
-					result = strings.ReplaceAll(result, "{{trigger.issue_title}}", issueTitle)
-				}
-				if issueBody, ok := contextMap["issue_body"].(string); ok {
-					result = strings.ReplaceAll(result, "{{trigger.issue_body}}", issueBody)
-				}
-				if issueURL, ok := contextMap["issue_url"].(string); ok {
-					result = strings.ReplaceAll(result, "{{trigger.issue_url}}", issueURL)
-				}
+				result = triggerPattern.ReplaceAllStringFunc(result, func(match string) string {
+					sub := triggerPattern.FindStringSubmatch(match)
+					if len(sub) < 2 {
+						return match
+					}
+					field := sub[1]
+					if val, ok := contextMap[field]; ok {
+						return fmt.Sprintf("%v", val)
+					}
+					return match // leave unresolved
+				})
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Adds full GitLab SCM support alongside the existing GitHub support, with a unified abstraction layer that auto-detects the platform from inputs.

### Bridge Actions
- **4 new GitLab actions**: `create-mr`, `await-pipeline`, `merge-mr`, `post-note`
- **4 unified actions**: `create-merge-request`, `await-checks`, `merge`, `comment` — auto-detect GitHub vs GitLab from `repo=` (GitHub) vs `project=` (GitLab)
- Split `bridge_actions.go` (860 lines) into 3 focused files: shared (~300), GitHub (~430), GitLab (~280)
- All old action names preserved as backward-compatible aliases

### JIRA Integration
- `JiraTrigger` struct on `EventTrigger` (projects, components, labels filtering)
- `JiraPoller` — polls JIRA for recently updated issues matching trigger configs via JQL, 24-hour deduplication
- Wired into Bridge startup

### Template Resolution
- Generic `{{trigger.FIELD}}` resolution from `_trigger_context` map (any field, not just hardcoded list)
- Supports JIRA fields like `issue_key`, `issue_status`, `issue_type`

### API
- `POST /api/v1/workflow-runs` now accepts `trigger_type`, `trigger_ref`, and `trigger_context`

### Demonstrated
- Created JIRA issue PULP-1645, triggered workflow, agent made docs change, Bridge created GitLab MR !71 on hosted-pulp/pulp-docs, awaited pipeline, posted /lgtm

## Test plan
- [ ] CI passes (all existing tests unaffected)
- [ ] go vet and go test clean