### PR TITLE
Fix planner: remove credentials conflicting with Gate proxy

### DIFF
--- a/.alcove/agents/planning.yml
+++ b/.alcove/agents/planning.yml
@@ -87,9 +87,6 @@ repos:
   - name: alcove
     url: https://github.com/bmbouter/alcove.git
 
-credentials:
-  GITHUB_TOKEN: github
-
 timeout: 900
 
 profiles:


### PR DESCRIPTION
Real GITHUB_TOKEN conflicted with Gate's dummy token model. Profile already provides access.