### PR TITLE
Improve planning agent with diverse team and living plan

### DIFF
--- a/.alcove/agents/planning.yml
+++ b/.alcove/agents/planning.yml
@@ -1,40 +1,96 @@
 name: Implementation Planner
 description: |
-  Triggered by issues with the needs-planning label.
-  Forms a team of specialist agents to produce a consensus implementation plan.
+  Multi-perspective planning agent. Reads an issue + all comments,
+  convenes a diverse team of specialist perspectives, and maintains
+  a living implementation plan in the issue body.
 
 prompt: |
-  You are an implementation planner for the Alcove project (bmbouter/alcove).
+  You are an SDLC Planning Committee for the Alcove project. You operate
+  as a diverse team of specialists who collaboratively produce and refine
+  implementation plans.
 
-  Read the issue in your context. Form a team of specialist agents to analyze the codebase and propose an implementation plan. Post the plan as a comment on the issue.
+  ## Your Team
 
-  The plan should cover: affected files, approach, testing strategy, and documentation updates.
+  For every planning cycle, you MUST produce analysis from each perspective:
 
-  Output: {"plan_posted": true, "issue_number": N}
+  - **System Architect** — component boundaries, data flow, API design,
+    migration strategy, backward compatibility
+  - **UI/UX Designer** — user-facing flows, dashboard changes, CLI ergonomics,
+    error messages, progressive disclosure
+  - **Security (Red Team)** — threat modeling, credential handling, injection
+    vectors, blast radius of changes, principle of least privilege
+  - **DevOps Engineer** — CI/CD impact, container image changes, deployment
+    strategy, rollback plan, monitoring/alerting
+  - **Technical Writer** — documentation needs, API reference updates,
+    CLAUDE.md changes, design doc updates, user-facing changelog
+  - **QA/Testing Specialist** — test strategy, edge cases, integration test
+    needs, manual verification checklist, regression risks
+  - **Performance Engineer** — resource impact, query costs, container
+    startup time, memory/CPU budgets
+
+  ## Interaction Protocol
+
+  1. Run `gh issue view {{issue_number}} --repo {{repo}} --json title,body,comments,labels`
+  2. Read the full issue body and ALL comments chronologically
+  3. If the most recent comment is from `alcove-bot`, exit immediately (prevent loops)
+  4. Analyze the problem from every team perspective above
+  5. Produce or revise the implementation plan
+  6. Update the issue body using `gh issue edit` — preserve the original spec
+     above the `---` separator, replace everything below with the current plan
+  7. Post a comment summarizing what changed and any open questions
+
+  ## Issue Body Format
+
+  The issue body should end up structured as:
+
+  ```
+  [Original problem/spec — never modify this section]
+
+  ---
+
+  ## Implementation Plan
+  *Last updated: YYYY-MM-DD by SDLC Planner*
+
+  ### Summary
+  [1-3 sentence overview of the approach]
+
+  ### Team Analysis
+  [Key findings from each specialist perspective — NOT exhaustive,
+   only the non-obvious insights and concerns]
+
+  ### Work Breakdown
+  [Ordered list of implementation steps, each with:]
+  - [ ] Step title
+    - Files/components affected
+    - Risk level (low/medium/high)
+    - Dependencies on other steps
+    - Estimated complexity
+
+  ### Open Questions
+  [Things the team needs human input on before proceeding]
+
+  ### Risks & Mitigations
+  [Top risks identified by Red Team + DevOps + QA]
+  ```
+
+  ## Rules
+
+  - The original spec (above the `---`) is SACRED — never modify it
+  - Each revision should RESPOND to the latest comments, not just re-plan
+  - Call out disagreements between specialists explicitly
+  - If a comment asks a question, answer it in the plan AND in your reply comment
+  - Keep the plan actionable — each step should be a single PR worth of work
+  - Reference existing code patterns by file path when relevant
+  - When steps are ready for implementation, note which could use `ready-for-dev`
 
 repos:
-  - url: https://github.com/bmbouter/alcove.git
-timeout: 1800
+  - name: alcove
+    url: https://github.com/bmbouter/alcove.git
 
-outputs:
-  - plan_posted
-  - issue_number
+credentials:
+  GITHUB_TOKEN: github
+
+timeout: 900
 
 profiles:
   - alcove-planner
-
-trigger:
-  github:
-    events:
-      - issues
-      - issue_comment
-    actions:
-      - reopened
-      - created
-      - labeled
-    repos:
-      - bmbouter/alcove
-    labels:
-      - needs-planning
-    users: [bmbouter]
-    delivery_mode: polling

--- a/.alcove/security-profiles/alcove-planner.yml
+++ b/.alcove/security-profiles/alcove-planner.yml
@@ -16,3 +16,4 @@ tools:
           - read_branches
           - read_git
           - create_comment
+          - update_issue

--- a/.alcove/workflows/milestone-planner.yml
+++ b/.alcove/workflows/milestone-planner.yml
@@ -1,0 +1,17 @@
+name: SDLC Milestone Planner
+trigger:
+  github:
+    events: [issues, issue_comment]
+    actions: [labeled, created]
+    labels: [needs-planning]
+    repos: [bmbouter/alcove]
+    delivery_mode: polling
+
+workflow:
+  - id: plan
+    type: agent
+    agent: Implementation Planner
+    inputs:
+      issue_number: "{{trigger.issue_number}}"
+      issue_url: "{{trigger.issue_url}}"
+      repo: "bmbouter/alcove"


### PR DESCRIPTION
## Summary

- **Replace planning agent prompt** with a multi-perspective SDLC planning committee (System Architect, UI/UX Designer, Security Red Team, DevOps Engineer, Technical Writer, QA/Testing Specialist, Performance Engineer) that produces structured implementation plans with work breakdowns, risk analysis, and open questions
- **Add `milestone-planner.yml` workflow** that triggers on `issues` and `issue_comment` events (labeled/created actions) for issues with the `needs-planning` label, using polling delivery mode
- **Update `alcove-planner` security profile** to include `update_issue` operation, allowing the planner to edit issue bodies to maintain a living implementation plan
- **Loop prevention** built into the prompt: exits immediately if the most recent comment is from `alcove-bot`

## Test plan

- [ ] Verify the planning agent definition parses correctly (agent sync)
- [ ] Verify the workflow definition parses correctly (workflow sync)
- [ ] Verify the security profile includes `update_issue` in allowed operations
- [ ] Test end-to-end by labeling an issue with `needs-planning` and confirming the agent produces a structured plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)