### PR TITLE
Restore trigger on Implementation Planner

### DIFF
--- a/.alcove/agents/planning.yml
+++ b/.alcove/agents/planning.yml
@@ -91,3 +91,17 @@ timeout: 900
 
 profiles:
   - alcove-planner
+
+trigger:
+  github:
+    events:
+      - issues
+      - issue_comment
+    actions:
+      - labeled
+      - created
+    repos:
+      - bmbouter/alcove
+    labels:
+      - needs-planning
+    delivery_mode: polling


### PR DESCRIPTION
Trigger was lost during rewrite. Restores needs-planning label trigger.