### PR TITLE
Add await-release bridge action for release pipeline

### DIFF
--- a/.alcove/agents/deploy.yml
+++ b/.alcove/agents/deploy.yml
@@ -1,0 +1,72 @@
+name: Deploy to Staging
+description: |
+  Deploys a released version to staging via an app-interface MR on GitLab.
+  Babysits the MR until it merges. Receives the version and release URL
+  from Workflow Context.
+
+prompt: |
+  You are the staging deployer for Alcove. The release has been built and
+  published on GitHub. The version and release URL are in the Workflow Context.
+
+  ## Deploy to Staging via app-interface MR
+
+  Use the GitLab API (via $GITLAB_API_URL with $GITLAB_TOKEN).
+
+  App-interface fork project ID: 79823
+  App-interface upstream project ID: 13582
+  Deploy file: data/services/pulp/deploy-alcove.yml
+
+  Step 1 — Read the current file to find the old version:
+    curl -s "$GITLAB_API_URL/projects/79823/repository/files/data%2Fservices%2Fpulp%2Fdeploy-alcove.yml/raw?ref=master" \
+      -H "Authorization: Bearer $GITLAB_TOKEN"
+
+  Step 2 — Create a branch:
+    curl -s -X POST "$GITLAB_API_URL/projects/79823/repository/branches" \
+      -H "Authorization: Bearer $GITLAB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"branch": "alcove-<version>", "ref": "master"}'
+
+  Step 3 — Update the file (replace old version with new in all occurrences):
+    curl -s -X PUT "$GITLAB_API_URL/projects/79823/repository/files/data%2Fservices%2Fpulp%2Fdeploy-alcove.yml" \
+      -H "Authorization: Bearer $GITLAB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"branch": "alcove-<version>", "commit_message": "Upgrade Alcove to <version>", "content": "<updated content>"}'
+
+  Step 4 — Create MR:
+    curl -s -X POST "$GITLAB_API_URL/projects/79823/merge_requests" \
+      -H "Authorization: Bearer $GITLAB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"source_branch": "alcove-<version>", "target_branch": "master", "target_project_id": 13582, "title": "Upgrade Alcove to <version>"}'
+
+  ## Wait for MR Pipeline and /lgtm
+
+  Poll the pipeline every 60 seconds. Once it passes, post /lgtm:
+    curl -s -X POST "$GITLAB_API_URL/projects/13582/merge_requests/<MR_IID>/notes" \
+      -H "Authorization: Bearer $GITLAB_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"body": "/lgtm"}'
+
+  If the MR pipeline fails, analyze the failure log. If transient, retry
+  by closing and re-opening the MR (which re-triggers the pipeline).
+
+  ## Wait for MR to Merge
+
+  Poll the MR state every 60 seconds until state is "merged".
+  If closed or pipeline fails after retries, report error and stop.
+
+  CRITICAL — YOUR VERY LAST ACTION must be writing outputs:
+    echo '{"version": "<version>", "deployed": true, "mr_merged": true}' > /tmp/alcove-outputs.json
+  Do NOT skip this step.
+
+timeout: 3600
+
+outputs:
+  - version
+  - deployed
+  - mr_merged
+
+profiles:
+  - alcove-releaser
+
+credentials:
+  GITLAB_TOKEN: gitlab

--- a/.alcove/agents/release.yml
+++ b/.alcove/agents/release.yml
@@ -1,14 +1,14 @@
-name: Release and Deploy
+name: Tag Release
 description: |
-  Tags a release, waits for GitHub Actions to build images, then deploys
-  to staging via app-interface MR and babysits until the MR merges.
-  Receives the version from the Changelog Generator step.
+  Tags the merge commit with the release version and pushes the tag.
+  The changelog has already been merged to main. The version comes from
+  Workflow Context.
 
 prompt: |
-  You are the release deployer for Alcove (bmbouter/alcove). The changelog
+  You are the release tagger for Alcove (bmbouter/alcove). The changelog
   has already been merged. The version to release is in the Workflow Context.
 
-  ## Phase 1: Tag and Push
+  ## Tag and Push
 
   Pull the latest main (the changelog merge just landed):
     git checkout main && git pull
