### PR TITLE
Fix dev-container-tests CI flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,7 +585,7 @@ jobs:
 
       - name: Start dev container
         run: |
-          docker run -d --rm \
+          docker run -d \
             --name alcove-dev-test \
             -e SHIM_TOKEN=ci-test-token \
             -p 19090:9090 \
@@ -599,11 +599,20 @@ jobs:
               echo "Shim is healthy"
               exit 0
             fi
+            # Check if container is still running
+            if ! docker ps --filter name=alcove-dev-test --format '{{.Status}}' | grep -q Up; then
+              echo "ERROR: Container exited prematurely"
+              echo "=== Container inspect ==="
+              docker inspect alcove-dev-test --format '{{.State.Status}} exit={{.State.ExitCode}}' 2>&1 || true
+              echo "=== Container logs ==="
+              docker logs alcove-dev-test 2>&1 || true
+              exit 1
+            fi
             echo "Waiting for shim... ($i/60)"
             sleep 2
           done
           echo "Shim did not become healthy in time"
-          docker logs alcove-dev-test || true
+          docker logs alcove-dev-test 2>&1 || true
           exit 1
 
       - name: Test shim exec
@@ -664,9 +673,13 @@ jobs:
       - name: Show logs on failure
         if: failure()
         run: |
-          echo "=== Dev container ==="
+          echo "=== Dev container status ==="
+          docker inspect alcove-dev-test --format '{{.State.Status}} exit={{.State.ExitCode}}' 2>&1 || true
+          echo "=== Dev container logs ==="
           docker logs alcove-dev-test 2>&1 || true
 
       - name: Teardown
         if: always()
-        run: docker stop alcove-dev-test 2>/dev/null || true
+        run: |
+          docker stop alcove-dev-test 2>/dev/null || true
+          docker rm alcove-dev-test 2>/dev/null || true

--- a/build/Containerfile.dev
+++ b/build/Containerfile.dev
@@ -41,6 +41,11 @@ RUN cd /tmp/gomod && go mod download && rm -rf /tmp/gomod
 RUN mkdir -p /var/lib/postgresql/data /var/run/postgresql && \
     chmod -R 777 /var/lib/postgresql/data /var/run/postgresql
 
+# Create alcove user so initdb can look up the UID in /etc/passwd.
+# Docker requires this; Podman auto-creates passwd entries.
+RUN groupadd -g 1001 alcove && \
+    useradd -u 1001 -g alcove -d /home/alcove -m alcove
+
 # Copy the shim binary
 COPY --from=builder /out/alcove-shim /usr/local/bin/alcove-shim
 

--- a/build/dev-entrypoint.sh
+++ b/build/dev-entrypoint.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
-set -e
+# Dev container entrypoint: starts PostgreSQL, NATS, and the shim.
+#
+# NOTE: No "set -e" — we want the shim to start even if PostgreSQL or NATS
+# fail. The CI health check only needs the shim's /healthz endpoint; PG and
+# NATS are tested separately. Using set -e caused the container to exit
+# silently on Docker (GHA) whenever a non-critical command failed, and with
+# --rm the logs were lost.
+
+echo "[entrypoint] starting dev container (pid $$, uid $(id -u))"
 
 # Use /tmp for all PostgreSQL state — it's always writable regardless of UID.
 # /var/lib/postgresql and /var/run/postgresql are on the overlay filesystem
@@ -13,30 +21,48 @@ mkdir -p "$PGRUN"
 # is owned by the current UID, which is required by PostgreSQL and
 # varies on OpenShift (random UID assignment).
 if [ ! -f "$PGDATA/PG_VERSION" ]; then
+  echo "[entrypoint] initializing PostgreSQL data directory"
   mkdir -p "$PGDATA"
