### PR TITLE
Support agent_definition field in POST /api/v1/sessions

### DIFF
--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -188,14 +188,12 @@ func (a *API) handleSessions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		var req TaskRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
-			return
+		var body struct {
+			TaskRequest
+			AgentDefinition string `json:"agent_definition,omitempty"`
 		}
-
-		if req.Prompt == "" {
-			respondError(w, http.StatusBadRequest, "prompt is required")
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 			return
 		}
 
@@ -203,10 +201,34 @@ func (a *API) handleSessions(w http.ResponseWriter, r *http.Request) {
 		if submitter == "" {
 			submitter = "anonymous"
 		}
+		teamID := getActiveTeamID(r)
+
+		var req TaskRequest
+		if body.AgentDefinition != "" {
+			def, err := a.defStore.GetAgentDefinition(r.Context(), body.AgentDefinition, teamID)
+			if err != nil {
+				respondError(w, http.StatusNotFound, "agent definition not found: "+body.AgentDefinition)
+				return
+			}
+			if def.SyncError != "" {
+				respondError(w, http.StatusBadRequest, "agent definition has sync error: "+def.SyncError)
+				return
+			}
+			req = def.ToTaskRequest()
+			req.TaskName = def.Name
+			if body.Prompt != "" {
+				req.Prompt = body.Prompt
+			}
+		} else {
+			req = body.TaskRequest
+			if req.Prompt == "" && req.Executable == nil {
+				respondError(w, http.StatusBadRequest, "prompt or agent_definition is required")
+				return
+			}
+		}
 
 		req.TriggerType = "manual"
 
-		teamID := getActiveTeamID(r)
 		session, err := a.dispatcher.DispatchTask(r.Context(), req, submitter, teamID)
 		if err != nil {
 			log.Printf("error: dispatch failed: %v", err)


### PR DESCRIPTION
## Summary
- `POST /api/v1/sessions` now accepts `agent_definition` (name or ID) to look up and dispatch an agent definition with all its config (executable, credentials, profiles, etc.)
- Fixes a bug where executable agents dispatched by name via this endpoint silently ran as Claude Code instead of the binary
- Optional `prompt` field overrides the definition's prompt
- Backwards compatible: prompt-only requests still work as before

## Root cause
`TaskRequest` struct had no `agent_definition` field — Go's JSON decoder silently ignored it. The lookup logic only existed at `POST /api/v1/agent-definitions/{id}/run`.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Local e2e: `agent_definition` by name dispatches executable agent (201, correct prompt)
- [x] Local e2e: `agent_definition` with prompt override works
- [x] Local e2e: nonexistent `agent_definition` returns 404
- [x] Local e2e: empty request returns 400 "prompt or agent_definition is required"
- [x] Local e2e: prompt-only request still works (backwards compat)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)