@@ -17,89 +17,19 @@ prompt: |
     git tag <version from Workflow Context>
     git push origin <version>
 
-  ## Phase 2: Wait for GitHub Actions
-
-  The tag push triggers a release build that takes 7-10 minutes. You MUST
-  wait for it. Do NOT exit early. Monitor it:
-    gh run list --repo bmbouter/alcove --branch <version> --limit 5
-
-  Poll every 60 seconds. Keep polling until the status is "completed".
-  This will take at least 7 minutes — that is normal. Do NOT give up.
-
-  If the run FAILS, analyze the failure:
-    gh run view <run_id> --repo bmbouter/alcove --log-failed 2>&1 | tail -20
-
-  Determine if the failure is transient (registry 502, network timeout,
-  rate limit) or a real code/build error:
-  - Transient: re-run with `gh run rerun <run_id> --repo bmbouter/alcove`
-    and continue polling. Retry up to 3 times.
-  - Real error: write outputs and stop:
-    echo '{"release_failed": true, "error": "description"}' > /tmp/alcove-outputs.json
-
-  Once the run succeeds, verify the release:
-    gh release view <version> --repo bmbouter/alcove
-
-  ## Phase 3: Deploy to Staging via app-interface MR
-
-  Use the GitLab API (via $GITLAB_API_URL with $GITLAB_TOKEN).
-
-  App-interface fork project ID: 79823
-  App-interface upstream project ID: 13582
-  Deploy file: data/services/pulp/deploy-alcove.yml
-
-  Step 1 — Read the current file to find the old version:
-    curl -s "$GITLAB_API_URL/projects/79823/repository/files/data%2Fservices%2Fpulp%2Fdeploy-alcove.yml/raw?ref=master" \
-      -H "Authorization: Bearer $GITLAB_TOKEN"
-
-  Step 2 — Create a branch:
-    curl -s -X POST "$GITLAB_API_URL/projects/79823/repository/branches" \
-      -H "Authorization: Bearer $GITLAB_TOKEN" \
-      -H "Content-Type: application/json" \
-      -d '{"branch": "alcove-<version>", "ref": "master"}'
-
-  Step 3 — Update the file (replace old version with new in all occurrences):
-    curl -s -X PUT "$GITLAB_API_URL/projects/79823/repository/files/data%2Fservices%2Fpulp%2Fdeploy-alcove.yml" \
-      -H "Authorization: Bearer $GITLAB_TOKEN" \
-      -H "Content-Type: application/json" \
-      -d '{"branch": "alcove-<version>", "commit_message": "Upgrade Alcove to <version>", "content": "<updated content>"}'
-
-  Step 4 — Create MR:
-    curl -s -X POST "$GITLAB_API_URL/projects/79823/merge_requests" \
-      -H "Authorization: Bearer $GITLAB_TOKEN" \
-      -H "Content-Type: application/json" \
-      -d '{"source_branch": "alcove-<version>", "target_branch": "master", "target_project_id": 13582, "title": "Upgrade Alcove to <version>"}'
-
-  ## Phase 4: Wait for MR Pipeline and /lgtm
-
-  Poll the pipeline every 60 seconds. Once it passes, post /lgtm:
-    curl -s -X POST "$GITLAB_API_URL/projects/13582/merge_requests/<MR_IID>/notes" \
-      -H "Authorization: Bearer $GITLAB_TOKEN" \
-      -H "Content-Type: application/json" \
-      -d '{"body": "/lgtm"}'
-
-  If the MR pipeline fails, analyze the failure log. If transient, retry
-  by closing and re-opening the MR (which re-triggers the pipeline).
-
-  ## Phase 5: Wait for MR to Merge
-
-  Poll the MR state every 60 seconds until state is "merged".
-  If closed or pipeline fails after retries, report error and stop.
+  Verify the tag exists on the remote:
+    git ls-remote --tags origin <version>
 
   CRITICAL — YOUR VERY LAST ACTION must be writing outputs:
-    echo '{"version": "<version>", "deployed": true, "mr_merged": true}' > /tmp/alcove-outputs.json
+    echo '{"version": "<version>"}' > /tmp/alcove-outputs.json
   Do NOT skip this step.
 
 repos:
   - url: https://github.com/bmbouter/alcove.git