-  /usr/lib/postgresql/16/bin/initdb -D "$PGDATA"
-  echo "host all all 0.0.0.0/0 trust" >> "$PGDATA/pg_hba.conf"
-  echo "local all all trust" >> "$PGDATA/pg_hba.conf"
-  # Use /tmp/pgrun for the Unix socket
-  sed -i "s|#unix_socket_directories.*|unix_socket_directories = '$PGRUN'|" "$PGDATA/postgresql.conf"
+  if /usr/lib/postgresql/16/bin/initdb -D "$PGDATA" > /tmp/initdb.log 2>&1; then
+    echo "[entrypoint] initdb succeeded"
+    echo "host all all 0.0.0.0/0 trust" >> "$PGDATA/pg_hba.conf"
+    echo "local all all trust" >> "$PGDATA/pg_hba.conf"
+    # Use /tmp/pgrun for the Unix socket
+    sed -i "s|#unix_socket_directories.*|unix_socket_directories = '$PGRUN'|" "$PGDATA/postgresql.conf"
+  else
+    echo "[entrypoint] WARNING: initdb failed (exit $?), PostgreSQL will not be available"
+    cat /tmp/initdb.log 2>/dev/null || true
+  fi
 fi
 
-# Start PostgreSQL
-/usr/lib/postgresql/16/bin/pg_ctl -D "$PGDATA" \
-  -o "-c listen_addresses=localhost -c dynamic_shared_memory_type=posix" \
-  -l /tmp/postgresql.log start
+# Start PostgreSQL (if initdb succeeded)
+if [ -f "$PGDATA/PG_VERSION" ]; then
+  echo "[entrypoint] starting PostgreSQL"
+  if /usr/lib/postgresql/16/bin/pg_ctl -D "$PGDATA" \
+    -o "-c listen_addresses=localhost -c dynamic_shared_memory_type=posix" \
+    -l /tmp/postgresql.log start; then
+    echo "[entrypoint] PostgreSQL started"
 
-# Wait for PostgreSQL to be ready
-for i in $(seq 1 30); do
-  /usr/lib/postgresql/16/bin/pg_isready -h "$PGRUN" -q 2>/dev/null && break
-  sleep 1
-done
+    # Wait for PostgreSQL to be ready
+    for i in $(seq 1 30); do
+      /usr/lib/postgresql/16/bin/pg_isready -h "$PGRUN" -q 2>/dev/null && break
+      sleep 1
+    done
 
-# Create the alcove database if it doesn't exist
-/usr/lib/postgresql/16/bin/createdb -h "$PGRUN" alcove 2>/dev/null || true
+    # Create the alcove database if it doesn't exist
+    /usr/lib/postgresql/16/bin/createdb -h "$PGRUN" alcove 2>/dev/null || true
+  else
+    echo "[entrypoint] WARNING: pg_ctl start failed (exit $?), PostgreSQL will not be available"
+    cat /tmp/postgresql.log 2>/dev/null || true
+  fi
+else
+  echo "[entrypoint] skipping PostgreSQL start (no data directory)"
+fi
 
-# Start NATS in the background
-nats-server -p 4222 &
+# Start NATS in the background (with monitoring on 8222 for health checks)
+echo "[entrypoint] starting NATS"
+nats-server -p 4222 -m 8222 &
 
 # Start the shim in the foreground (keeps the container alive)
+echo "[entrypoint] starting shim"
 exec /usr/local/bin/alcove-shim


### PR DESCRIPTION
## Problem

`dev-container-tests` has been failing on every CI run since the s6-overlay was replaced with a shell entrypoint. The container crashes immediately on Docker (GHA runners) but works fine on Podman locally.

## Root Causes

1. **`set -e`** in the entrypoint makes any non-zero command fatal — Docker handles UID/signal behavior differently from Podman
2. **Missing `-m 8222`** on nats-server — the NATS monitoring endpoint test always fails
3. **`--rm` flag** on `docker run` destroys container logs on crash, making failures undiagnosable

## Fix

- Remove `set -e`, use explicit `if` error handling
- Add `[entrypoint]` logging for startup visibility
- Restore `-m 8222` on nats-server
- Remove `--rm` from CI, add container exit detection in health loop, add `docker inspect` on failure

## Test plan
- [ ] `dev-container-tests` job passes (the whole point)
- [ ] All other CI jobs unaffected