### PR TITLE
Fix: create-pr/create-mr reuse existing PR/MR instead of failing

### DIFF
--- a/internal/bridge/bridge_actions_github.go
+++ b/internal/bridge/bridge_actions_github.go
@@ -75,6 +75,29 @@ func bridgeActionCreatePR(ctx context.Context, inputs map[string]interface{}, cr
 	url := fmt.Sprintf("%s/repos/%s/pulls", apiHost, repo)
 	respBody, err := githubRequest(ctx, token, "POST", url, bodyJSON)
 	if err != nil {
+		// Check if a PR already exists for this branch
+		if strings.Contains(err.Error(), "422") || strings.Contains(err.Error(), "already exists") {
+			// Find the existing PR
+			existingURL := fmt.Sprintf("%s/repos/%s/pulls?head=%s:%s&state=open", apiHost, repo, strings.Split(repo, "/")[0], branch)
+			existingBody, findErr := githubRequest(ctx, token, "GET", existingURL, nil)
+			if findErr == nil {
+				var existingPRs []struct {
+					Number  int    `json:"number"`
+					HTMLURL string `json:"html_url"`
+				}
+				if json.Unmarshal(existingBody, &existingPRs) == nil && len(existingPRs) > 0 {
+					log.Printf("bridge-action create-pr: PR already exists for branch %s: #%d", branch, existingPRs[0].Number)
+					return &BridgeActionResult{
+						Status: "succeeded",
+						Outputs: map[string]interface{}{
+							"pr_number": existingPRs[0].Number,
+							"pr_url":    existingPRs[0].HTMLURL,
+							"reused":    true,
+						},
+					}, nil
+				}
+			}
+		}
 		return &BridgeActionResult{
 			Status: "failed",
 			Error:  fmt.Sprintf("GitHub API error creating PR: %v", err),

--- a/internal/bridge/bridge_actions_gitlab.go
+++ b/internal/bridge/bridge_actions_gitlab.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -63,7 +64,7 @@ func bridgeActionCreateMR(ctx context.Context, inputs map[string]interface{}, cr
 	respBody, err := gitlabRequest(ctx, token, "POST", apiURL, bodyJSON)
 	if err != nil {
 		if strings.Contains(err.Error(), "409") || strings.Contains(err.Error(), "already exists") {
-			existingURL := fmt.Sprintf("%s/api/v4/projects/%s/merge_requests?source_branch=%s&state=opened", apiHost, encodedProject, sourceBranch)
+			existingURL := fmt.Sprintf("%s/api/v4/projects/%s/merge_requests?source_branch=%s&state=opened", apiHost, encodedProject, url.QueryEscape(sourceBranch))
 			existingBody, findErr := gitlabRequest(ctx, token, "GET", existingURL, nil)
 			if findErr == nil {
 				var existingMRs []struct {

--- a/internal/bridge/bridge_actions_gitlab.go
+++ b/internal/bridge/bridge_actions_gitlab.go
@@ -62,6 +62,27 @@ func bridgeActionCreateMR(ctx context.Context, inputs map[string]interface{}, cr
 
 	respBody, err := gitlabRequest(ctx, token, "POST", apiURL, bodyJSON)
 	if err != nil {
+		if strings.Contains(err.Error(), "409") || strings.Contains(err.Error(), "already exists") {
+			existingURL := fmt.Sprintf("%s/api/v4/projects/%s/merge_requests?source_branch=%s&state=opened", apiHost, encodedProject, sourceBranch)
+			existingBody, findErr := gitlabRequest(ctx, token, "GET", existingURL, nil)
+			if findErr == nil {
+				var existingMRs []struct {
+					IID    int    `json:"iid"`
+					WebURL string `json:"web_url"`
+				}
+				if json.Unmarshal(existingBody, &existingMRs) == nil && len(existingMRs) > 0 {
+					log.Printf("bridge-action create-mr: MR already exists for branch %s: !%d", sourceBranch, existingMRs[0].IID)
+					return &BridgeActionResult{
+						Status: "succeeded",
+						Outputs: map[string]interface{}{
+							"mr_iid": existingMRs[0].IID,
+							"mr_url": existingMRs[0].WebURL,
+							"reused": true,
+						},
+					}, nil
+				}
+			}
+		}
 		return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("GitLab API error creating MR: %v", err)}, nil
 	}
 


### PR DESCRIPTION
## Problem

When a workflow runs multiple times and the agent pushes to the same branch, the `create-pr`/`create-mr` bridge action fails because a PR/MR already exists for that source branch (GitHub 422, GitLab 409). This caused the Pulp Dependency Upgrade Pipeline to fail at the `create-pr` step even though the agent completed successfully.

## Fix

Both GitHub and GitLab bridge actions now detect the "already exists" error, query for the existing PR/MR, and return it with `reused: true` in the outputs. Downstream steps (`await-checks`, `merge`) receive the same `pr_number`/`mr_iid` they expect.

- **GitHub**: queries `GET /repos/{repo}/pulls?head={owner}:{branch}&state=open`
- **GitLab**: queries `GET /api/v4/projects/{id}/merge_requests?source_branch={branch}&state=opened` (with URL-encoded branch name)

## Test plan
- [ ] CI passes
- [ ] Retrigger the Pulp Dependency Upgrade Pipeline on HCMAI — `create-pr` step should succeed by reusing the existing PR