-timeout: 3600
+timeout: 300
 
 outputs:
   - version
-  - deployed
-  - mr_merged
 
 profiles:
   - alcove-releaser
-
-credentials:
-  GITLAB_TOKEN: gitlab

--- a/.alcove/workflows/release-pipeline.yml
+++ b/.alcove/workflows/release-pipeline.yml
@@ -49,10 +49,28 @@ workflow:
       repo: bmbouter/alcove
       pr: "{{steps.changelog-pr.outputs.pr_number}}"
 
-  - id: release-deploy
+  - id: tag-release
     type: agent
-    agent: Release and Deploy
+    agent: Tag Release
     depends: "changelog-merge.Succeeded"
     inputs:
       version: "{{steps.changelog.outputs.version}}"
+    outputs: [version]
+
+  - id: await-release
+    type: bridge
+    action: await-release
+    depends: "tag-release.Succeeded"
+    inputs:
+      repo: bmbouter/alcove
+      tag: "{{steps.changelog.outputs.version}}"
+      timeout: 900
+
+  - id: deploy-staging
+    type: agent
+    agent: Deploy to Staging
+    depends: "await-release.Succeeded"
+    inputs:
+      version: "{{steps.changelog.outputs.version}}"
+      release_url: "{{steps.await-release.outputs.release_url}}"
     outputs: [deployed, mr_merged]

--- a/internal/bridge/bridge_actions.go
+++ b/internal/bridge/bridge_actions.go
@@ -49,9 +49,10 @@ func RegisterBridgeActions() map[string]BridgeActionHandler {
 		"comment":              bridgeActionUnifiedComment,
 
 		// GitHub-specific aliases.
-		"create-pr": bridgeActionCreatePR,
-		"await-ci":  bridgeActionAwaitCI,
-		"merge-pr":  bridgeActionMergePR,
+		"create-pr":      bridgeActionCreatePR,
+		"await-ci":       bridgeActionAwaitCI,
+		"merge-pr":       bridgeActionMergePR,
+		"await-release":  bridgeActionAwaitRelease,
 
 		// GitLab-specific aliases.
 		"create-mr":      bridgeActionCreateMR,
@@ -173,6 +174,18 @@ func ListBridgeActionSchemas() []BridgeActionSchema {
 			},
 			Outputs: map[string]string{
 				"merge_sha": "string - The SHA of the merge commit",
+			},
+		},
+		{
+			Name:        "await-release",
+			Description: "Wait for a GitHub release to exist by tag",
+			Inputs: map[string]string{
+				"repo":    "string (required) - Repository in owner/repo format",
+				"tag":     "string (required) - Release tag (e.g. v0.35.5)",
+				"timeout": "int (optional) - Timeout in seconds (default 900)",
+			},
+			Outputs: map[string]string{
+				"release_url": "string - The HTML URL of the release",
 			},
 		},
 	}

--- a/internal/bridge/bridge_actions_github.go
+++ b/internal/bridge/bridge_actions_github.go
@@ -416,6 +416,93 @@ func bridgeActionMergePR(ctx context.Context, inputs map[string]interface{}, cre
 	}, nil
 }
 
