### PR TITLE
Add env snapshot capture for session debugging

### DIFF
--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -186,6 +186,19 @@ func main() {
 	// --- Install lola modules (must run after cloneRepo so cwd is correct) ---
 	installLolaModules()
 
+	// --- Capture and send redacted environment snapshot ---
+	// Reuse the debug-env binary (baked into the Skiff image) for env
+	// classification, redaction, and formatting — one source of truth.
+	if envOut, err := exec.Command("/usr/local/bin/debug-env").Output(); err == nil {
+		if err := lc.UpdateEnvSnapshot(sessionID, string(envOut)); err != nil {
+			log.Printf("warning: failed to send env snapshot to Ledger: %v", err)
+		} else {
+			log.Printf("env snapshot captured (%d bytes)", len(envOut))
+		}
+	} else {
+		log.Printf("warning: debug-env not available for env snapshot: %v", err)
+	}
+
 	// --- Build context with hard timeout ---
 	ctx, cancel := context.WithTimeout(context.Background(), task.Timeout)
 	defer cancel()
@@ -1132,6 +1145,7 @@ func injectClaudeMD(repos []internal.RepoSpec, prompt string) string {
 	// Prepend CLAUDE.md content to the prompt
 	return strings.Join(claudeMDs, "\n\n---\n\n") + "\n\n---\n\n" + prompt
 }
+
 
 // requireEnv returns the value of an environment variable or exits fatally.
 func requireEnv(key string) string {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -478,7 +478,8 @@ func MeHandler(authBackend string) http.HandlerFunc {
 func isSessionIngestionPath(path string) bool {
 	return strings.HasSuffix(path, "/transcript") ||
 		strings.HasSuffix(path, "/status") ||
-		strings.HasSuffix(path, "/proxy-log")
+		strings.HasSuffix(path, "/proxy-log") ||
+		strings.HasSuffix(path, "/env-snapshot")
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -296,6 +296,13 @@ func (a *API) handleSessionByID(w http.ResponseWriter, r *http.Request) {
 				respondError(w, http.StatusMethodNotAllowed, "method not allowed")
 			}
 			return
+		case "env-snapshot":
+			if r.Method == http.MethodPost {
+				a.handleUpdateEnvSnapshot(w, r, sessionID)
+			} else {
+				respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+			}
+			return
 		}
 	}
 
@@ -326,20 +333,22 @@ func (a *API) handleGetSession(w http.ResponseWriter, r *http.Request, sessionID
 		return
 	}
 
-	// Also fetch transcript, proxy log, and runtime config.
+	// Also fetch transcript, proxy log, runtime config, and env snapshot.
 	type sessionDetail struct {
 		internal.Session
 		Transcript    json.RawMessage `json:"transcript,omitempty"`
 		ProxyLog      json.RawMessage `json:"proxy_log,omitempty"`
 		RuntimeConfig json.RawMessage `json:"runtime_config,omitempty"`
+		EnvSnapshot   *string         `json:"env_snapshot,omitempty"`
 	}
 
 	detail := sessionDetail{Session: *session}
 
 	var transcript, proxyLog, runtimeConfig []byte
+	var envSnapshot *string
 	_ = a.db.QueryRow(r.Context(),
-		`SELECT transcript, proxy_log, runtime_config FROM sessions WHERE id = $1`, sessionID,
-	).Scan(&transcript, &proxyLog, &runtimeConfig)
+		`SELECT transcript, proxy_log, runtime_config, env_snapshot FROM sessions WHERE id = $1`, sessionID,
+	).Scan(&transcript, &proxyLog, &runtimeConfig, &envSnapshot)
 
 	if transcript != nil {
 		detail.Transcript = transcript
@@ -349,6 +358,9 @@ func (a *API) handleGetSession(w http.ResponseWriter, r *http.Request, sessionID
 	}
 	if runtimeConfig != nil {
 		detail.RuntimeConfig = runtimeConfig
+	}
+	if envSnapshot != nil {
+		detail.EnvSnapshot = envSnapshot
 	}
 
 	respondJSON(w, http.StatusOK, detail)
@@ -725,6 +737,45 @@ func (a *API) handleUpdateStatus(w http.ResponseWriter, r *http.Request, session
 	}
 	if result.RowsAffected() == 0 {
 		respondError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]bool{"updated": true})
+}
+
+func (a *API) handleUpdateEnvSnapshot(w http.ResponseWriter, r *http.Request, sessionID string) {
+	// Validate session token for ingestion auth.
+	token := r.Header.Get("Authorization")
+	if strings.HasPrefix(token, "Bearer ") {
+		token = strings.TrimPrefix(token, "Bearer ")
+	}
+	if token != "" {
+		var storedToken *string
+		_ = a.db.QueryRow(r.Context(), `SELECT session_token FROM sessions WHERE id = $1`, sessionID).Scan(&storedToken)
+		if storedToken == nil || token != *storedToken {
+			respondError(w, http.StatusForbidden, "invalid session token")
+			return
+		}
+	}
+
+	var req struct {
+		EnvSnapshot string `json:"env_snapshot"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if req.EnvSnapshot == "" {
+		respondError(w, http.StatusBadRequest, "env_snapshot is required")
+		return
+	}
+
+	_, err := a.db.Exec(r.Context(),
+		`UPDATE sessions SET env_snapshot = $1 WHERE id = $2`,
+		req.EnvSnapshot, sessionID)
+	if err != nil {
+		log.Printf("error: updating env_snapshot for session %s: %v", sessionID, err)
+		respondError(w, http.StatusInternalServerError, "failed to update env snapshot")
 		return
 	}
 

--- a/internal/bridge/migrations/032_env_snapshot.sql
+++ b/internal/bridge/migrations/032_env_snapshot.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS env_snapshot TEXT;

--- a/internal/ledger/client.go
+++ b/internal/ledger/client.go
@@ -60,6 +60,15 @@ func (c *Client) AppendTranscript(sessionID string, events []json.RawMessage) er
 	return c.post(path, payload)
 }
 
+// UpdateEnvSnapshot stores the redacted environment variable snapshot for a session.
+func (c *Client) UpdateEnvSnapshot(sessionID string, envSnapshot string) error {
+	path := fmt.Sprintf("/api/v1/sessions/%s/env-snapshot", sessionID)
+	payload := struct {
+		EnvSnapshot string `json:"env_snapshot"`
+	}{EnvSnapshot: envSnapshot}
+	return c.post(path, payload)
+}
+
 // UpdateSession updates the final status of a session (status, exit code, artifacts).
 // Only the status, exit_code, and artifacts fields are mutable; all other fields
 // are immutable after creation.

--- a/web/index.html
+++ b/web/index.html
@@ -712,6 +712,7 @@
                     <button class="detail-tab active" data-detail-tab="transcript" role="tab" aria-selected="true">Transcript</button>
                     <button class="detail-tab" data-detail-tab="proxy-log" role="tab" aria-selected="false">Proxy Log</button>
                     <button class="detail-tab" data-detail-tab="runtime-config" role="tab" aria-selected="false">Runtime Config</button>
+                    <button class="detail-tab" data-detail-tab="environment" role="tab" aria-selected="false">Environment</button>
                 </div>
                 <div id="detail-transcript" class="detail-panel">
                     <div id="transcript-content" class="transcript-content"></div>
@@ -755,6 +756,9 @@
                 </div>
                 <div id="detail-runtime-config" class="detail-panel" hidden>
                     <div id="runtime-config-content"></div>
+                </div>
+                <div id="detail-environment" class="detail-panel" hidden>
+                    <div id="env-snapshot-content"></div>
                 </div>
             </div>
         </main>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2334,6 +2334,13 @@
                 $('#runtime-config-content').innerHTML = '<p class="form-help" style="text-align:center;padding:24px;">Runtime configuration not available for this session.</p>';
             }
 
+            // Render environment tab
+            if (session.env_snapshot) {
+                renderEnvSnapshot(session.env_snapshot);
+            } else {
+                $('#env-snapshot-content').innerHTML = '<p class="form-help" style="text-align:center;padding:24px;">Environment snapshot not available for this session.</p>';
+            }
+
             // Auto-refresh while running
             if (session.status === 'running') {
                 stopRefresh();
@@ -2596,6 +2603,42 @@
         el.innerHTML = html;
     }
 
+    function renderEnvSnapshot(snapshot) {
+        var el = $('#env-snapshot-content');
+        if (!snapshot) {
+            el.innerHTML = '<p class="form-help" style="text-align:center;padding:24px;">No environment data.</p>';
+            return;
+        }
+
+        var lines = snapshot.split('\n');
+        var html = '<div style="padding:16px;">';
+        html += '<div style="margin-bottom:12px;color:var(--text-secondary);font-size:0.875rem;">' + lines.length + ' environment variable' + (lines.length !== 1 ? 's' : '') + ' captured at session startup. Sensitive values are redacted.</div>';
+        html += '<pre style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:16px;overflow-x:auto;font-size:0.8125rem;line-height:1.6;margin:0;white-space:pre-wrap;word-break:break-all;">';
+
+        lines.forEach(function(line) {
+            var eqIdx = line.indexOf('=');
+            if (eqIdx < 0) {
+                html += escapeHtml(line) + '\n';
+                return;
+            }
+            var key = line.substring(0, eqIdx);
+            var value = line.substring(eqIdx + 1);
+
+            html += '<span style="color:var(--accent);">' + escapeHtml(key) + '</span>=';
+            if (value === '[REDACTED]') {
+                html += '<span style="color:#e74c3c;font-style:italic;">[REDACTED]</span>';
+            } else if (value === '[DUMMY]') {
+                html += '<span style="color:#f1c40f;font-style:italic;">[DUMMY]</span>';
+            } else {
+                html += escapeHtml(value);
+            }
+            html += '\n';
+        });
+
+        html += '</pre></div>';
+        el.innerHTML = html;
+    }
+
     // Detail tabs
     $$('.detail-tab').forEach((tab) => {
         tab.addEventListener('click', () => {
@@ -2610,6 +2653,7 @@
             hide($('#detail-transcript'));
             hide($('#detail-proxy-log'));
             hide($('#detail-runtime-config'));
+            hide($('#detail-environment'));
             if (target === 'transcript') {
                 show($('#detail-transcript'));
             } else if (target === 'proxy-log') {
@@ -2621,6 +2665,8 @@
                 }
             } else if (target === 'runtime-config') {
                 show($('#detail-runtime-config'));
+            } else if (target === 'environment') {
+                show($('#detail-environment'));
             }
         });
     });


### PR DESCRIPTION
## Summary
Every session now captures a redacted environment variable snapshot at startup. Reuses the `debug-env` binary (already baked into Skiff) for env classification, redaction, and formatting — single source of truth.

## Changes
- skiff-init runs `/usr/local/bin/debug-env` at startup, sends output to Ledger
- New `env_snapshot TEXT` column on sessions table (migration 032)
- New `POST /api/v1/sessions/{id}/env-snapshot` ingestion endpoint (auth bypass for session token, same as transcript/status)
- Session detail API includes `env_snapshot` field
- New "Environment" tab in session detail UI
- Color-coded display: `[REDACTED]` in red, `[DUMMY]` in yellow

## Test evidence
Verified in local dev environment: dispatched session, env snapshot captured (2285 chars), visible in API response with all env vars properly categorized and redacted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)