+// bridgeActionAwaitRelease polls GitHub for a release to exist by tag.
+func bridgeActionAwaitRelease(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	repo := getStringInput(inputs, "repo")
+	tag := getStringInput(inputs, "tag")
+	timeout := getIntInput(inputs, "timeout")
+
+	if repo == "" || tag == "" {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  "missing required inputs: repo, tag",
+		}, nil
+	}
+
+	if timeout <= 0 {
+		timeout = 900 // 15 minutes default
+	}
+
+	token, apiHost, err := credStore.AcquireSCMTokenForOwner(ctx, "github", teamID)
+	if err != nil {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  fmt.Sprintf("failed to acquire GitHub token: %v", err),
+		}, nil
+	}
+
+	if apiHost == "" {
+		apiHost = "https://api.github.com"
+	}
+
+	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
+	pollInterval := 30 * time.Second
+
+	for time.Now().Before(deadline) {
+		// Check for context cancellation.
+		select {
+		case <-ctx.Done():
+			return &BridgeActionResult{
+				Status: "failed",
+				Error:  "context cancelled",
+			}, nil
+		default:
+		}
+
+		releaseURL := fmt.Sprintf("%s/repos/%s/releases/tags/%s", apiHost, repo, tag)
+		respBody, err := githubRequest(ctx, token, "GET", releaseURL, nil)
+		if err != nil {
+			// 404 means the release doesn't exist yet — keep polling.
+			if strings.Contains(err.Error(), "HTTP 404") {
+				log.Printf("bridge-action await-release: release %s not found yet for %s, polling...", tag, repo)
+				time.Sleep(pollInterval)
+				continue
+			}
+			// Other errors — log and retry.
+			log.Printf("bridge-action await-release: error checking release %s for %s: %v", tag, repo, err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		// Release exists — parse the response.
+		var release struct {
+			HTMLURL string `json:"html_url"`
+			TagName string `json:"tag_name"`
+		}
+		if err := json.Unmarshal(respBody, &release); err != nil {
+			return &BridgeActionResult{
+				Status: "failed",
+				Error:  fmt.Sprintf("failed to parse release response: %v", err),
+			}, nil
+		}
+
+		log.Printf("bridge-action await-release: release %s found for %s at %s", tag, repo, release.HTMLURL)
+		return &BridgeActionResult{
+			Status: "succeeded",
+			Outputs: map[string]interface{}{
+				"release_url": release.HTMLURL,
+			},
+		}, nil
+	}
+
+	// Timeout.
+	log.Printf("bridge-action await-release: timed out waiting for release %s on %s", tag, repo)
+	return &BridgeActionResult{
+		Status: "failed",
+		Error:  fmt.Sprintf("timed out after %d seconds waiting for release %s", timeout, tag),
+	}, nil
+}
+
 // githubRequest performs an authenticated HTTP request to the GitHub API.
 func githubRequest(ctx context.Context, token, method, url string, body []byte) ([]byte, error) {
 	var reqBody io.Reader

--- a/internal/bridge/workflow.go
+++ b/internal/bridge/workflow.go
@@ -101,9 +101,10 @@ func ParseWorkflowDefinition(data []byte) (*WorkflowDefinition, error) {
 // validBridgeActions lists the allowed bridge action names.
 var validBridgeActions = map[string]bool{
 	// GitHub-specific aliases.
-	"create-pr": true,
-	"await-ci":  true,
-	"merge-pr":  true,
+	"create-pr":     true,
+	"await-ci":      true,
+	"merge-pr":      true,
+	"await-release": true,
 	// Unified actions.
 	"create-merge-request": true,
 	"await-checks":         true,

--- a/scripts/test-simplified-agents.sh
+++ b/scripts/test-simplified-agents.sh
@@ -104,7 +104,7 @@ DEFS_RESPONSE=$(curl -s "$BRIDGE_URL/api/v1/agent-definitions" \
 log "Test 1: Agent definition listing"
 
 # Verify the response includes expected agents
-EXPECTED_AGENTS=("Autonomous Developer" "PR Reviewer" "Release and Deploy" "Implementation Planner")
+EXPECTED_AGENTS=("Autonomous Developer" "PR Reviewer" "Tag Release" "Implementation Planner")
 
 for AGENT_NAME in "${EXPECTED_AGENTS[@]}"; do
   HAS_AGENT=$(echo "$DEFS_RESPONSE" | python3 -c "


### PR DESCRIPTION
## Problem
The Release and Deploy LLM agent exits after ~4 minutes instead of waiting 7+ minutes for GitHub Actions to finish building. Prompt engineering didn't fix it.

## Solution
New `await-release` bridge action that polls GitHub releases API every 30 seconds for up to 15 minutes. Deterministic code, not LLM — it won't give up.

Split the pipeline: tag-release (agent) → await-release (bridge) → deploy-staging (agent).

## Test plan
- [x] `go build ./...` and `go test ./...` pass
- [x] `await-release` registered in bridge actions and workflow validator
- [x] Pipeline chains correctly
- [x] Deploy agent has GitLab credentials and security profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)