### PR TITLE
MITM TLS re-encrypt proxy for Gate service domains

### DIFF
--- a/.alcove/agents/planning.yml
+++ b/.alcove/agents/planning.yml
@@ -88,6 +88,7 @@ repos:
     url: https://github.com/bmbouter/alcove.git
 
 timeout: 900
+enforcement_mode: monitor
 
 profiles:
   - alcove-planner

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Bridge → Hail (NATS) → Skiff Pod [skiff container + gate sidecar] → Gate �
 
 - Skiff pods are ephemeral: one session, one container, then destroyed
 - Gate is a sidecar (shares network namespace with Skiff)
-- Gate proxies ALL external traffic including LLM API calls (Skiff has no real credentials)
+- Gate proxies ALL external traffic: MITM TLS interception for service domains (GitHub, GitLab, Jira) and `/v1/` endpoint for LLM API calls (Skiff has no real credentials)
 - Optional dev container runs alongside Skiff with a shared `/workspace` volume, enabling agents to build/test code in project-specific environments; the shim binary is baked into the dev container image (built with `make build-dev`); a simple shell entrypoint starts PostgreSQL, NATS, and the shim without requiring a process supervisor
 - On OpenShift, a static `alcove-allow-internal` NetworkPolicy restricts egress (per-task NetworkPolicy is disabled due to OVN-Kubernetes DNS resolution issues); dual-network isolation (`--internal` flag) on podman
 - k3s is supported for local Kubernetes development (`make k3s-setup && make k3s-up && make k3s-watch`); Bridge runs on the host, NATS+PostgreSQL run as k8s pods with port-forwards, Skiff Jobs are dispatched into the same k3s cluster
@@ -40,11 +40,11 @@ Read these for full context:
 
 1. `docs/design/implementation-status.md` — **START HERE** — current state, what works, what's next
 2. `docs/design/architecture.md` — component design, deployment diagrams, network isolation, roadmap
-3. `docs/design/architecture-decisions.md` — 23 resolved decisions, CLI design, config format, repo layout
+3. `docs/design/architecture-decisions.md` — 24 resolved decisions, CLI design, config format, repo layout
 4. `docs/design/problem-statement.md` — why ephemeral agents
 5. `docs/design/credential-management.md` — credential storage, encryption, OAuth2 token flow
 6. `docs/design/auth-backends.md` — auth backend design (memory, postgres, rh-identity)
-7. `docs/design/gate-scm-authorization.md` — SCM proxy endpoints, operation taxonomy, security model
+7. `docs/design/gate-scm-authorization.md` — SCM MITM proxy, operation taxonomy, security model
 
 ## Quick Commands
 
@@ -95,7 +95,7 @@ make k3s-status               # Show pods, port-forwards, and jobs
 
 - **Teams are the ownership unit** — every resource belongs to a team; every user belongs to one or more teams; personal team auto-created on signup; `X-Alcove-Team` header scopes all API requests
 - **Gate is a sidecar** per Skiff pod (not shared service) — credential isolation
-- **No MITM TLS** — protocol-level interception (HTTP_PROXY, git credential helpers)
+- **MITM TLS for service domains** — ephemeral CA per session, Gate terminates CONNECT tunnels to service domains (GitHub, GitLab, Jira), inspects requests, injects credentials, and re-encrypts to upstream; tools use standard HTTP_PROXY; CA cert injected into Skiff trust store
 - **LLM keys never enter Skiff** — Gate proxies LLM API calls, injects keys; Gate also translates Anthropic API format to Vertex AI format when using Vertex AI (`GATE_VERTEX_PROJECT`, `GATE_VERTEX_REGION`)
 - **Fresh git clone per session** — `git clone --depth=1`, no persistent volumes
 - **NATS for messaging** — status updates and cancellation only (session config via env vars)
@@ -103,7 +103,7 @@ make k3s-status               # Show pods, port-forwards, and jobs
 - **Podman + k8s** dual runtime via `Runtime` interface in `internal/runtime/`
 - **Credential management via Bridge** — Bridge pre-fetches OAuth2 tokens, Gate receives only short-lived tokens
 - **Three auth backends** — `AUTH_BACKEND=memory` (default), `postgres`, or `rh-identity` (trusted `X-RH-Identity` header from Red Hat Turnpike, JIT user provisioning, no passwords)
-- **SCM and tool APIs proxied through Gate** — `/github/`, `/gitlab/`, and `/jira/` endpoints with dummy tokens, operation-level scope enforcement, real credentials never enter Skiff
+- **SCM and tool APIs proxied through Gate** — MITM TLS interception of CONNECT tunnels to service domains with operation-level scope enforcement, real credentials never enter Skiff
 - **Custom migration runner** — embedded SQL files, advisory locking, no external dependencies
 - **Per-item catalog granularity** — catalog has a two-level hierarchy: sources (git repos, unit of distribution) and items (plugins, agents, LSPs, MCPs); catalog items are seeded from embedded data at compile time (no runtime cloning of catalog source repos); teams toggle individual items, not whole sources; enabled agents are referenced in workflow steps as `source/item` slugs; workflow definitions are validated at sync time for unknown/disabled agent references
 - **Workflow graph with bounded cycles** — workflows support agent steps (Skiff pods) and bridge steps (deterministic `create-pr`/`await-ci`/`merge-pr` actions); `depends` expressions with `&&`/`||`; `max_iterations` prevents infinite loops in review/revision cycles

--- a/build/Containerfile.skiff-base
+++ b/build/Containerfile.skiff-base
@@ -52,6 +52,7 @@ RUN git config --system credential.helper '/usr/local/bin/alcove-credential-help
     git config --system url."https://gitlab.com/".insteadOf "ssh://git@gitlab.com/"
 
 RUN mkdir -p /workspace && chmod 777 /workspace
+RUN mkdir -p /etc/alcove-tls && chmod 777 /etc/alcove-tls
 
 USER 1001
 WORKDIR /home/skiff

--- a/cmd/gate/main.go
+++ b/cmd/gate/main.go
@@ -191,6 +191,34 @@ func loadConfig() (gate.Config, error) {
 		}
 	}
 
+	// MITM TLS interception: base64-encoded PEM CA cert and key.
+	// When set, Gate performs MITM re-encrypt proxy for service domains,
+	// enabling credential injection and scope enforcement on CONNECT tunnels.
+	var caCertPEM, caKeyPEM []byte
+	if certB64 := os.Getenv("GATE_CA_CERT_PEM"); certB64 != "" {
+		decoded, err := gate.DecodePEMFromBase64(certB64)
+		if err != nil {
+			return gate.Config{}, fmt.Errorf("invalid GATE_CA_CERT_PEM: %w", err)
+		}
+		caCertPEM = decoded
+	}
+	if keyB64 := os.Getenv("GATE_CA_KEY_PEM"); keyB64 != "" {
+		decoded, err := gate.DecodePEMFromBase64(keyB64)
+		if err != nil {
+			return gate.Config{}, fmt.Errorf("invalid GATE_CA_KEY_PEM: %w", err)
+		}
+		caKeyPEM = decoded
+	}
+
+	if len(caCertPEM) > 0 && len(caKeyPEM) > 0 {
+		log.Printf("gate: MITM mode enabled for service domains")
+	}
+
+	enforcementMode := os.Getenv("GATE_ENFORCEMENT_MODE") // "monitor" or "" (enforce)
+	if enforcementMode == "monitor" {
+		log.Printf("gate: enforcement mode = monitor (log-only, all requests allowed)")
+	}
+
 	return gate.Config{
 		SessionID:          sessionID,
 		Scope:              scope,
@@ -206,5 +234,8 @@ func loadConfig() (gate.Config, error) {
 		VertexProject:      vertexProject,
 		LedgerURL:          ledgerURL,
 		GitLabHost:         gitlabHost,
+		CACertPEM:          caCertPEM,
+		CAKeyPEM:           caKeyPEM,
+		EnforcementMode:    enforcementMode,
 	}, nil
 }

--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -133,6 +134,11 @@ func main() {
 		// No-op cancel channel
 		ch := make(chan struct{})
 		cancelCh = ch
+	}
+
+	// --- Set up CA trust for MITM proxy ---
+	if err := setupCATrust(); err != nil {
+		log.Printf("warning: CA trust setup failed: %v", err)
 	}
 
 	// --- Send running status ---
@@ -1146,6 +1152,65 @@ func injectClaudeMD(repos []internal.RepoSpec, prompt string) string {
 	return strings.Join(claudeMDs, "\n\n---\n\n") + "\n\n---\n\n" + prompt
 }
 
+
+// setupCATrust installs the ephemeral CA certificate into the trust store so that
+// tools like gh, curl, git, Python requests, and Node.js fetch all trust Gate's
+// MITM certificates. The CA cert PEM is passed via ALCOVE_CA_CERT_PEM (base64-encoded).
+func setupCATrust() error {
+	caCertB64 := os.Getenv("ALCOVE_CA_CERT_PEM")
+	if caCertB64 == "" {
+		return nil // No CA cert, MITM not enabled
+	}
+
+	caCertPEM, err := base64.StdEncoding.DecodeString(caCertB64)
+	if err != nil {
+		return fmt.Errorf("decoding ALCOVE_CA_CERT_PEM: %w", err)
+	}
+
+	// Create the TLS directory
+	tlsDir := "/etc/alcove-tls"
+	if err := os.MkdirAll(tlsDir, 0755); err != nil {
+		return fmt.Errorf("creating %s: %w", tlsDir, err)
+	}
+
+	// Write the CA cert
+	caPath := filepath.Join(tlsDir, "ca.pem")
+	if err := os.WriteFile(caPath, caCertPEM, 0644); err != nil {
+		return fmt.Errorf("writing CA cert: %w", err)
+	}
+
+	// Create a combined bundle: system CAs + ephemeral CA
+	// UBI9/RHEL system CA bundle location
+	systemBundle := "/etc/pki/tls/certs/ca-bundle.crt"
+	bundlePath := filepath.Join(tlsDir, "ca-bundle.pem")
+
+	systemCAs, err := os.ReadFile(systemBundle)
+	if err != nil {
+		// Fallback: try the Debian/Ubuntu location
+		systemCAs, err = os.ReadFile("/etc/ssl/certs/ca-certificates.crt")
+		if err != nil {
+			// If no system bundle found, just use the CA cert alone
+			systemCAs = nil
+		}
+	}
+
+	bundle := append(systemCAs, '\n')
+	bundle = append(bundle, caCertPEM...)
+	if err := os.WriteFile(bundlePath, bundle, 0644); err != nil {
+		return fmt.Errorf("writing CA bundle: %w", err)
+	}
+
+	// Set trust store env vars for all common tools
+	os.Setenv("SSL_CERT_FILE", bundlePath)
+	os.Setenv("NODE_EXTRA_CA_CERTS", caPath)
+	os.Setenv("CURL_CA_BUNDLE", bundlePath)
+	os.Setenv("GIT_SSL_CAINFO", bundlePath)
+	os.Setenv("REQUESTS_CA_BUNDLE", bundlePath)
+
+	log.Printf("installed ephemeral CA trust (%d bytes) at %s", len(caCertPEM), tlsDir)
+
+	return nil
+}
 
 // requireEnv returns the value of an environment variable or exits fatally.
 func requireEnv(key string) string {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,7 +198,10 @@ they are documented here for debugging and for custom deployment scenarios.
 | `GATE_LEDGER_URL` | string | _(unset)_ | URL where Gate sends proxy audit logs. |
 | `GATE_VERTEX_REGION` | string | `us-east5` | Vertex AI region for API URL construction. |
 | `GATE_VERTEX_PROJECT` | string | _(unset)_ | Vertex AI project ID for API URL construction. |
-| `GATE_GITLAB_HOST` | string | `gitlab.com` | GitLab hostname for self-hosted GitLab instances. Used to route `/gitlab/` proxy requests to the correct host. |
+| `GATE_GITLAB_HOST` | string | `gitlab.com` | GitLab hostname for self-hosted GitLab instances. |
+| `GATE_CA_CERT_PEM` | string | _(injected)_ | Base64-encoded ephemeral CA certificate PEM for MITM TLS. Gate signs leaf certs with this CA to intercept CONNECT tunnels to service domains. |
+| `GATE_CA_KEY_PEM` | string | _(injected)_ | Base64-encoded ephemeral CA private key PEM for MITM TLS leaf cert signing. Exists only in Gate's memory. |
+| `GATE_ENFORCEMENT_MODE` | string | _(unset)_ | Enforcement mode: empty or `enforce` (default) denies unauthorized requests; `monitor` logs all requests but allows them regardless of scope. Set via `enforcement_mode` in agent definitions. |
 
 Gate listens on port **8443** inside the pod.
 
@@ -236,26 +239,24 @@ Skiff is the ephemeral worker container (`cmd/skiff-init`). These variables are
 | `DEV_CONTAINER_HOST` | string | _(injected)_ | Hostname and port of the dev container's shim (e.g., `dev-<taskID>:9090`). Set only when `dev_container` is configured. |
 
 The following SCM-related environment variables are injected by Bridge when the
-task's scope includes a `github` or `gitlab` service. They configure the `gh`
-and `glab` CLIs and the git credential helper inside the Skiff container.
+task's scope includes a `github` or `gitlab` service. They configure dummy
+tokens and the git credential helper inside the Skiff container. Tools like
+`gh` and `glab` connect to their standard upstream URLs; Gate intercepts the
+connections via MITM TLS through HTTP_PROXY.
 
 | Variable | Type | Default | Description |
 |---|---|---|---|
-| `GITHUB_TOKEN` | string | _(injected)_ | Dummy GitHub token. Routed through Gate which swaps it for the real PAT. |
+| `GITHUB_TOKEN` | string | _(injected)_ | Dummy GitHub token. Gate intercepts CONNECT tunnels to GitHub and swaps it for the real PAT. |
 | `GH_TOKEN` | string | _(injected)_ | Alias for `GITHUB_TOKEN` used by the `gh` CLI. |
 | `GITHUB_PERSONAL_ACCESS_TOKEN` | string | _(injected)_ | Alias recognized by some GitHub tooling. |
-| `GITHUB_API_URL` | string | _(injected)_ | Points to Gate's `/github/` proxy endpoint (e.g., `http://gate-<taskID>:8443/github`). |
-| `GH_HOST` | string | _(injected)_ | GitHub host for `gh` CLI (e.g., `github.com`). |
 | `GH_PROMPT_DISABLED` | string | `1` | Disables interactive prompts in `gh` CLI. |
 | `GH_NO_UPDATE_NOTIFIER` | string | `1` | Disables `gh` CLI update notifications. |
-| `GITLAB_TOKEN` | string | _(injected)_ | Dummy GitLab token. Routed through Gate which swaps it for the real PAT. |
+| `GITLAB_TOKEN` | string | _(injected)_ | Dummy GitLab token. Gate intercepts CONNECT tunnels to GitLab and swaps it for the real PAT. |
 | `GITLAB_PERSONAL_ACCESS_TOKEN` | string | _(injected)_ | Alias recognized by some GitLab tooling. |
-| `GITLAB_API_URL` | string | _(injected)_ | Points to Gate's `/gitlab/` proxy endpoint (e.g., `http://gate-<taskID>:8443/gitlab`). |
-| `GLAB_HOST` | string | _(injected)_ | GitLab host for `glab` CLI (e.g., `gitlab.com`). |
-| `JIRA_TOKEN` | string | _(injected)_ | Dummy JIRA token. Routed through Gate which swaps it for real credentials (Basic auth). |
-| `JIRA_API_URL` | string | _(injected)_ | Points to Gate's `/jira/` proxy endpoint (e.g., `http://gate-<taskID>:8443/jira`). |
+| `JIRA_TOKEN` | string | _(injected)_ | Dummy JIRA token. Gate intercepts CONNECT tunnels to Jira and swaps it for real credentials (Basic auth). |
 | `GATE_CREDENTIAL_URL` | string | _(injected)_ | Gate endpoint URL used by the git credential helper to acquire tokens. |
 | `GIT_SSH_COMMAND` | string | _(injected)_ | Set to disable SSH-based git operations (forces HTTPS through Gate). |
+| `ALCOVE_CA_CERT_PEM` | string | _(injected)_ | Base64-encoded ephemeral CA certificate PEM for MITM TLS. skiff-init writes this to a file and sets `SSL_CERT_FILE` and `NODE_EXTRA_CA_CERTS`. |
 
 Skiff also sets these git environment variables automatically (unless already
 present):
@@ -686,6 +687,7 @@ schedule: "0 2 * * *"
 | `plugins`   | PluginSpec[] | no   | Claude Code plugins to install (see [Plugins](#plugins)) |
 | `credentials` | map[string]string | no | Environment variable names to credential provider mappings (see [Credentials](#credentials)) |
 | `direct_outbound` | bool | no | Allow direct outbound connections bypassing Gate proxy (default `false`) |
+| `enforcement_mode` | string | no | Gate enforcement mode: `enforce` (default) denies unauthorized requests; `monitor` logs all requests but allows them regardless of scope, enabling iterative policy development |
 | `dev_container` | object | no | Dev container sidecar configuration (see [Dev Containers](#dev-containers)) |
 | `schedule`  | string   | no       | Cron expression for automatic execution |
 | `labels`    | string[] | no       | GitHub issue/PR labels for event filtering (see below) |

--- a/docs/design/architecture-decisions.md
+++ b/docs/design/architecture-decisions.md
@@ -24,9 +24,11 @@ and Integration architecture.
 and `gate` (sidecar proxy). They share a network namespace, so `HTTP_PROXY=localhost:8443`
 works without Service routing.
 
-### 2. HTTPS Interception: Protocol-Level (no MITM CA)
+### 2. HTTPS Interception: MITM TLS Re-encrypt for Service Domains
 
-**Decision**: Use protocol-level interception, not MITM TLS.
+**Decision**: Use MITM TLS re-encrypt proxy for known service domains (GitHub,
+GitLab, Jira). Gate terminates CONNECT tunnels, inspects plaintext HTTP requests,
+performs scope checking and credential injection, then re-encrypts to upstream.
 
 **Approach by tool type**:
 
@@ -34,17 +36,21 @@ works without Service routing.
 |------|-------------------|
 | Git (clone/push/fetch) | Git credential helper routed through Gate |
 | LLM API calls | Custom base URL → Gate localhost → real provider endpoint |
-| MCP servers (Phase 2) | Gate wraps MCP — Claude Code talks to proxy stubs |
-| `gh` / `glab` CLI | HTTP_PROXY + CONNECT tunneling (domain-level) |
-| `curl` / arbitrary HTTP | HTTP_PROXY + CONNECT tunneling (domain-level) |
+| `gh` / `glab` CLI | HTTP_PROXY → CONNECT tunnel → MITM TLS interception by Gate |
+| `curl` / arbitrary HTTP | HTTP_PROXY → CONNECT tunnel → MITM TLS for service domains, passthrough for others |
+| JIRA tools | HTTP_PROXY → CONNECT tunnel → MITM TLS interception by Gate |
 
-**Phase 1 simplification**: Skip MCP entirely. Configure Claude Code with CLI-only
-tools (`Bash, Edit, Read, Write, Grep, Glob`). All external access happens through
-CLI tools routed via HTTP_PROXY. MCP gateway added in Phase 2.
+An ephemeral CA is generated per session by Bridge. The CA cert is injected into
+Skiff's trust store (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`). Gate presents
+leaf certs signed by this CA for intercepted domains. The CA private key exists
+only in Gate's memory (passed via `GATE_CA_KEY_PEM` env var from Bridge).
 
-**Rationale** (Security): MITM CA is the weakest option — the CA private key in
-Gate becomes a high-value target, breaks cert pinning, is detectable by the agent,
-and requires per-runtime trust store configuration (Python, Node, Java all differ).
+**Rationale**: The `gh` CLI sends GraphQL requests via CONNECT tunnels to
+`api.github.com:443`. The previous protocol-level-only approach could not
+inject tokens into encrypted tunnels. MITM is general-purpose -- any tool using
+HTTP_PROXY works without per-tool env var configuration (no `GH_HOST`,
+`GITHUB_API_URL`, etc.). Ephemeral CA with 24-hour validity and 1-hour leaf
+certs limits the blast radius.
 
 ### 3. LLM API Key Isolation: Gate Proxies LLM Calls
 
@@ -428,6 +434,52 @@ duplication and keeps agent definitions minimal.
 - `scripts/k3s-bridge-endpoint.sh` — headless Service Endpoints for host Bridge
 - `deploy/k3s/infra.yaml` — Namespace, Deployments, Services, PVC, NetworkPolicy
 - `Makefile` — k3s-setup, k3s-up, k3s-watch, k3s-down, k3s-reset, k3s-status targets
+
+
+### 24. MITM TLS Re-encrypt Proxy for Service Domains
+
+**Decision**: Gate intercepts CONNECT tunnels to known service domains (GitHub,
+GitLab, Jira) using MITM TLS. An ephemeral CA is generated per session by Bridge,
+the CA cert is injected into Skiff's trust store, and Gate presents leaf certs
+signed by this CA. Gate reads the plaintext HTTP request, performs scope checking
+and credential injection, then forwards over real TLS to the upstream. This
+replaces the previous boutique `/github/`, `/gitlab/`, `/jira/` path-prefix
+proxy endpoints.
+
+**Why**: The `gh` CLI sends GraphQL requests via CONNECT tunnels to
+`api.github.com:443`. The previous architecture blocked these because Gate
+couldn't inject tokens into encrypted tunnels. The MITM approach is
+general-purpose -- any tool using HTTP_PROXY works without per-tool
+configuration. Inspired by OpenShell's sandbox proxy architecture.
+
+**Trade-offs**:
+- More complex than prefix proxying, but eliminates per-service handlers
+- Requires trust store injection (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, etc.)
+- Ephemeral CA has 24-hour validity; leaf certs have 1-hour validity
+- CA private key exists only in Gate's memory (passed via env var from Bridge)
+
+**How it works**:
+1. Bridge generates an ephemeral CA key pair at session dispatch time
+2. Bridge passes `GATE_CA_CERT_PEM` and `GATE_CA_KEY_PEM` to Gate as env vars
+3. Bridge passes `ALCOVE_CA_CERT_PEM` to Skiff; skiff-init writes it to a file
+   and sets `SSL_CERT_FILE` and `NODE_EXTRA_CA_CERTS`
+4. When Skiff makes a CONNECT request to a service domain (e.g.,
+   `api.github.com:443`), Gate accepts the tunnel
+5. Gate generates a leaf cert for that domain signed by the session CA
+6. Gate performs a TLS handshake with Skiff using the leaf cert
+7. Gate reads the plaintext HTTP request, classifies the operation, checks scope
+8. If allowed, Gate injects real credentials and forwards to the upstream over
+   real TLS
+9. The response flows back through Gate to Skiff
+
+**Impact on Skiff environment**: `GITHUB_API_URL`, `GH_HOST`, `GITLAB_API_URL`,
+`JIRA_API_URL` env vars are no longer needed. Tools connect to their standard
+upstream URLs; Gate intercepts transparently via HTTP_PROXY.
+
+**Files**:
+- `internal/gate/proxy.go` -- MITM proxy handler, leaf cert generation
+- `internal/bridge/dispatcher.go` -- CA generation, env var injection
+- `cmd/skiff-init/main.go` -- trust store setup from `ALCOVE_CA_CERT_PEM`
 
 
 ## CLI Design

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -132,15 +132,15 @@ Gate sidecar. Gate provides:
   configured with a custom base URL pointing to the Gate sidecar (`ANTHROPIC_BASE_URL=http://localhost:8443`).
   Gate injects the real API key and forwards to the provider. This prevents
   prompt injection attacks from exfiltrating LLM credentials.
-- **SCM API proxying** — Gate exposes `/github/` and `/gitlab/` reverse-proxy
-  endpoints. `gh` and `glab` CLIs inside Skiff are configured via
-  `GITHUB_API_URL` and `GITLAB_API_URL` to point at these local endpoints.
-  Gate performs operation-level scope enforcement on every request, injects
-  real SCM credentials, and forwards to the upstream API.
-- **CLI and MCP coverage** — Gate intercepts both MCP tool calls and CLI-initiated
-  network requests (e.g., `gh pr create`, `git push`, `curl`). This is achieved
-  by running Gate as an HTTP/HTTPS proxy (via `HTTP_PROXY`/`HTTPS_PROXY` env vars
-  in Skiff pods) combined with MCP server wrapping.
+- **SCM API proxying** — Gate intercepts CONNECT tunnels to service domains
+  (GitHub, GitLab, Jira) via MITM TLS. An ephemeral CA per session signs leaf
+  certs for intercepted domains. Tools like `gh` and `glab` connect to their
+  standard upstream URLs through HTTP_PROXY; Gate terminates the TLS tunnel,
+  inspects the plaintext request, performs operation-level scope enforcement,
+  injects real SCM credentials, and re-encrypts to upstream.
+- **CLI coverage** — Gate intercepts CLI-initiated network requests (e.g.,
+  `gh pr create`, `git push`, `curl`) via HTTP_PROXY with MITM TLS interception
+  for service domains. Tools work natively without per-tool API URL configuration.
 - **Request logging** — every proxied request is logged with timestamp, operation
   type, target service, authorization decision (allow/deny), and response status.
   Logs are forwarded to the Ledger.
@@ -152,14 +152,14 @@ variables or config files gets only the opaque session token, which is:
 - Short-lived (expires when the session ends)
 - Revocable by Bridge at any time
 
-**HTTPS interception approach**: protocol-level, not MITM TLS.
+**HTTPS interception approach**: MITM TLS re-encrypt for service domains.
 
 | Tool | Interception Method |
 |------|-------------------|
 | Git (clone/push/fetch) | Git credential helper routed through Gate |
-| MCP servers (Phase 2) | Gate wraps MCP — Claude Code talks to proxy stubs |
-| `gh` / `glab` CLI | `GITHUB_API_URL` / `GITLAB_API_URL` pointing to Gate's `/github/` and `/gitlab/` HTTP endpoints (operation-level enforcement) |
-| `curl` / arbitrary HTTP | HTTP_PROXY + CONNECT tunneling (domain-level) |
+| `gh` / `glab` CLI | HTTP_PROXY → CONNECT tunnel → MITM TLS interception (operation-level enforcement) |
+| `curl` / arbitrary HTTP | HTTP_PROXY → CONNECT tunnel → MITM TLS for service domains, passthrough for others |
+| JIRA tools | HTTP_PROXY → CONNECT tunnel → MITM TLS interception |
 | LLM API calls | Custom base URL → Gate → real provider endpoint |
 
 ### Ledger — Session Storage

--- a/docs/design/gate-scm-authorization.md
+++ b/docs/design/gate-scm-authorization.md
@@ -9,6 +9,8 @@ Phase 6 (alias expansion).
 
 This document describes how Gate handles GitHub, GitLab, and JIRA operations with
 operation-level authorization, credential injection, and dummy-token isolation.
+Gate uses MITM TLS interception of CONNECT tunnels to service domains, replacing
+the previous `/github/`, `/gitlab/`, `/jira/` path-prefix proxy endpoints.
 
 ---
 
@@ -87,7 +89,7 @@ grouped into tiers to simplify common configurations.
 
 **JIRA/Atlassian operations** (matched against `*.atlassian.net` hosts):
 
-Gate proxies JIRA REST API requests via the `/jira/` endpoint. The scope uses
+Gate intercepts JIRA REST API requests via MITM TLS. The scope uses
 service name `"jira"` (also accepts `"atlassian"` for backward compatibility).
 The `repos` field specifies allowed JIRA project keys (e.g., `["PROJ"]` or
 `["*"]` for all). Project keys are extracted from issue keys in the URL path
@@ -151,100 +153,44 @@ the credential and sends it as `Authorization: Basic <encoded>`.
 
 ## 2. Gate Proxy Changes
 
-### 2.1 API proxy endpoints (new)
+### 2.1 MITM TLS re-encrypt proxy
 
-Gate adds two new reverse-proxy route prefixes to its mux. These handle GitHub
-and GitLab API calls when the Skiff container is configured to use Gate as the
-API base URL (see Section 4).
+Gate intercepts CONNECT tunnels to known service domains using MITM TLS. This
+replaces the previous `/github/`, `/gitlab/`, `/jira/` path-prefix reverse
+proxy endpoints. Tools like `gh`, `glab`, and `curl` connect to their standard
+upstream URLs via HTTP_PROXY; Gate transparently intercepts the encrypted tunnel.
 
-```
-/github/   -->  https://api.github.com/
-/gitlab/   -->  https://gitlab.com/    (or self-hosted, from GATE_GITLAB_HOST)
-/jira/     -->  https://<instance>.atlassian.net/
-```
+**How it works:**
 
-These work identically to the existing `/v1/` LLM proxy pattern:
+1. Skiff sets `HTTP_PROXY=http://gate-<taskID>:8443`.
+2. The `gh` CLI (or any HTTP client) sends a CONNECT request to
+   `api.github.com:443` through the proxy.
+3. Gate accepts the CONNECT tunnel and checks if the target host is a known
+   service domain.
+4. For known domains, Gate performs MITM TLS interception:
+   a. Generates a leaf certificate for the target domain, signed by the
+      session's ephemeral CA.
+   b. Performs a TLS handshake with the client using the leaf cert.
+   c. Reads the plaintext HTTP request from the client.
+   d. Calls `CheckAccess(method, url, scope)` to classify the operation.
+   e. If denied, returns 403 with the reason.
+   f. If allowed, injects real credentials and forwards to the upstream over
+      real TLS.
+5. For unknown domains, Gate either passes through (if allowed by scope) or
+   blocks the tunnel.
 
-1. Skiff sets `GITHUB_API_URL=http://gate-<taskID>:8443/github` (plain HTTP).
-2. The `gh` CLI, GitHub MCP server, and any HTTP client send requests to Gate
-   over plain HTTP.
-3. Gate receives the request, sees the `/github/` prefix, and:
-   a. Strips the prefix to get the real API path.
-   b. Calls `CheckAccess(method, path, scope)` to classify the operation.
-   c. If denied, returns 403 with the reason.
-   d. If allowed, injects real credentials and reverse-proxies to the real API
-      over HTTPS.
+**Ephemeral CA trust chain:**
 
-**File: `internal/gate/proxy.go`**
-
-New handler registrations in `Handler()`:
-
-```go
-mux.HandleFunc("/github/", func(w http.ResponseWriter, r *http.Request) {
-    p.handleSCMProxy(w, r, "github")
-})
-
-mux.HandleFunc("/gitlab/", func(w http.ResponseWriter, r *http.Request) {
-    p.handleSCMProxy(w, r, "gitlab")
-})
-```
-
-New method:
-
-```go
-func (p *Proxy) handleSCMProxy(w http.ResponseWriter, r *http.Request, service string) {
-    // 1. Strip the /<service>/ prefix to get the real API path
-    prefix := "/" + service + "/"
-    apiPath := strings.TrimPrefix(r.URL.Path, prefix)
-    if apiPath == "" {
-        apiPath = "/"
-    }
-
-    // 2. Reconstruct the full URL as if it were the real API
-    var targetHost string
-    switch service {
-    case "github":
-        targetHost = "api.github.com"
-    case "gitlab":
-        targetHost = p.config.GitLabHost // defaults to "gitlab.com"
-        if targetHost == "" {
-            targetHost = "gitlab.com"
-        }
-    }
-
-    fakeURL := fmt.Sprintf("https://%s/%s", targetHost, apiPath)
-    if r.URL.RawQuery != "" {
-        fakeURL += "?" + r.URL.RawQuery
-    }
-
-    // 3. Check access against scope
-    result := CheckAccess(r.Method, fakeURL, p.config.Scope)
-    if !result.Allowed {
-        http.Error(w, "Forbidden: "+result.Reason, http.StatusForbidden)
-        p.logEntry(r.Method, fakeURL, result.Service, result.Operation, "deny", http.StatusForbidden)
-        return
-    }
-
-    // 4. Build real target URL
-    targetURL, _ := url.Parse(fmt.Sprintf("https://%s/%s", targetHost, apiPath))
-    if r.URL.RawQuery != "" {
-        targetURL.RawQuery = r.URL.RawQuery
-    }
-
-    // 5. Reverse proxy with credential injection
-    proxy := &httputil.ReverseProxy{
-        Director: func(req *http.Request) {
-            req.URL = targetURL
-            req.Host = targetHost
-            p.injectServiceCredential(req, service)
-            // Strip the dummy token that the client sent
-            req.Header.Del("X-Session-Token")
-        },
-    }
-    proxy.ServeHTTP(w, r)
-    p.logEntry(r.Method, fakeURL, result.Service, result.Operation, "allow", http.StatusOK)
-}
-```
+- Bridge generates an ephemeral CA key pair (RSA 2048) per session at
+  dispatch time, with 24-hour validity.
+- The CA cert PEM is passed to Skiff as `ALCOVE_CA_CERT_PEM`. skiff-init
+  writes it to a file and sets `SSL_CERT_FILE` and `NODE_EXTRA_CA_CERTS`
+  to make it trusted by Go, Node.js, Python, and system tools.
+- The CA cert and key PEM are passed to Gate as `GATE_CA_CERT_PEM` and
+  `GATE_CA_KEY_PEM` env vars.
+- Gate generates leaf certs on-the-fly for each intercepted domain, signed
+  by the session CA. Leaf certs have 1-hour validity.
+- The CA private key exists only in Gate's memory.
 
 ### 2.2 Dummy token validation
 
@@ -308,29 +254,17 @@ p.logEntry("POST", fmt.Sprintf("git-credential://%s/%s", host, repoPath),
     service, "git_credential", "allow", http.StatusOK)
 ```
 
-### 2.4 CONNECT tunnel changes
+### 2.4 CONNECT tunnel handling
 
-The implementation blocks CONNECT tunnels only to `api.github.com`. CONNECT
-tunnels to `github.com` and `gitlab.com` (used for git transport) are still
-allowed through the existing `tunnelToService` method, which checks that the
-service is in scope.
+CONNECT tunnels to known service domains (including `api.github.com`,
+`github.com`, `gitlab.com`, and `*.atlassian.net`) are intercepted via MITM
+TLS. Gate terminates the tunnel, generates a leaf cert for the target domain,
+reads the plaintext request, performs scope checking and credential injection,
+and re-encrypts to the upstream.
 
-In `handleConnect`, `api.github.com` is handled as a special case before
-`isServiceHost`:
-
-```go
-case hostname == "api.github.com":
-    // Block CONNECT tunnels to api.github.com -- API operations must go
-    // through the /github/ proxy endpoint for operation-level enforcement.
-    http.Error(w, "Forbidden: use /github/ proxy endpoint for API calls", http.StatusForbidden)
-    p.logEntry("CONNECT", host, "github", "", "deny", http.StatusForbidden)
-```
-
-All other service hosts (including `github.com`, `gitlab.com`) pass through
-`tunnelToService`, which validates that the service is in scope and then
-creates a direct TCP tunnel. Git transport uses the credential helper
-(`credential.helper`) to obtain credentials from Gate's `/git-credential`
-endpoint, so the tunnel itself carries no Gate-managed secrets.
+Git transport to `github.com` and `gitlab.com` continues to use the credential
+helper (`credential.helper`) for authentication. The MITM path handles API
+calls (e.g., `gh` CLI GraphQL requests to `api.github.com:443`).
 
 ### 2.5 Config changes
 
@@ -342,18 +276,22 @@ Add to `Config`:
 type Config struct {
     // ... existing fields ...
     GitLabHost string // self-hosted GitLab hostname (default: "gitlab.com")
+    CACertPEM  string // ephemeral CA certificate PEM (from GATE_CA_CERT_PEM)
+    CAKeyPEM   string // ephemeral CA private key PEM (from GATE_CA_KEY_PEM)
 }
 ```
 
 **File: `cmd/gate/main.go`**
 
-Add env var:
+Add env vars:
 
 ```go
 gitlabHost := os.Getenv("GATE_GITLAB_HOST")
 if gitlabHost == "" {
     gitlabHost = "gitlab.com"
 }
+caCertPEM := os.Getenv("GATE_CA_CERT_PEM")
+caKeyPEM := os.Getenv("GATE_CA_KEY_PEM")
 ```
 
 ---
@@ -429,6 +367,12 @@ In `DispatchTask`, after building `gateEnv`, SCM credential resolution sets
 the following environment variables:
 
 ```go
+// Generate ephemeral CA for MITM TLS interception.
+caCert, caKey, err := generateEphemeralCA()
+gateEnv["GATE_CA_CERT_PEM"] = caCert
+gateEnv["GATE_CA_KEY_PEM"] = caKey
+skiffEnv["ALCOVE_CA_CERT_PEM"] = caCert
+
 // Resolve SCM credentials for services in scope.
 scmCredentials := make(map[string]string)
 scmDummyTokens := make(map[string]string)
@@ -451,31 +395,27 @@ if len(scmCredentials) > 0 {
     gateEnv["GATE_CREDENTIALS"] = string(credJSON)
 }
 
-// Set SCM environment for Skiff tools (dummy tokens + Gate proxy URLs).
+// Set SCM environment for Skiff tools (dummy tokens only, no per-tool API URLs).
+// Tools connect to standard upstream URLs; Gate intercepts via MITM TLS.
 if token, ok := scmDummyTokens["github"]; ok {
     skiffEnv["GITHUB_TOKEN"] = token
     skiffEnv["GH_TOKEN"] = token
     skiffEnv["GITHUB_PERSONAL_ACCESS_TOKEN"] = token
-    skiffEnv["GITHUB_API_URL"] = fmt.Sprintf("http://%s:8443/github", gateName)
-    skiffEnv["GH_HOST"] = fmt.Sprintf("%s:8443", gateName)
     skiffEnv["GH_PROMPT_DISABLED"] = "1"
     skiffEnv["GH_NO_UPDATE_NOTIFIER"] = "1"
 }
 if token, ok := scmDummyTokens["gitlab"]; ok {
     skiffEnv["GITLAB_TOKEN"] = token
     skiffEnv["GITLAB_PERSONAL_ACCESS_TOKEN"] = token
-    skiffEnv["GITLAB_API_URL"] = fmt.Sprintf("http://%s:8443/gitlab/api/v4", gateName)
-    skiffEnv["GLAB_HOST"] = fmt.Sprintf("http://%s:8443/gitlab", gateName)
 }
 ```
 
-Notable differences from the original design:
-- `GH_PROTOCOL` is not set (not needed; `GH_HOST` includes the port).
-- `GL_TOKEN` and `CI_API_V4_URL` are not set.
-- `GITHUB_PERSONAL_ACCESS_TOKEN`, `GH_PROMPT_DISABLED`, and
-  `GH_NO_UPDATE_NOTIFIER` are set for GitHub.
-- `GITLAB_PERSONAL_ACCESS_TOKEN` and `GLAB_HOST` are set for GitLab.
-- `GITLAB_API_URL` points to `/gitlab/api/v4` (not `/gitlab`).
+Notable differences from the previous prefix-proxy design:
+- `GITHUB_API_URL`, `GH_HOST`, `GITLAB_API_URL`, `GLAB_HOST`, and
+  `JIRA_API_URL` are no longer set. Tools connect to standard upstream URLs.
+- Gate intercepts CONNECT tunnels to service domains via MITM TLS.
+- `GATE_CA_CERT_PEM`, `GATE_CA_KEY_PEM`, and `ALCOVE_CA_CERT_PEM` are new
+  env vars for the ephemeral CA trust chain.
 
 ### 3.4 Dummy token properties
 
@@ -505,20 +445,16 @@ GIT_TERMINAL_PROMPT=0
 GATE_CREDENTIAL_URL=http://gate-<taskID>:8443   # derived from ANTHROPIC_BASE_URL
 GIT_SSH_COMMAND="echo 'SSH disabled — use HTTPS' && exit 1"
 
-# GitHub -- dummy token + API routed through Gate (set by Bridge dispatcher)
+# GitHub -- dummy token (set by Bridge dispatcher)
 GITHUB_TOKEN=alcove-session-<uuid>
 GH_TOKEN=alcove-session-<uuid>
 GITHUB_PERSONAL_ACCESS_TOKEN=alcove-session-<uuid>
-GITHUB_API_URL=http://gate-<taskID>:8443/github
-GH_HOST=gate-<taskID>:8443
 GH_PROMPT_DISABLED=1
 GH_NO_UPDATE_NOTIFIER=1
 
-# GitLab -- dummy token + API routed through Gate (set by Bridge dispatcher)
+# GitLab -- dummy token (set by Bridge dispatcher)
 GITLAB_TOKEN=alcove-session-<uuid>
 GITLAB_PERSONAL_ACCESS_TOKEN=alcove-session-<uuid>
-GITLAB_API_URL=http://gate-<taskID>:8443/gitlab/api/v4
-GLAB_HOST=http://gate-<taskID>:8443/gitlab
 
 # LLM (existing)
 ANTHROPIC_BASE_URL=http://gate-<taskID>:8443
@@ -528,12 +464,23 @@ ANTHROPIC_API_KEY=sk-placeholder-routed-through-gate
 HTTP_PROXY=http://gate-<taskID>:8443
 HTTPS_PROXY=http://gate-<taskID>:8443
 NO_PROXY=localhost,127.0.0.1,gate-<taskID>
+
+# Ephemeral CA trust store (set by Bridge, written by skiff-init)
+ALCOVE_CA_CERT_PEM=<base64-encoded PEM CA certificate>
+SSL_CERT_FILE=/etc/alcove-tls/ca-bundle.pem
+NODE_EXTRA_CA_CERTS=/etc/alcove-tls/ca-bundle.pem
 ```
 
 `GATE_CREDENTIAL_URL` is set by `skiff-init`'s `setupEnv()` function, derived
 from `ANTHROPIC_BASE_URL` (which already points to the Gate sidecar).
 `GIT_SSH_COMMAND` blocks SSH git transport to force HTTPS through Gate's
 credential helper.
+
+Tools like `gh` and `glab` connect to their standard upstream URLs
+(`api.github.com`, `gitlab.com`). Gate intercepts these connections
+transparently via MITM TLS through the HTTP_PROXY. No per-tool API URL
+env vars (`GITHUB_API_URL`, `GH_HOST`, `GITLAB_API_URL`, `GLAB_HOST`,
+`JIRA_API_URL`) are needed.
 
 ### 4.2 Git credential helper script
 
@@ -577,21 +524,23 @@ The credential helper reads `GATE_CREDENTIAL_URL` (set by `skiff-init` from
 URL. Git is configured system-wide to use this helper via
 `git config --system credential.helper` in the Containerfile.
 
-### 4.3 MCP server configuration
+### 4.3 CLI tool compatibility
 
-Claude Code's MCP servers (GitHub MCP, GitLab MCP) read their configuration
-from environment variables. The key insight is that these MCP servers use the
-same environment variables we set:
+With MITM TLS interception, CLI tools work natively through HTTP_PROXY
+without any per-tool configuration:
 
-- **GitHub MCP server:** reads `GITHUB_TOKEN` and `GITHUB_API_URL`. Since we
-  set `GITHUB_API_URL` to Gate's endpoint, the MCP server sends all API calls
-  through Gate. The dummy `GITHUB_TOKEN` is passed in the Authorization header,
-  and Gate replaces it with the real token.
+- **`gh` CLI:** connects to `api.github.com:443` via CONNECT tunnel. Gate
+  intercepts via MITM TLS, inspects the request, injects real credentials,
+  and forwards to GitHub. No `GITHUB_API_URL` or `GH_HOST` env vars needed.
 
-- **GitLab MCP server:** reads `GITLAB_TOKEN` and `GITLAB_API_URL`. Same
-  pattern.
+- **`glab` CLI:** connects to `gitlab.com:443` via CONNECT tunnel. Same
+  MITM interception pattern. No `GITLAB_API_URL` or `GLAB_HOST` env vars needed.
 
-No special MCP configuration is needed beyond the environment variables.
+- **`curl` / arbitrary HTTP:** any tool using HTTP_PROXY is intercepted for
+  known service domains. Unknown domains pass through or are blocked per scope.
+
+The GitHub MCP server is no longer needed -- `gh` CLI works directly through
+the MITM proxy for all GitHub API operations including GraphQL.
 
 ---
 
@@ -768,10 +717,9 @@ the Gate sidecar (same pod, localhost) and allowed package registries.
 `api.github.com` and `gitlab.com` API endpoints are not in the egress allowlist.
 
 **Mitigation (podman):** `HTTP_PROXY`/`HTTPS_PROXY` is set to Gate, and
-iptables rules block direct egress from the Skiff container to external hosts.
-Git transport to `github.com:443` is allowed through CONNECT tunnels (Gate
-validates the service is in scope), but API calls must go through the
-`/github/` or `/gitlab/` proxy endpoints.
+the `--internal` podman network blocks direct egress from the Skiff container
+to external hosts. All CONNECT tunnels to service domains are intercepted
+via MITM TLS, allowing Gate to inspect and authorize every request.
 
 ### Threat: Skiff sends unauthorized operations through Gate
 
@@ -804,6 +752,25 @@ within the Gate sidecar of a single, ephemeral Skiff pod.
 messages, or any output visible to Skiff. Error messages reference the service
 name and operation, never the credential value.
 
+### Enforcement Modes
+
+Agent definitions support an `enforcement_mode` field:
+
+- `enforce` (default) -- Gate checks scope and denies unauthorized requests with 403
+- `monitor` -- Gate logs all requests but allows them regardless of scope, enabling iterative policy development
+
+In monitor mode, the proxy log records every request with its would-be decision, allowing operators to:
+1. Deploy an agent with `enforcement_mode: monitor`
+2. Run the workload
+3. Review the proxy log to see what operations the agent performed
+4. Build a security profile from the observed traffic
+5. Switch to `enforcement_mode: enforce`
+
+The enforcement mode is set in the agent definition YAML and passed to Gate as the
+`GATE_ENFORCEMENT_MODE` environment variable. It cannot be set via the API
+(`json:"-"` on the TaskRequest field), ensuring that only version-controlled
+agent definitions control the enforcement policy.
+
 ---
 
 ## 8. Implementation Plan
@@ -812,12 +779,11 @@ Ordered list of tasks with file paths. Each task is independently testable.
 
 ### Phase 1: Core SCM Proxy (MVP) -- IMPLEMENTED
 
-**Task 1.1: Add SCM proxy endpoints to Gate**
+**Task 1.1: Add MITM TLS proxy to Gate**
 - File: `internal/gate/proxy.go`
-- Add `handleSCMProxy()` method
-- Add `/github/` and `/gitlab/` route registrations in `Handler()`
-- Add `GitLabHost` to `Config`
-- Block CONNECT tunnels to `api.github.com` (but allow `github.com` for git)
+- Add MITM TLS interception for CONNECT tunnels to service domains
+- Add ephemeral leaf cert generation from session CA
+- Add `GitLabHost`, `CACertPEM`, `CAKeyPEM` to `Config`
 - Tests: `internal/gate/proxy_test.go`
 
 **Task 1.2: Enhance scope checker for SCM operations**
@@ -837,13 +803,13 @@ Ordered list of tasks with file paths. Each task is independently testable.
 - File: `internal/bridge/dispatcher.go`
 - Resolve SCM credentials from CredentialStore
 - Generate dummy tokens
-- Set Skiff env vars (`GITHUB_TOKEN`, `GITHUB_API_URL`, etc.)
-- Set Gate env vars (`GATE_CREDENTIALS` with real tokens)
+- Set Skiff env vars (`GITHUB_TOKEN`, `ALCOVE_CA_CERT_PEM`, etc.)
+- Set Gate env vars (`GATE_CREDENTIALS`, `GATE_CA_CERT_PEM`, `GATE_CA_KEY_PEM`)
 - Tests: integration test with mock runtime
 
 **Task 1.5: Gate env var loading for SCM config**
 - File: `cmd/gate/main.go`
-- Load `GATE_GITLAB_HOST` env var
+- Load `GATE_GITLAB_HOST`, `GATE_CA_CERT_PEM`, `GATE_CA_KEY_PEM` env vars
 - Tests: unit test for `loadConfig()`
 
 ### Phase 2: Git Transport -- IMPLEMENTED

--- a/docs/design/implementation-status.md
+++ b/docs/design/implementation-status.md
@@ -15,7 +15,7 @@ all resolved decisions.
 |-----------|------|---------|
 | Controller | **Bridge** | REST API, dashboard, session dispatch, scheduler, admin settings, security profile builder |
 | Worker | **Skiff** | Ephemeral Claude Code execution |
-| Auth Proxy | **Gate** | Sidecar proxy: token swap, LLM API proxy, SCM proxy (`/github/`, `/gitlab/`), scope enforcement, MCP tool configs |
+| Auth Proxy | **Gate** | Sidecar proxy: token swap, LLM API proxy, MITM TLS SCM proxy, scope enforcement, MCP tool configs |
 | Message Bus | **Hail** | NATS-based status, transcript ingestion, cancellation |
 | Session Store | **Ledger** | PostgreSQL session records, transcripts, proxy logs |
 
@@ -27,7 +27,7 @@ all resolved decisions.
 alcove/
 ├── cmd/
 │   ├── bridge/main.go          ✅ Controller: REST API, auth, session dispatch, migration, scheduling, admin settings
-│   ├── gate/main.go            ✅ HTTP proxy with scope enforcement, LLM proxying, SCM proxying (/github/, /gitlab/), token refresh, MCP tool configs
+│   ├── gate/main.go            ✅ HTTP proxy with scope enforcement, LLM proxying, MITM TLS SCM proxying, token refresh, MCP tool configs
 │   ├── skiff-init/main.go      ✅ PID 1 init: reads session config from env, runs claude, streams output, publishes transcript events to NATS
 │   ├── shim/main.go            ✅ Dev container execution sidecar: GET /healthz + POST /exec with NDJSON streaming, bearer auth, timeout enforcement
 │   ├── hashpw/main.go          ✅ Utility: password hashing tool
@@ -98,7 +98,7 @@ alcove/
 │   └── design/
 │       ├── implementation-status.md    ✅ This file
 │       ├── architecture.md             ✅ Full component design
-│       ├── architecture-decisions.md   ✅ 22 resolved decisions
+│       ├── architecture-decisions.md   ✅ 24 resolved decisions
 │       ├── problem-statement.md        ✅ Why ephemeral agents
 │       ├── credential-management.md    ✅ Credential storage and token flow design
 │       ├── auth-backends.md            ✅ Dual auth backend design
@@ -191,16 +191,16 @@ alcove/
    AI endpoints, body transformation (removes `model` and `context_management`,
    adds `anthropic_version`), model name conversion, and header stripping.
 
-10. **SCM Authorization** — Gate provides `/github/` and `/gitlab/` reverse-proxy
-    endpoints that forward requests to the respective SCM APIs after operation-level
-    scope checking. Bridge resolves SCM credentials via `AcquireSCMToken` at dispatch
-    time and injects dummy tokens into the Skiff container. Gate swaps the dummy
-    tokens for real PATs at proxy time. The Skiff base image includes the `gh` and
-    `glab` CLIs, and a git credential helper (`build/alcove-credential-helper`) that
-    acquires HTTPS git credentials from Gate. SCM-related environment variables
-    (`GITHUB_TOKEN`, `GH_TOKEN`, `GITLAB_TOKEN`, `GITHUB_API_URL`, `GITLAB_API_URL`,
-    `GH_HOST`, `GLAB_HOST`, `GATE_CREDENTIAL_URL`, `GIT_SSH_COMMAND`, etc.) are
-    injected by Bridge when the session scope includes a `github` or `gitlab` service.
+10. **SCM Authorization** — Gate intercepts CONNECT tunnels to service domains
+    (GitHub, GitLab, Jira) via MITM TLS. An ephemeral CA is generated per session
+    by Bridge; the CA cert is injected into Skiff's trust store. Gate terminates
+    TLS tunnels, inspects plaintext requests, performs operation-level scope
+    checking, injects real credentials, and re-encrypts to upstream. Bridge
+    resolves SCM credentials via `AcquireSCMToken` at dispatch time and injects
+    dummy tokens into the Skiff container. The Skiff base image includes the `gh`
+    and `glab` CLIs (which work natively through HTTP_PROXY without per-tool API
+    URL env vars), and a git credential helper (`build/alcove-credential-helper`)
+    that acquires HTTPS git credentials from Gate.
 
 11. **Transcript Viewing** — Skiff flushes transcript events to the database
     every 5 seconds via `POST /api/v1/sessions/{id}/transcript`. The dashboard
@@ -444,12 +444,12 @@ See the full roadmap in [architecture-decisions.md](architecture-decisions.md#ro
 ## Key Design Documents
 
 - [architecture.md](architecture.md) — full component design, deployment diagrams, network isolation
-- [architecture-decisions.md](architecture-decisions.md) — 22 resolved decisions, CLI design, config format, repo layout, revised roadmap
+- [architecture-decisions.md](architecture-decisions.md) — 24 resolved decisions, CLI design, config format, repo layout, revised roadmap
 - [problem-statement.md](problem-statement.md) — why ephemeral agents (context contamination, credential drift, filesystem poisoning, credential exposure)
 - [credential-management.md](credential-management.md) — credential storage, encryption, OAuth2 token flow, token refresh design
 - [auth-backends.md](auth-backends.md) — auth backend design (memory, postgres, rh-identity)
 - [podman-network-isolation.md](podman-network-isolation.md) — dual-network isolation design with `--internal` flag on podman
-- [gate-scm-authorization.md](gate-scm-authorization.md) — SCM authorization design: Gate proxy endpoints, scope checking, credential resolution, git credential helper
+- [gate-scm-authorization.md](gate-scm-authorization.md) — SCM authorization design: Gate MITM TLS proxy, scope checking, credential resolution, git credential helper
 - [mcp-tool-gateway.md](mcp-tool-gateway.md) — MCP tool gateway design
 - [security-profiles-and-system-llm.md](security-profiles-and-system-llm.md) — Security profiles and system LLM design
 
@@ -512,19 +512,18 @@ See the full roadmap in [architecture-decisions.md](architecture-decisions.md#ro
 | `NO_PROXY` | Addresses excluded from proxy |
 | `ANTHROPIC_BASE_URL` | Points to Gate container (`http://gate-<taskID>:8443`) for LLM API proxying |
 | `ANTHROPIC_API_KEY` | Placeholder API key (real key injected by Gate) |
-| `GITHUB_TOKEN` | Dummy GitHub token (Gate swaps for real PAT) |
+| `GITHUB_TOKEN` | Dummy GitHub token (Gate swaps for real PAT via MITM TLS) |
 | `GH_TOKEN` | Alias for `GITHUB_TOKEN` used by `gh` CLI |
 | `GITHUB_PERSONAL_ACCESS_TOKEN` | Alias for GitHub tooling |
-| `GITHUB_API_URL` | Points to Gate's `/github/` proxy endpoint |
-| `GH_HOST` | GitHub host for `gh` CLI |
 | `GH_PROMPT_DISABLED` | Disables interactive prompts in `gh` CLI |
 | `GH_NO_UPDATE_NOTIFIER` | Disables `gh` update notifications |
-| `GITLAB_TOKEN` | Dummy GitLab token (Gate swaps for real PAT) |
+| `GITLAB_TOKEN` | Dummy GitLab token (Gate swaps for real PAT via MITM TLS) |
 | `GITLAB_PERSONAL_ACCESS_TOKEN` | Alias for GitLab tooling |
-| `GITLAB_API_URL` | Points to Gate's `/gitlab/` proxy endpoint |
-| `GLAB_HOST` | GitLab host for `glab` CLI |
 | `GATE_CREDENTIAL_URL` | Gate endpoint for git credential helper |
 | `GIT_SSH_COMMAND` | Disables SSH git operations (forces HTTPS via Gate) |
+| `ALCOVE_CA_CERT_PEM` | Ephemeral CA certificate PEM for MITM TLS trust |
+| `SSL_CERT_FILE` | Path to CA bundle including ephemeral CA (set by skiff-init) |
+| `NODE_EXTRA_CA_CERTS` | Path to CA bundle for Node.js trust (set by skiff-init) |
 | `DEV_TOKEN` | Bearer token for authenticating with the dev container's shim (set when `dev_container` is configured) |
 | `DEV_CONTAINER_HOST` | Hostname and port of the dev container's shim (e.g., `dev-<taskID>:9090`; overridden to `localhost:9090` on K8s) |
 
@@ -545,3 +544,5 @@ See the full roadmap in [architecture-decisions.md](architecture-decisions.md#ro
 | `GATE_VERTEX_REGION` | Vertex AI region (default `us-east5`) |
 | `GATE_VERTEX_PROJECT` | GCP project ID for Vertex AI |
 | `GATE_GITLAB_HOST` | GitLab hostname for self-hosted instances (default `gitlab.com`) |
+| `GATE_CA_CERT_PEM` | Ephemeral CA certificate PEM for MITM TLS leaf cert signing |
+| `GATE_CA_KEY_PEM` | Ephemeral CA private key PEM for MITM TLS leaf cert signing |

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -627,14 +627,16 @@ embedded at compile time, so they are available immediately on Bridge startup
 without cloning catalog source repos. Only custom agent repo definitions
 require the sync interval.
 
-## Gate SCM Proxy Endpoints
+## Gate SCM MITM Proxy
 
-Gate exposes `/github/` and `/gitlab/` reverse-proxy endpoints that forward
-requests to the upstream GitHub and GitLab APIs. Inside Skiff, the `gh` and
-`glab` CLIs are configured via `GITHUB_API_URL` and `GITLAB_API_URL` to point
-at these local Gate endpoints. Gate inspects each request, enforces
-operation-level scope (e.g., allowing `create_pr_draft` but blocking
-`merge_pr`), injects real SCM credentials, and forwards to the upstream API.
+Gate intercepts CONNECT tunnels to service domains (GitHub, GitLab, Jira)
+via MITM TLS. An ephemeral CA is generated per session by Bridge; the CA cert
+is injected into Skiff's trust store (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`).
+Gate generates leaf certs signed by this CA, terminates TLS tunnels, inspects
+plaintext requests, enforces operation-level scope (e.g., allowing
+`create_pr_draft` but blocking `merge_pr`), injects real SCM credentials,
+and re-encrypts to the upstream API. Tools like `gh` and `glab` work natively
+through HTTP_PROXY without per-tool API URL env vars.
 See `internal/gate/` for the proxy implementation and
 `docs/design/gate-scm-authorization.md` for the full design.
 

--- a/internal/bridge/agentdef.go
+++ b/internal/bridge/agentdef.go
@@ -67,8 +67,9 @@ type AgentDefinition struct {
 	Schedule       *AgentDefSchedule         `json:"schedule,omitempty" yaml:"schedule"`
 	Trigger        *EventTrigger            `json:"trigger,omitempty" yaml:"trigger"`
 	CIGate         *CIGate                  `json:"ci_gate,omitempty" yaml:"ci_gate"`
-	DirectOutbound bool                     `json:"direct_outbound,omitempty" yaml:"direct_outbound"`
-	DevContainer   *DevContainerSpec       `json:"dev_container,omitempty" yaml:"dev_container"`
+	DirectOutbound  bool                     `json:"direct_outbound,omitempty" yaml:"direct_outbound"`
+	EnforcementMode string                  `json:"enforcement_mode,omitempty" yaml:"enforcement_mode"`
+	DevContainer    *DevContainerSpec       `json:"dev_container,omitempty" yaml:"dev_container"`
 
 	// Metadata (not from YAML).
 	TeamID       string     `json:"team_id,omitempty"`
@@ -176,8 +177,9 @@ func (td *AgentDefinition) ToTaskRequest() TaskRequest {
 		Debug:          td.Debug,
 		Plugins:        td.Plugins,
 		Credentials:    td.Credentials,
-		DirectOutbound: td.DirectOutbound,
-		DevContainer:   td.DevContainer,
+		DirectOutbound:  td.DirectOutbound,
+		EnforcementMode: td.EnforcementMode,
+		DevContainer:    td.DevContainer,
 	}
 }
 
@@ -248,6 +250,7 @@ func (s *AgentDefStore) ListAgentDefinitions(ctx context.Context, teamID string)
 				td.Plugins = parsed.Plugins
 				td.Credentials = parsed.Credentials
 				td.DirectOutbound = parsed.DirectOutbound
+				td.EnforcementMode = parsed.EnforcementMode
 				td.CIGate = parsed.CIGate
 				td.DevContainer = parsed.DevContainer
 			}
@@ -314,6 +317,7 @@ func (s *AgentDefStore) GetAgentDefinition(ctx context.Context, id, teamID strin
 			td.Plugins = parsed.Plugins
 			td.Credentials = parsed.Credentials
 			td.DirectOutbound = parsed.DirectOutbound
+			td.EnforcementMode = parsed.EnforcementMode
 			td.CIGate = parsed.CIGate
 			td.DevContainer = parsed.DevContainer
 		}
@@ -422,6 +426,7 @@ func (s *AgentDefStore) ListAgentDefinitionsByRepo(ctx context.Context, repoURL,
 				td.Plugins = parsed.Plugins
 				td.Credentials = parsed.Credentials
 				td.DirectOutbound = parsed.DirectOutbound
+				td.EnforcementMode = parsed.EnforcementMode
 				td.CIGate = parsed.CIGate
 				td.DevContainer = parsed.DevContainer
 			}

--- a/internal/bridge/agentdef_test.go
+++ b/internal/bridge/agentdef_test.go
@@ -492,7 +492,8 @@ func TestGetAgentDefinitionFieldCopyRoundTrip(t *testing.T) {
 			MaxRetries: 3,
 			Timeout:    900,
 		},
-		DirectOutbound: true,
+		DirectOutbound:  true,
+		EnforcementMode: "monitor",
 		DevContainer: &DevContainerSpec{
 			Image:         "quay.io/myorg/devenv:latest",
 			NetworkAccess: "external",
@@ -536,6 +537,7 @@ func TestGetAgentDefinitionFieldCopyRoundTrip(t *testing.T) {
 	td.Plugins = parsed.Plugins
 	td.Credentials = parsed.Credentials
 	td.DirectOutbound = parsed.DirectOutbound
+	td.EnforcementMode = parsed.EnforcementMode
 	td.CIGate = parsed.CIGate
 	td.DevContainer = parsed.DevContainer
 
@@ -566,7 +568,7 @@ func TestGetAgentDefinitionFieldCopyRoundTrip(t *testing.T) {
 
 	// Sanity check: make sure we actually checked a meaningful number of fields.
 	// Update this count when adding new yaml-tagged fields to AgentDefinition.
-	const expectedYAMLFields = 19
+	const expectedYAMLFields = 20
 	if yamlFieldCount != expectedYAMLFields {
 		t.Errorf("expected %d yaml-tagged fields in AgentDefinition, found %d; "+
 			"update this test and the copy block in GetAgentDefinition",

--- a/internal/bridge/ca.go
+++ b/internal/bridge/ca.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"time"
+)
+
+// generateEphemeralCA creates a self-signed 2048-bit RSA CA certificate
+// valid for 24 hours. The returned PEM-encoded cert and key are passed to
+// Gate (for MITM re-encrypt) and Skiff (for trust store injection).
+func generateEphemeralCA() (certPEM, keyPEM []byte, err error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: "Alcove Session CA"},
+		NotBefore:             time.Now().Add(-1 * time.Minute),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	return certPEM, keyPEM, nil
+}

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -17,6 +17,7 @@ package bridge
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -101,8 +102,9 @@ type TaskRequest struct {
 	Debug          bool                     `json:"debug,omitempty"`
 	Plugins        []PluginSpec             `json:"-"` // Set internally from agent definition
 	Credentials    map[string]string        `json:"-"` // ENV_VAR_NAME: credential_provider_name
-	DirectOutbound bool                     `json:"direct_outbound,omitempty"`
-	DevContainer   *DevContainerSpec       `json:"dev_container,omitempty"`
+	DirectOutbound  bool                     `json:"direct_outbound,omitempty"`
+	EnforcementMode string                  `json:"-"` // "enforce" (default) or "monitor"
+	DevContainer    *DevContainerSpec       `json:"dev_container,omitempty"`
 	// Task metadata — set by dispatch code paths, stored in sessions table.
 	TaskName    string `json:"-"` // Schedule/agent definition name
 	TriggerType string `json:"-"` // "event", "cron", "manual", "webhook"
@@ -365,7 +367,13 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		}
 	}
 
-	// Build Gate sidecar env vars (scope config + LLM credentials).
+	// Generate ephemeral CA for Gate MITM re-encrypt proxy.
+	caCertPEM, caKeyPEM, err := generateEphemeralCA()
+	if err != nil {
+		return nil, fmt.Errorf("generating ephemeral CA: %w", err)
+	}
+
+	// Build Gate sidecar env vars (scope config + LLM credentials + MITM CA).
 	scopeBytes, _ := json.Marshal(scope)
 	gateEnv := map[string]string{
 		"GATE_SESSION_ID":           sessionID,
@@ -380,15 +388,24 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		"GATE_CREDENTIALS":          "{}",
 		"GATE_VERTEX_REGION":        vertexRegion,
 		"GATE_VERTEX_PROJECT":       vertexProject,
+		"GATE_CA_CERT_PEM":          base64.StdEncoding.EncodeToString(caCertPEM),
+		"GATE_CA_KEY_PEM":           base64.StdEncoding.EncodeToString(caKeyPEM),
+	}
+
+	// Pass ephemeral CA cert to Skiff for trust store injection.
+	skiffEnv["ALCOVE_CA_CERT_PEM"] = base64.StdEncoding.EncodeToString(caCertPEM)
+
+	// Pass enforcement mode to Gate (monitor = log-only, no denials).
+	if req.EnforcementMode == "monitor" {
+		gateEnv["GATE_ENFORCEMENT_MODE"] = "monitor"
 	}
 
 	// Resolve SCM credentials for services in scope.
 	scmCredentials := make(map[string]string)
 	scmDummyTokens := make(map[string]string)
-	scmAPIHosts := make(map[string]string) // service -> custom api_host from credential
 	for service := range scope.Services {
 		if service == "github" || service == "gitlab" || service == "jira" || service == "splunk" {
-			realToken, apiHost, err := d.credStore.AcquireSCMTokenWithHost(ctx, service)
+			realToken, _, err := d.credStore.AcquireSCMTokenWithHost(ctx, service)
 			if err != nil {
 				log.Printf("warning: no credential for %s: %v", service, err)
 				continue
@@ -396,9 +413,6 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 			scmCredentials[service] = realToken
 			dummyToken := "alcove-session-" + uuid.New().String()
 			scmDummyTokens[service] = dummyToken
-			if apiHost != "" {
-				scmAPIHosts[service] = stripURLToHost(apiHost)
-			}
 		}
 	}
 
@@ -410,11 +424,9 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 
 	// Resolve MCP tool configurations for the task.
 	var mcpConfigs map[string]any
-	var gateToolConfigs map[string]any
 
 	if len(req.Tools) > 0 {
 		mcpConfigs = make(map[string]any)
-		gateToolConfigs = make(map[string]any)
 
 		for toolName, toolCfg := range req.Tools {
 			if !toolCfg.Enabled {
@@ -435,7 +447,7 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 			}
 
 			// Resolve credential for this tool.
-			realToken, apiHost, err := d.credStore.AcquireSCMTokenWithHost(ctx, toolName)
+			realToken, _, err := d.credStore.AcquireSCMTokenWithHost(ctx, toolName)
 			dummyToken := "alcove-session-" + uuid.New().String()
 
 			if err != nil {
@@ -448,23 +460,14 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 				scmCredentials[toolName] = realToken
 			}
 
-			// If credential has a custom API host, track it for overriding tool config.
-			if apiHost != "" {
-				scmAPIHosts[toolName] = stripURLToHost(apiHost)
-			}
-
 			// Build MCP server config for Skiff.
 			if tool.MCPCommand != "" {
 				envMap := map[string]string{}
 
-				// Set the tool's API URL to go through Gate.
+				// Set the tool's MCP server env vars.
 				switch toolName {
-				case "github":
-					envMap["GITHUB_PERSONAL_ACCESS_TOKEN"] = dummyToken
-					envMap["GITHUB_HOST"] = fmt.Sprintf("http://%s:8443/github", gateName)
 				case "gitlab":
 					envMap["GITLAB_TOKEN"] = dummyToken
-					envMap["GITLAB_API_URL"] = fmt.Sprintf("http://%s:8443/gitlab/api/v4", gateName)
 				default:
 					// Custom tools: set a generic token env var.
 					envMap["TOOL_TOKEN"] = dummyToken
@@ -488,26 +491,12 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 				}
 			}
 
-			// Gate tool config.
-			if tool.APIHost != "" {
-				gateToolConfigs[toolName] = map[string]string{
-					"api_host":    tool.APIHost,
-					"auth_header": tool.AuthHeader,
-					"auth_format": tool.AuthFormat,
-				}
-			}
 		}
 
 		// Set Skiff MCP config env var.
 		if len(mcpConfigs) > 0 {
 			mcpJSON, _ := json.Marshal(mcpConfigs)
 			skiffEnv["ALCOVE_MCP_CONFIG"] = string(mcpJSON)
-		}
-
-		// Set Gate tool configs env var.
-		if len(gateToolConfigs) > 0 {
-			gtcJSON, _ := json.Marshal(gateToolConfigs)
-			gateEnv["GATE_TOOL_CONFIGS"] = string(gtcJSON)
 		}
 	}
 
@@ -517,89 +506,28 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		gateEnv["GATE_CREDENTIALS"] = string(credJSON)
 	}
 
-	// Override Gate tool configs with custom API hosts from credentials.
-	if len(scmAPIHosts) > 0 {
-		if gateToolConfigs == nil {
-			gateToolConfigs = make(map[string]any)
-		}
-		for service, apiHost := range scmAPIHosts {
-			if existing, ok := gateToolConfigs[service]; ok {
-				// Override the api_host in the existing tool config.
-				if m, ok := existing.(map[string]string); ok {
-					m["api_host"] = apiHost
-					gateToolConfigs[service] = m
-				}
-			} else {
-				// Create a new tool config entry with the credential's api_host.
-				switch service {
-				case "gitlab":
-					gateToolConfigs[service] = map[string]string{
-						"api_host":    apiHost,
-						"auth_header": "PRIVATE-TOKEN",
-						"auth_format": "header",
-					}
-				case "github":
-					gateToolConfigs[service] = map[string]string{
-						"api_host":    apiHost,
-						"auth_header": "Authorization",
-						"auth_format": "bearer",
-					}
-				case "jira":
-					gateToolConfigs[service] = map[string]string{
-						"api_host":    apiHost,
-						"auth_header": "Authorization",
-						"auth_format": "basic",
-					}
-				case "splunk":
-					gateToolConfigs[service] = map[string]string{
-						"api_host":    apiHost,
-						"auth_header": "Authorization",
-						"auth_format": "bearer",
-					}
-				}
-			}
-		}
-
-		// Set Gate tool configs env var if we added entries.
-		if len(gateToolConfigs) > 0 {
-			gtcJSON, _ := json.Marshal(gateToolConfigs)
-			gateEnv["GATE_TOOL_CONFIGS"] = string(gtcJSON)
-		}
-
-		// Set GATE_GITLAB_HOST for custom GitLab instances.
-		if gitlabHost, ok := scmAPIHosts["gitlab"]; ok {
-			gateEnv["GATE_GITLAB_HOST"] = gitlabHost
-		}
-	}
-
 	// Re-marshal scope after tool resolution may have added services.
 	scopeBytes, _ = json.Marshal(scope)
 	gateEnv["GATE_SCOPE"] = string(scopeBytes)
 
-	// Set SCM environment for Skiff tools (dummy tokens + Gate proxy URLs).
+	// Set SCM environment for Skiff tools (dummy tokens so tools don't prompt for auth).
+	// Tools reach upstream hosts via HTTP_PROXY -> Gate MITM, so no custom API URLs needed.
 	if token, ok := scmDummyTokens["github"]; ok {
 		skiffEnv["GITHUB_TOKEN"] = token
 		skiffEnv["GH_TOKEN"] = token
 		skiffEnv["GITHUB_PERSONAL_ACCESS_TOKEN"] = token
-		skiffEnv["GITHUB_API_URL"] = fmt.Sprintf("http://%s:8443/github", gateName)
-		skiffEnv["GH_HOST"] = fmt.Sprintf("%s:8443", gateName)
-		skiffEnv["GH_PROTOCOL"] = "http"
 		skiffEnv["GH_PROMPT_DISABLED"] = "1"
 		skiffEnv["GH_NO_UPDATE_NOTIFIER"] = "1"
 	}
 	if token, ok := scmDummyTokens["gitlab"]; ok {
 		skiffEnv["GITLAB_TOKEN"] = token
 		skiffEnv["GITLAB_PERSONAL_ACCESS_TOKEN"] = token
-		skiffEnv["GITLAB_API_URL"] = fmt.Sprintf("http://%s:8443/gitlab/api/v4", gateName)
-		skiffEnv["GLAB_HOST"] = fmt.Sprintf("http://%s:8443/gitlab", gateName)
 	}
 	if token, ok := scmDummyTokens["jira"]; ok {
 		skiffEnv["JIRA_TOKEN"] = token
-		skiffEnv["JIRA_API_URL"] = fmt.Sprintf("http://%s:8443/jira", gateName)
 	}
 	if token, ok := scmDummyTokens["splunk"]; ok {
 		skiffEnv["SPLUNK_TOKEN"] = token
-		skiffEnv["SPLUNK_URL"] = fmt.Sprintf("http://%s:8443/splunk", gateName)
 	}
 
 	// Resolve skill repos for this task (catalog-based for team sessions).

--- a/internal/bridge/tools.go
+++ b/internal/bridge/tools.go
@@ -317,7 +317,7 @@ func (ts *ToolStore) SeedBuiltinTools(ctx context.Context) error {
 		{
 			name:        "github",
 			displayName: "GitHub",
-			mcpCommand:  "github-mcp-server",
+			mcpCommand:  "",
 			mcpArgs:     `[]`,
 			apiHost:     "api.github.com",
 			authHeader:  "Authorization",

--- a/internal/gate/mitm.go
+++ b/internal/gate/mitm.go
@@ -1,0 +1,490 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gate
+
+import (
+	"bufio"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const certCacheMaxSize = 256
+
+// CertCache is an LRU cache for per-hostname leaf certificates.
+type CertCache struct {
+	mu      sync.Mutex
+	entries map[string]*certCacheEntry
+	order   []string // oldest first for LRU eviction
+}
+
+type certCacheEntry struct {
+	cert *tls.Certificate
+}
+
+func newCertCache() *CertCache {
+	return &CertCache{
+		entries: make(map[string]*certCacheEntry),
+	}
+}
+
+// GetOrCreate returns a cached leaf cert for the hostname, or generates a new
+// one signed by the given CA.
+func (cc *CertCache) GetOrCreate(hostname string, caCert *x509.Certificate, caKey crypto.PrivateKey) (*tls.Certificate, error) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+
+	if e, ok := cc.entries[hostname]; ok {
+		// Move to end (most recently used)
+		cc.moveToEnd(hostname)
+		return e.cert, nil
+	}
+
+	cert, err := generateLeafCert(hostname, caCert, caKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Evict oldest if at capacity
+	if len(cc.entries) >= certCacheMaxSize {
+		oldest := cc.order[0]
+		cc.order = cc.order[1:]
+		delete(cc.entries, oldest)
+	}
+
+	cc.entries[hostname] = &certCacheEntry{cert: cert}
+	cc.order = append(cc.order, hostname)
+	return cert, nil
+}
+
+func (cc *CertCache) moveToEnd(hostname string) {
+	for i, h := range cc.order {
+		if h == hostname {
+			cc.order = append(cc.order[:i], cc.order[i+1:]...)
+			cc.order = append(cc.order, hostname)
+			return
+		}
+	}
+}
+
+func (cc *CertCache) len() int {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	return len(cc.entries)
+}
+
+func generateLeafCert(hostname string, caCert *x509.Certificate, caKey crypto.PrivateKey) (*tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating leaf key: %w", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("generating serial number: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: hostname,
+		},
+		NotBefore:             time.Now().Add(-5 * time.Minute),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{hostname},
+	}
+
+	if ip := net.ParseIP(hostname); ip != nil {
+		template.IPAddresses = []net.IP{ip}
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("creating leaf certificate: %w", err)
+	}
+
+	leafCert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, fmt.Errorf("parsing leaf certificate: %w", err)
+	}
+
+	return &tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  key,
+		Leaf:        leafCert,
+	}, nil
+}
+
+// MITMHandler handles CONNECT requests by performing TLS interception,
+// credential injection, and scope enforcement.
+type MITMHandler struct {
+	caCert    *x509.Certificate
+	caKey     crypto.PrivateKey
+	certCache *CertCache
+	config    *Config
+	domains   map[string]bool // set of MITM-eligible hostnames
+}
+
+// NewMITMHandler parses the PEM-encoded CA cert+key and initializes the handler.
+func NewMITMHandler(caCertPEM, caKeyPEM []byte, config *Config) (*MITMHandler, error) {
+	certBlock, _ := pem.Decode(caCertPEM)
+	if certBlock == nil {
+		return nil, fmt.Errorf("failed to decode CA certificate PEM")
+	}
+	caCert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing CA certificate: %w", err)
+	}
+
+	keyBlock, _ := pem.Decode(caKeyPEM)
+	if keyBlock == nil {
+		return nil, fmt.Errorf("failed to decode CA key PEM")
+	}
+	caKey, err := parsePrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing CA key: %w", err)
+	}
+
+	m := &MITMHandler{
+		caCert:    caCert,
+		caKey:     caKey,
+		certCache: newCertCache(),
+		config:    config,
+		domains:   make(map[string]bool),
+	}
+
+	// Build domain set from config.Scope.Services
+	for service := range config.Scope.Services {
+		switch service {
+		case "github":
+			m.domains["api.github.com"] = true
+			m.domains["github.com"] = true
+		case "gitlab":
+			host := config.GitLabHost
+			if host == "" {
+				host = "gitlab.com"
+			}
+			m.domains[host] = true
+			// Mark gitlab for wildcard matching (handled in IsMITMDomain)
+		case "jira":
+			// Handled by wildcard matching in IsMITMDomain
+		}
+	}
+
+	// Add custom hosts from ToolConfigs
+	for _, tc := range config.ToolConfigs {
+		if tc.APIHost != "" {
+			m.domains[tc.APIHost] = true
+		}
+	}
+
+	return m, nil
+}
+
+func parsePrivateKey(der []byte) (crypto.PrivateKey, error) {
+	if key, err := x509.ParsePKCS8PrivateKey(der); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParseECPrivateKey(der); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return key, nil
+	}
+	return nil, fmt.Errorf("failed to parse private key")
+}
+
+// IsMITMDomain checks if a hostname should be MITM'd.
+func (m *MITMHandler) IsMITMDomain(hostname string) bool {
+	if m.domains[hostname] {
+		return true
+	}
+
+	// Wildcard matching for gitlab subdomains
+	if _, ok := m.config.Scope.Services["gitlab"]; ok {
+		if hostname == "gitlab.com" || strings.HasSuffix(hostname, ".gitlab.com") {
+			return true
+		}
+	}
+
+	// Wildcard matching for Jira/Atlassian
+	if _, ok := m.config.Scope.Services["jira"]; ok {
+		if strings.HasSuffix(hostname, ".atlassian.net") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HandleCONNECT performs MITM TLS interception on a CONNECT tunnel.
+func (m *MITMHandler) HandleCONNECT(w http.ResponseWriter, r *http.Request, targetHost string) {
+	hostname := hostOnly(targetHost)
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		log.Printf("gate: MITM hijack failed: %v", err)
+		return
+	}
+	defer clientConn.Close()
+
+	_, _ = clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+
+	// Get or create leaf cert for hostname
+	leafCert, err := m.certCache.GetOrCreate(hostname, m.caCert, m.caKey)
+	if err != nil {
+		log.Printf("gate: MITM cert generation failed for %s: %v", hostname, err)
+		return
+	}
+
+	// TLS handshake with the client using our leaf cert
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{*leafCert},
+		NextProtos:   []string{"http/1.1"},
+	}
+	tlsConn := tls.Server(clientConn, tlsConfig)
+	if err := tlsConn.Handshake(); err != nil {
+		log.Printf("gate: MITM TLS handshake failed for %s: %v", hostname, err)
+		return
+	}
+	defer tlsConn.Close()
+
+	// Read HTTP requests in a loop (keep-alive support)
+	reader := bufio.NewReader(tlsConn)
+	for {
+		req, err := http.ReadRequest(reader)
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("gate: MITM read request failed for %s: %v", hostname, err)
+			}
+			return
+		}
+
+		// Set the full URL for scope checking
+		req.URL.Scheme = "https"
+		req.URL.Host = hostname
+
+		m.handleMITMRequest(tlsConn, req, hostname, targetHost)
+	}
+}
+
+func (m *MITMHandler) handleMITMRequest(clientConn net.Conn, req *http.Request, hostname, targetHost string) {
+	// Check scope (skip enforcement in monitor mode)
+	result := CheckAccess(req.Method, req.URL.String(), m.config.Scope)
+	if !result.Allowed {
+		if m.config.EnforcementMode == "monitor" {
+			log.Printf("gate: MITM monitor: would deny %s %s: %s (allowing)", req.Method, req.URL.String(), result.Reason)
+		} else {
+			resp := &http.Response{
+				StatusCode: http.StatusForbidden,
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("Forbidden: " + result.Reason)),
+			}
+			resp.Header.Set("Content-Type", "text/plain")
+			_ = resp.Write(clientConn)
+			log.Printf("gate: MITM denied %s %s: %s", req.Method, req.URL.String(), result.Reason)
+			return
+		}
+	}
+
+	// Inject credentials
+	if err := m.injectMITMCredential(req, hostname); err != nil {
+		log.Printf("gate: MITM credential injection failed for %s: %v", hostname, err)
+	}
+
+	// Forward to real upstream over TLS
+	upstreamConn, err := tls.Dial("tcp", ensurePort(targetHost, "443"), &tls.Config{
+		ServerName: hostname,
+	})
+	if err != nil {
+		log.Printf("gate: MITM upstream dial failed for %s: %v", targetHost, err)
+		resp := &http.Response{
+			StatusCode: http.StatusBadGateway,
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("Bad Gateway")),
+		}
+		_ = resp.Write(clientConn)
+		return
+	}
+	defer upstreamConn.Close()
+
+	// Send the request to upstream
+	req.RequestURI = "" // Must be empty for client requests
+	upstreamURL := *req.URL
+	req.URL = &upstreamURL
+
+	if err := req.Write(upstreamConn); err != nil {
+		log.Printf("gate: MITM upstream write failed for %s: %v", targetHost, err)
+		return
+	}
+
+	// Read the response from upstream
+	upstreamReader := bufio.NewReader(upstreamConn)
+	resp, err := http.ReadResponse(upstreamReader, req)
+	if err != nil {
+		log.Printf("gate: MITM upstream response read failed for %s: %v", targetHost, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Forward response to client
+	if err := resp.Write(clientConn); err != nil {
+		log.Printf("gate: MITM response write failed for %s: %v", targetHost, err)
+		return
+	}
+}
+
+// injectMITMCredential injects real credentials into the request based on the
+// hostname and service configuration.
+func (m *MITMHandler) injectMITMCredential(req *http.Request, hostname string) error {
+	service := m.identifyServiceFromHost(hostname)
+	if service == "" {
+		return nil
+	}
+
+	// Check ToolConfigs first for custom credential injection
+	if tc, ok := m.config.ToolConfigs[service]; ok {
+		cred, ok := m.config.Credentials[service]
+		if !ok || cred == "" {
+			return nil
+		}
+		switch tc.AuthFormat {
+		case "bearer":
+			req.Header.Set(tc.AuthHeader, "Bearer "+cred)
+		case "header":
+			req.Header.Set(tc.AuthHeader, cred)
+		case "basic":
+			req.Header.Set(tc.AuthHeader, "Basic "+base64.StdEncoding.EncodeToString([]byte(cred)))
+		default:
+			req.Header.Set(tc.AuthHeader, "Bearer "+cred)
+		}
+		return nil
+	}
+
+	cred, ok := m.config.Credentials[service]
+	if !ok || cred == "" {
+		return nil
+	}
+
+	switch service {
+	case "github":
+		req.Header.Set("Authorization", "token "+cred)
+	case "gitlab":
+		req.Header.Set("Authorization", "Bearer "+cred)
+	case "jira":
+		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(cred)))
+	}
+
+	return nil
+}
+
+func (m *MITMHandler) identifyServiceFromHost(hostname string) string {
+	// Check ToolConfigs for matching API host
+	for name, tc := range m.config.ToolConfigs {
+		if tc.APIHost == hostname {
+			return name
+		}
+	}
+
+	switch {
+	case hostname == "api.github.com" || hostname == "github.com" || strings.HasSuffix(hostname, ".github.com"):
+		return "github"
+	case hostname == "gitlab.com" || strings.HasSuffix(hostname, ".gitlab.com"):
+		return "gitlab"
+	case strings.HasSuffix(hostname, ".atlassian.net"):
+		return "jira"
+	default:
+		return ""
+	}
+}
+
+// DecodePEMFromBase64 decodes base64-encoded PEM data, as used by the
+// GATE_CA_CERT_PEM and GATE_CA_KEY_PEM environment variables.
+func DecodePEMFromBase64(encoded string) ([]byte, error) {
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("base64 decode: %w", err)
+	}
+	return data, nil
+}
+
+// GenerateTestCA creates a self-signed CA certificate and key for testing.
+func GenerateTestCA() (certPEM, keyPEM []byte, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "Alcove Gate Test CA",
+		},
+		NotBefore:             time.Now().Add(-5 * time.Minute),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            1,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return certPEM, keyPEM, nil
+}

--- a/internal/gate/mitm_test.go
+++ b/internal/gate/mitm_test.go
@@ -1,0 +1,552 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gate
+
+import (
+	"bufio"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bmbouter/alcove/internal"
+)
+
+func mustGenerateTestCA(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+	certPEM, keyPEM, err := GenerateTestCA()
+	if err != nil {
+		t.Fatalf("generating test CA: %v", err)
+	}
+	return certPEM, keyPEM
+}
+
+// TestCertCacheGetOrCreate verifies leaf cert generation, hostname in SAN, and caching.
+func TestCertCacheGetOrCreate(t *testing.T) {
+	certPEM, keyPEM := mustGenerateTestCA(t)
+	cfg := &Config{
+		Scope: internal.Scope{
+			Services: map[string]internal.ServiceScope{
+				"github": {Repos: []string{"*"}, Operations: []string{"*"}},
+			},
+		},
+		Credentials: map[string]string{"github": "ghp_test"},
+		ToolConfigs: map[string]ToolConfig{},
+	}
+	m, err := NewMITMHandler(certPEM, keyPEM, cfg)
+	if err != nil {
+		t.Fatalf("creating MITM handler: %v", err)
+	}
+
+	cert1, err := m.certCache.GetOrCreate("api.github.com", m.caCert, m.caKey)
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+
+	// Verify hostname is in SAN
+	leaf := cert1.Leaf
+	if leaf == nil {
+		t.Fatal("leaf cert is nil")
+	}
+	found := false
+	for _, name := range leaf.DNSNames {
+		if name == "api.github.com" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected api.github.com in SAN, got %v", leaf.DNSNames)
+	}
+
+	// Verify CN
+	if leaf.Subject.CommonName != "api.github.com" {
+		t.Errorf("expected CN=api.github.com, got %q", leaf.Subject.CommonName)
+	}
+
+	// Second call should return cached cert
+	cert2, err := m.certCache.GetOrCreate("api.github.com", m.caCert, m.caKey)
+	if err != nil {
+		t.Fatalf("GetOrCreate (cached): %v", err)
+	}
+	if cert1 != cert2 {
+		t.Error("expected second call to return cached certificate")
+	}
+
+	// Different hostname should return different cert
+	cert3, err := m.certCache.GetOrCreate("github.com", m.caCert, m.caKey)
+	if err != nil {
+		t.Fatalf("GetOrCreate (different host): %v", err)
+	}
+	if cert1 == cert3 {
+		t.Error("expected different cert for different hostname")
+	}
+}
+
+// TestCertCacheEviction verifies oldest entries are evicted at capacity.
+func TestCertCacheEviction(t *testing.T) {
+	certPEM, keyPEM := mustGenerateTestCA(t)
+	cfg := &Config{
+		Scope: internal.Scope{
+			Services: map[string]internal.ServiceScope{
+				"github": {Repos: []string{"*"}, Operations: []string{"*"}},
+			},
+		},
+		Credentials: map[string]string{},
+		ToolConfigs: map[string]ToolConfig{},
+	}
+	m, err := NewMITMHandler(certPEM, keyPEM, cfg)
+	if err != nil {
+		t.Fatalf("creating MITM handler: %v", err)
+	}
+
+	// Fill cache to capacity
+	for i := 0; i < certCacheMaxSize; i++ {
+		hostname := fmt.Sprintf("host%d.example.com", i)
+		_, err := m.certCache.GetOrCreate(hostname, m.caCert, m.caKey)
+		if err != nil {
+			t.Fatalf("GetOrCreate for %s: %v", hostname, err)
+		}
+	}
+
+	if m.certCache.len() != certCacheMaxSize {
+		t.Fatalf("expected cache size %d, got %d", certCacheMaxSize, m.certCache.len())
+	}
+
+	// Add one more — should evict host0.example.com
+	_, err = m.certCache.GetOrCreate("overflow.example.com", m.caCert, m.caKey)
+	if err != nil {
+		t.Fatalf("GetOrCreate for overflow: %v", err)
+	}
+
+	if m.certCache.len() != certCacheMaxSize {
+		t.Fatalf("expected cache size %d after eviction, got %d", certCacheMaxSize, m.certCache.len())
+	}
+
+	// Verify host0 was evicted
+	m.certCache.mu.Lock()
+	_, exists := m.certCache.entries["host0.example.com"]
+	m.certCache.mu.Unlock()
+	if exists {
+		t.Error("expected host0.example.com to be evicted")
+	}
+
+	// Verify overflow exists
+	m.certCache.mu.Lock()
+	_, exists = m.certCache.entries["overflow.example.com"]
+	m.certCache.mu.Unlock()
+	if !exists {
+		t.Error("expected overflow.example.com to be in cache")
+	}
+}
+
+// TestMITMHandler_IsMITMDomain tests domain matching.
+func TestMITMHandler_IsMITMDomain(t *testing.T) {
+	certPEM, keyPEM := mustGenerateTestCA(t)
+	cfg := &Config{
+		Scope: internal.Scope{
+			Services: map[string]internal.ServiceScope{
+				"github": {Repos: []string{"*"}, Operations: []string{"*"}},
+				"gitlab": {Repos: []string{"*"}, Operations: []string{"*"}},
+				"jira":   {Repos: []string{"*"}, Operations: []string{"*"}},
+			},
+		},
+		Credentials: map[string]string{},
+		ToolConfigs: map[string]ToolConfig{
+			"custom": {APIHost: "custom-api.example.com"},
+		},
+	}
+	m, err := NewMITMHandler(certPEM, keyPEM, cfg)
+	if err != nil {
+		t.Fatalf("creating MITM handler: %v", err)
+	}
+
+	tests := []struct {
+		hostname string
+		expected bool
+	}{
+		{"api.github.com", true},
+		{"github.com", true},
+		{"gitlab.com", true},
+		{"ci.gitlab.com", true},
+		{"company.atlassian.net", true},
+		{"other.atlassian.net", true},
+		{"custom-api.example.com", true},
+		{"api.anthropic.com", false},
+		{"pypi.org", false},
+		{"random.example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hostname, func(t *testing.T) {
+			got := m.IsMITMDomain(tt.hostname)
+			if got != tt.expected {
+				t.Errorf("IsMITMDomain(%q) = %v, want %v", tt.hostname, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestMITMHandler_IsMITMDomain_NoServices verifies that with no services in scope,
+// no domains are MITM-eligible.
+func TestMITMHandler_IsMITMDomain_NoServices(t *testing.T) {
+	certPEM, keyPEM := mustGenerateTestCA(t)
+	cfg := &Config{
+		Scope:       internal.Scope{Services: map[string]internal.ServiceScope{}},
+		Credentials: map[string]string{},
+		ToolConfigs: map[string]ToolConfig{},
+	}
+	m, err := NewMITMHandler(certPEM, keyPEM, cfg)
+	if err != nil {
+		t.Fatalf("creating MITM handler: %v", err)
+	}
+
+	if m.IsMITMDomain("api.github.com") {
+		t.Error("expected api.github.com to NOT be MITM'd with no services in scope")
+	}
+	if m.IsMITMDomain("company.atlassian.net") {
+		t.Error("expected company.atlassian.net to NOT be MITM'd with no services in scope")
+	}
+}
+
+// TestMITMHandler_HandleCONNECT tests the full MITM round-trip: CONNECT, TLS
+// handshake, HTTP request, credential injection, and response forwarding.
+func TestMITMHandler_HandleCONNECT(t *testing.T) {
+	certPEM, keyPEM := mustGenerateTestCA(t)
+
+	cfg := Config{
+		SessionID: "test-session",
+		Scope: internal.Scope{
+			Services: map[string]internal.ServiceScope{
+				"github": {Repos: []string{"*"}, Operations: []string{"*"}},
+			},
+		},
+		Credentials: map[string]string{"github": "ghp_real_secret"},
+		ToolConfigs: map[string]ToolConfig{},
+		CACertPEM:   certPEM,
+		CAKeyPEM:    keyPEM,
+	}
+	p := NewProxy(cfg)
+	ts := httptest.NewServer(p.Handler())
+	defer ts.Close()
+	defer p.Stop()
+
+	// Connect to Gate proxy
+	conn, err := net.Dial("tcp", strings.TrimPrefix(ts.URL, "http://"))
+	if err != nil {
+		t.Fatalf("connecting to gate: %v", err)
+	}
+	defer conn.Close()
+
+	// Send CONNECT
+	fmt.Fprintf(conn, "CONNECT api.github.com:443 HTTP/1.1\r\nHost: api.github.com:443\r\n\r\n")
+
+	// Read the "200 Connection Established" response
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatalf("reading CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from CONNECT, got %d", resp.StatusCode)
+	}
+
+	// TLS handshake with the MITM cert
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(certPEM)
+
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName: "api.github.com",
+		RootCAs:    caPool,
+		NextProtos: []string{"http/1.1"},
+	})
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake with MITM: %v", err)
+	}
+
+	// Send an HTTP request through the MITM'd connection
+	req, _ := http.NewRequest("GET", "https://api.github.com/repos/test/repo/pulls", nil)
+	req.Header.Set("Authorization", "Bearer dummy-token")
+	if err := req.Write(tlsConn); err != nil {
+		t.Fatalf("writing request through MITM: %v", err)
+	}
+
+	// Read the response. The upstream may fail (real GitHub) but the MITM
+	// handshake and request forwarding should succeed.
+	mitmReader := bufio.NewReader(tlsConn)
+	mitmResp, err := http.ReadResponse(mitmReader, req)
+	if err != nil {
+		// Upstream connection failure is acceptable — the MITM part worked
+		t.Logf("response read error (expected if no real upstream): %v", err)
+		return
+	}
+	defer mitmResp.Body.Close()
+	t.Logf("MITM response status: %d", mitmResp.StatusCode)
+}
+
+// TestMITMHandler_ScopeEnforcement verifies that out-of-scope requests get 403
+// through the MITM proxy.
+func TestMITMHandler_ScopeEnforcement(t *testing.T) {
+	certPEM, keyPEM := mustGenerateTestCA(t)
+
+	cfg := Config{
+		SessionID: "test-session",
+		Scope: internal.Scope{
+			Services: map[string]internal.ServiceScope{
+				"github": {Repos: []string{"allowed/repo"}, Operations: []string{"read_prs"}},
+			},
+		},
+		Credentials: map[string]string{"github": "ghp_real_secret"},
+		ToolConfigs: map[string]ToolConfig{},
+		CACertPEM:   certPEM,
+		CAKeyPEM:    keyPEM,
+	}
+	p := NewProxy(cfg)
+	ts := httptest.NewServer(p.Handler())
+	defer ts.Close()
+	defer p.Stop()
+
+	conn, err := net.Dial("tcp", strings.TrimPrefix(ts.URL, "http://"))
+	if err != nil {
+		t.Fatalf("connecting to gate: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "CONNECT api.github.com:443 HTTP/1.1\r\nHost: api.github.com:443\r\n\r\n")
+
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatalf("reading CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from CONNECT, got %d", resp.StatusCode)
+	}
+
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(certPEM)
+
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName: "api.github.com",
+		RootCAs:    caPool,
+		NextProtos: []string{"http/1.1"},
+	})
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake: %v", err)
+	}
+
+	// Request for a repo NOT in scope
+	req, _ := http.NewRequest("GET", "https://api.github.com/repos/evil/exfiltrate/pulls", nil)
+	if err := req.Write(tlsConn); err != nil {
+		t.Fatalf("writing request: %v", err)
+	}
+
+	mitmReader := bufio.NewReader(tlsConn)
+	mitmResp, err := http.ReadResponse(mitmReader, req)
+	if err != nil {
+		t.Fatalf("reading MITM response: %v", err)
+	}
+	defer mitmResp.Body.Close()
+
+	if mitmResp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(mitmResp.Body)
+		t.Errorf("expected 403 for out-of-scope repo, got %d: %s", mitmResp.StatusCode, string(body))
+	}
+}
+
+func TestMITMHandler_MonitorMode(t *testing.T) {
+	certPEM, keyPEM := mustGenerateTestCA(t)
+
+	cfg := Config{
+		SessionID: "test-session",
+		Scope: internal.Scope{
+			Services: map[string]internal.ServiceScope{
+				"github": {Repos: []string{"allowed/repo"}, Operations: []string{"read_prs"}},
+			},
+		},
+		Credentials:     map[string]string{"github": "ghp_real_secret"},
+		ToolConfigs:     map[string]ToolConfig{},
+		CACertPEM:       certPEM,
+		CAKeyPEM:        keyPEM,
+		EnforcementMode: "monitor",
+	}
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "upstream-ok")
+	}))
+	defer upstream.Close()
+
+	p := NewProxy(cfg)
+	ts := httptest.NewServer(p.Handler())
+	defer ts.Close()
+	defer p.Stop()
+
+	conn, err := net.Dial("tcp", strings.TrimPrefix(ts.URL, "http://"))
+	if err != nil {
+		t.Fatalf("connecting to gate: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "CONNECT api.github.com:443 HTTP/1.1\r\nHost: api.github.com:443\r\n\r\n")
+
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatalf("reading CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from CONNECT, got %d", resp.StatusCode)
+	}
+
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(certPEM)
+
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName: "api.github.com",
+		RootCAs:    caPool,
+		NextProtos: []string{"http/1.1"},
+	})
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake: %v", err)
+	}
+
+	// Request for a repo NOT in scope — should be allowed in monitor mode
+	req, _ := http.NewRequest("GET", "https://api.github.com/repos/evil/exfiltrate/pulls", nil)
+	if err := req.Write(tlsConn); err != nil {
+		t.Fatalf("writing request: %v", err)
+	}
+
+	mitmReader := bufio.NewReader(tlsConn)
+	mitmResp, err := http.ReadResponse(mitmReader, req)
+	if err != nil {
+		t.Fatalf("reading MITM response: %v", err)
+	}
+	defer mitmResp.Body.Close()
+
+	if mitmResp.StatusCode == http.StatusForbidden {
+		t.Errorf("monitor mode should allow out-of-scope requests, got 403")
+	}
+}
+
+// TestMITMHandler_CredentialInjection verifies that MITM correctly maps
+// hostnames to services and injects the right credential format.
+func TestMITMHandler_CredentialInjection(t *testing.T) {
+	certPEM, keyPEM := mustGenerateTestCA(t)
+	cfg := &Config{
+		Scope: internal.Scope{
+			Services: map[string]internal.ServiceScope{
+				"github": {Repos: []string{"*"}, Operations: []string{"*"}},
+				"gitlab": {Repos: []string{"*"}, Operations: []string{"*"}},
+				"jira":   {Repos: []string{"*"}, Operations: []string{"*"}},
+			},
+		},
+		Credentials: map[string]string{
+			"github": "ghp_github_token",
+			"gitlab": "glpat_gitlab_token",
+			"jira":   "user@example.com:jira-api-token",
+		},
+		ToolConfigs: map[string]ToolConfig{},
+	}
+	m, err := NewMITMHandler(certPEM, keyPEM, cfg)
+	if err != nil {
+		t.Fatalf("creating MITM handler: %v", err)
+	}
+
+	tests := []struct {
+		hostname   string
+		wantHeader string
+		wantValue  string
+	}{
+		{"api.github.com", "Authorization", "token ghp_github_token"},
+		{"gitlab.com", "Authorization", "Bearer glpat_gitlab_token"},
+		{"company.atlassian.net", "Authorization", "Basic " + base64.StdEncoding.EncodeToString([]byte("user@example.com:jira-api-token"))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hostname, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "https://"+tt.hostname+"/test", nil)
+			if err := m.injectMITMCredential(req, tt.hostname); err != nil {
+				t.Fatalf("injectMITMCredential: %v", err)
+			}
+			got := req.Header.Get(tt.wantHeader)
+			if got != tt.wantValue {
+				t.Errorf("expected %q=%q, got %q", tt.wantHeader, tt.wantValue, got)
+			}
+		})
+	}
+}
+
+// TestMITMHandler_CredentialInjection_ToolConfig verifies that ToolConfig
+// overrides are used when available.
+func TestMITMHandler_CredentialInjection_ToolConfig(t *testing.T) {
+	certPEM, keyPEM := mustGenerateTestCA(t)
+	cfg := &Config{
+		Scope: internal.Scope{
+			Services: map[string]internal.ServiceScope{
+				"custom": {Repos: []string{"*"}, Operations: []string{"*"}},
+			},
+		},
+		Credentials: map[string]string{
+			"custom": "custom-secret-key",
+		},
+		ToolConfigs: map[string]ToolConfig{
+			"custom": {
+				APIHost:    "api.custom.example.com",
+				AuthHeader: "X-Custom-Auth",
+				AuthFormat: "header",
+			},
+		},
+	}
+	m, err := NewMITMHandler(certPEM, keyPEM, cfg)
+	if err != nil {
+		t.Fatalf("creating MITM handler: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "https://api.custom.example.com/test", nil)
+	if err := m.injectMITMCredential(req, "api.custom.example.com"); err != nil {
+		t.Fatalf("injectMITMCredential: %v", err)
+	}
+
+	got := req.Header.Get("X-Custom-Auth")
+	if got != "custom-secret-key" {
+		t.Errorf("expected header format credential %q, got %q", "custom-secret-key", got)
+	}
+}
+
+// TestDecodePEMFromBase64 verifies base64 decoding of PEM data.
+func TestDecodePEMFromBase64(t *testing.T) {
+	certPEM, _, err := GenerateTestCA()
+	if err != nil {
+		t.Fatalf("generating CA: %v", err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(certPEM)
+
+	decoded, err := DecodePEMFromBase64(encoded)
+	if err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+
+	if string(decoded) != string(certPEM) {
+		t.Error("decoded PEM does not match original")
+	}
+}

--- a/internal/gate/proxy.go
+++ b/internal/gate/proxy.go
@@ -73,11 +73,15 @@ type Config struct {
 	VertexProject      string // Vertex AI project ID
 	LedgerURL          string
 	GitLabHost         string // self-hosted GitLab hostname (default: "gitlab.com")
+	CACertPEM          []byte // PEM-encoded CA certificate for MITM TLS interception
+	CAKeyPEM           []byte // PEM-encoded CA private key for MITM TLS interception
+	EnforcementMode    string // "monitor" = log-only, "" or "enforce" = enforce scope
 }
 
 // Proxy is the Gate authorization proxy.
 type Proxy struct {
-	config Config
+	config      Config
+	MITMHandler *MITMHandler
 
 	mu       sync.Mutex
 	logBuf   []internal.ProxyLogEntry
@@ -86,10 +90,22 @@ type Proxy struct {
 
 // NewProxy creates a new Gate proxy with the given configuration.
 func NewProxy(cfg Config) *Proxy {
-	return &Proxy{
+	p := &Proxy{
 		config:   cfg,
 		stopChan: make(chan struct{}),
 	}
+
+	if len(cfg.CACertPEM) > 0 && len(cfg.CAKeyPEM) > 0 {
+		m, err := NewMITMHandler(cfg.CACertPEM, cfg.CAKeyPEM, &p.config)
+		if err != nil {
+			log.Printf("gate: failed to initialize MITM handler: %v", err)
+		} else {
+			p.MITMHandler = m
+			log.Printf("gate: MITM mode enabled for service domains")
+		}
+	}
+
+	return p
 }
 
 // Handler returns an http.Handler that implements the Gate proxy.
@@ -107,26 +123,6 @@ func (p *Proxy) Handler() http.Handler {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "ok")
 	})
-
-	// Register dynamic tool proxy endpoints from ToolConfigs
-	for toolName := range p.config.ToolConfigs {
-		name := toolName // capture for closure
-		mux.HandleFunc("/"+name+"/", func(w http.ResponseWriter, r *http.Request) {
-			p.handleSCMProxy(w, r, name)
-		})
-	}
-
-	// Keep hardcoded /github/ and /gitlab/ as fallbacks if not in ToolConfigs
-	if _, ok := p.config.ToolConfigs["github"]; !ok {
-		mux.HandleFunc("/github/", func(w http.ResponseWriter, r *http.Request) {
-			p.handleSCMProxy(w, r, "github")
-		})
-	}
-	if _, ok := p.config.ToolConfigs["gitlab"]; !ok {
-		mux.HandleFunc("/gitlab/", func(w http.ResponseWriter, r *http.Request) {
-			p.handleSCMProxy(w, r, "gitlab")
-		})
-	}
 
 	// LLM API proxy -- handles requests when ANTHROPIC_BASE_URL or similar
 	// is set to http://localhost:8443. These arrive as normal HTTP requests
@@ -176,17 +172,11 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 
 	hostname := hostOnly(host)
 
-	// Determine request category
 	switch {
 	case isLLMHost(hostname):
 		p.tunnelToLLM(w, r, host)
-	case hostname == "api.github.com":
-		// Block CONNECT tunnels to api.github.com -- API operations must go
-		// through the /github/ proxy endpoint for operation-level enforcement.
-		http.Error(w, "Forbidden: use /github/ proxy endpoint for API calls", http.StatusForbidden)
-		p.logEntry("CONNECT", host, "github", "", "deny", http.StatusForbidden)
-	case isServiceHost(hostname):
-		p.tunnelToService(w, r, host, hostname)
+	case p.MITMHandler != nil && p.MITMHandler.IsMITMDomain(hostname):
+		p.MITMHandler.HandleCONNECT(w, r, host)
 	case isDomainAllowed(hostname):
 		p.tunnelDirect(w, r, host)
 		p.logEntry("CONNECT", host, "allowlist", "passthrough", "allow", http.StatusOK)
@@ -206,7 +196,8 @@ func (p *Proxy) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if isServiceHost(hostname) {
-		p.handleServiceForward(w, r)
+		http.Error(w, "Forbidden: use HTTPS (CONNECT) for service API calls", http.StatusForbidden)
+		p.logEntry(r.Method, r.URL.String(), identifyService(hostname), "", "deny", http.StatusForbidden)
 		return
 	}
 
@@ -407,101 +398,6 @@ func (p *Proxy) handleLLMForward(w http.ResponseWriter, r *http.Request) {
 	p.logEntry(r.Method, r.URL.String(), "llm", p.config.LLMProvider, "allow", http.StatusOK)
 }
 
-// handleServiceForward handles service API requests arriving as plain HTTP proxy requests.
-func (p *Proxy) handleServiceForward(w http.ResponseWriter, r *http.Request) {
-	result := CheckAccess(r.Method, r.URL.String(), p.config.Scope)
-	if !result.Allowed {
-		http.Error(w, "Forbidden: "+result.Reason, http.StatusForbidden)
-		p.logEntry(r.Method, r.URL.String(), result.Service, result.Operation, "deny", http.StatusForbidden)
-		return
-	}
-
-	proxy := &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL = r.URL
-			req.Host = r.URL.Host
-			p.injectServiceCredential(req, result.Service)
-		},
-	}
-	proxy.ServeHTTP(w, r)
-	p.logEntry(r.Method, r.URL.String(), result.Service, result.Operation, "allow", http.StatusOK)
-}
-
-// handleSCMProxy handles API calls arriving at proxy endpoints like /github/,
-// /gitlab/, or any dynamically registered tool endpoint. It strips the service
-// prefix, checks access against the scope, injects real credentials, and
-// reverse-proxies to the real API.
-func (p *Proxy) handleSCMProxy(w http.ResponseWriter, r *http.Request, service string) {
-	prefix := "/" + service + "/"
-	apiPath := strings.TrimPrefix(r.URL.Path, prefix)
-	if apiPath == "" {
-		apiPath = "/"
-	}
-
-	// Look up tool config for target host and auth settings
-	var targetHost, authHeader, authFormat string
-	if tc, ok := p.config.ToolConfigs[service]; ok {
-		targetHost = tc.APIHost
-		authHeader = tc.AuthHeader
-		authFormat = tc.AuthFormat
-	} else {
-		// Fallback to hardcoded defaults for backward compat
-		switch service {
-		case "github":
-			targetHost = "api.github.com"
-			authHeader = "Authorization"
-			authFormat = "bearer"
-		case "gitlab":
-			targetHost = p.config.GitLabHost
-			if targetHost == "" {
-				targetHost = "gitlab.com"
-			}
-			authHeader = "PRIVATE-TOKEN"
-			authFormat = "header"
-		default:
-			http.Error(w, "unknown tool: "+service, http.StatusNotFound)
-			return
-		}
-	}
-
-	fakeURL := fmt.Sprintf("https://%s/%s", targetHost, apiPath)
-	if r.URL.RawQuery != "" {
-		fakeURL += "?" + r.URL.RawQuery
-	}
-
-	// Use service-aware access check for services that may not be
-	// recognized by hostname in CheckAccess (e.g., Splunk on custom hosts).
-	var result AccessResult
-	switch service {
-	case "github", "gitlab", "jira":
-		result = CheckAccess(r.Method, fakeURL, p.config.Scope)
-	default:
-		parsedURL, parseErr := url.Parse(fakeURL)
-		if parseErr != nil {
-			result = AccessResult{Allowed: false, Reason: "invalid URL"}
-		} else {
-			result = CheckServiceAccess(r.Method, parsedURL.Path, service, p.config.Scope)
-		}
-	}
-	if !result.Allowed {
-		http.Error(w, "Forbidden: "+result.Reason, http.StatusForbidden)
-		p.logEntry(r.Method, fakeURL, result.Service, result.Operation, "deny", http.StatusForbidden)
-		return
-	}
-
-	targetURL, _ := url.Parse(fakeURL)
-
-	proxy := &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL = targetURL
-			req.Host = targetHost
-			p.injectToolCredential(req, service, authHeader, authFormat)
-		},
-		FlushInterval: -1,
-	}
-	proxy.ServeHTTP(w, r)
-	p.logEntry(r.Method, fakeURL, result.Service, result.Operation, "allow", http.StatusOK)
-}
 
 // tunnelToLLM handles CONNECT tunnels for LLM API hosts.
 // Since the design prefers ANTHROPIC_BASE_URL=http://localhost:8443 for
@@ -536,42 +432,6 @@ func (p *Proxy) tunnelToLLM(w http.ResponseWriter, r *http.Request, targetHost s
 	bidirectionalCopy(clientConn, clientBuf, upstreamConn)
 }
 
-// tunnelToService handles CONNECT tunnels for service APIs (GitHub, GitLab, etc.).
-// CONNECT tunnels only allow domain-level enforcement since we cannot inspect
-// or modify the encrypted payload without MITM TLS.
-func (p *Proxy) tunnelToService(w http.ResponseWriter, r *http.Request, targetHost, hostname string) {
-	service := identifyService(hostname)
-	if _, ok := p.config.Scope.Services[service]; !ok {
-		http.Error(w, "Forbidden: service not in scope", http.StatusForbidden)
-		p.logEntry("CONNECT", targetHost, service, "", "deny", http.StatusForbidden)
-		return
-	}
-
-	hijacker, ok := w.(http.Hijacker)
-	if !ok {
-		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
-		return
-	}
-
-	clientConn, clientBuf, err := hijacker.Hijack()
-	if err != nil {
-		log.Printf("gate: hijack failed: %v", err)
-		return
-	}
-	defer clientConn.Close()
-
-	upstreamConn, err := net.DialTimeout("tcp", ensurePort(targetHost, "443"), 10*time.Second)
-	if err != nil {
-		log.Printf("gate: upstream dial failed for %s: %v", targetHost, err)
-		return
-	}
-	defer upstreamConn.Close()
-
-	_, _ = clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
-
-	p.logEntry("CONNECT", targetHost, service, "tunnel", "allow", http.StatusOK)
-	bidirectionalCopy(clientConn, clientBuf, upstreamConn)
-}
 
 // tunnelDirect creates a passthrough tunnel for allowed domains.
 func (p *Proxy) tunnelDirect(w http.ResponseWriter, r *http.Request, targetHost string) {

--- a/internal/gate/proxy_test.go
+++ b/internal/gate/proxy_test.go
@@ -15,8 +15,13 @@
 package gate
 
 import (
+	"bufio"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -30,7 +35,7 @@ import (
 // --------------------------------------------------------------------
 
 // newTestProxy creates a Gate proxy configured with the given scope and
-// credentials.  It returns the proxy and a test HTTP server bound to it.
+// credentials. It returns the proxy and a test HTTP server bound to it.
 func newTestProxy(t *testing.T, scope internal.Scope, creds map[string]string) (*Proxy, *httptest.Server) {
 	t.Helper()
 	cfg := Config{
@@ -47,6 +52,31 @@ func newTestProxy(t *testing.T, scope internal.Scope, creds map[string]string) (
 	ts := httptest.NewServer(p.Handler())
 	t.Cleanup(func() { ts.Close(); p.Stop() })
 	return p, ts
+}
+
+// newTestProxyWithMITM creates a Gate proxy with MITM enabled.
+func newTestProxyWithMITM(t *testing.T, scope internal.Scope, creds map[string]string) (*Proxy, *httptest.Server, []byte) {
+	t.Helper()
+	certPEM, keyPEM, err := GenerateTestCA()
+	if err != nil {
+		t.Fatalf("generating test CA: %v", err)
+	}
+	cfg := Config{
+		SessionID:    "test-session",
+		Scope:        scope,
+		Credentials:  creds,
+		ToolConfigs:  map[string]ToolConfig{},
+		SessionToken: "session-tok",
+		LLMToken:     "llm-secret-key",
+		LLMProvider:  "anthropic",
+		LLMTokenType: "api_key",
+		CACertPEM:    certPEM,
+		CAKeyPEM:     keyPEM,
+	}
+	p := NewProxy(cfg)
+	ts := httptest.NewServer(p.Handler())
+	t.Cleanup(func() { ts.Close(); p.Stop() })
+	return p, ts, certPEM
 }
 
 // doRequest sends a request to the test server and returns the status code
@@ -73,8 +103,58 @@ func doRequest(t *testing.T, method, url string, body string) (int, string) {
 	return resp.StatusCode, string(respBody)
 }
 
+// doMITMRequest sends a request through the MITM proxy via CONNECT tunnel.
+// Returns the HTTP response status code, response body, and any error.
+func doMITMRequest(t *testing.T, proxyAddr string, caCertPEM []byte, method, targetHost, path string) (int, string) {
+	t.Helper()
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("connecting to gate: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n\r\n", targetHost, targetHost)
+
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatalf("reading CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from CONNECT, got %d", resp.StatusCode)
+	}
+
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(caCertPEM)
+
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName: targetHost,
+		RootCAs:    caPool,
+		NextProtos: []string{"http/1.1"},
+	})
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake: %v", err)
+	}
+
+	req, _ := http.NewRequest(method, "https://"+targetHost+path, nil)
+	if err := req.Write(tlsConn); err != nil {
+		t.Fatalf("writing request: %v", err)
+	}
+
+	mitmReader := bufio.NewReader(tlsConn)
+	mitmResp, err := http.ReadResponse(mitmReader, req)
+	if err != nil {
+		t.Fatalf("reading MITM response: %v", err)
+	}
+	defer mitmResp.Body.Close()
+
+	body, _ := io.ReadAll(mitmResp.Body)
+	return mitmResp.StatusCode, string(body)
+}
+
 // --------------------------------------------------------------------
-// Category 1: Scope enforcement — GitHub
+// Category 1: Scope enforcement — GitHub (via CheckAccess)
 // --------------------------------------------------------------------
 
 // githubScope returns a scope allowing github with the specified repos and operations.
@@ -91,28 +171,27 @@ func TestGitHubScopeEnforcement_AllowedOperations(t *testing.T) {
 		[]string{"pulp/pulpcore"},
 		[]string{"read_prs", "create_pr_draft", "read_contents", "read_issues", "read_commits"},
 	)
-	_, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_real_token"})
 
 	tests := []struct {
 		name   string
 		method string
-		path   string
+		url    string
 	}{
-		{"read PRs", "GET", "/github/repos/pulp/pulpcore/pulls"},
-		{"read single PR", "GET", "/github/repos/pulp/pulpcore/pulls/42"},
-		{"create draft PR", "POST", "/github/repos/pulp/pulpcore/pulls"},
-		{"read file contents", "GET", "/github/repos/pulp/pulpcore/contents/README.md"},
-		{"read nested contents", "GET", "/github/repos/pulp/pulpcore/contents/src/main.go"},
-		{"read issues", "GET", "/github/repos/pulp/pulpcore/issues"},
-		{"read single issue", "GET", "/github/repos/pulp/pulpcore/issues/7"},
-		{"read commits", "GET", "/github/repos/pulp/pulpcore/commits"},
+		{"read PRs", "GET", "https://api.github.com/repos/pulp/pulpcore/pulls"},
+		{"read single PR", "GET", "https://api.github.com/repos/pulp/pulpcore/pulls/42"},
+		{"create draft PR", "POST", "https://api.github.com/repos/pulp/pulpcore/pulls"},
+		{"read file contents", "GET", "https://api.github.com/repos/pulp/pulpcore/contents/README.md"},
+		{"read nested contents", "GET", "https://api.github.com/repos/pulp/pulpcore/contents/src/main.go"},
+		{"read issues", "GET", "https://api.github.com/repos/pulp/pulpcore/issues"},
+		{"read single issue", "GET", "https://api.github.com/repos/pulp/pulpcore/issues/7"},
+		{"read commits", "GET", "https://api.github.com/repos/pulp/pulpcore/commits"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code, body := doRequest(t, tt.method, ts.URL+tt.path, "")
-			if code == http.StatusForbidden {
-				t.Errorf("expected allowed (non-403) but got 403: %s", body)
+			result := CheckAccess(tt.method, tt.url, scope)
+			if !result.Allowed {
+				t.Errorf("expected allowed but got denied: %s", result.Reason)
 			}
 		})
 	}
@@ -123,28 +202,27 @@ func TestGitHubScopeEnforcement_DeniedOperations(t *testing.T) {
 		[]string{"pulp/pulpcore"},
 		[]string{"read_prs", "create_pr_draft", "read_contents"},
 	)
-	_, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_real_token"})
 
 	tests := []struct {
 		name   string
 		method string
-		path   string
+		url    string
 	}{
-		{"merge PR - op not in scope", "PUT", "/github/repos/pulp/pulpcore/pulls/1/merge"},
-		{"delete branch - op not in scope", "DELETE", "/github/repos/pulp/pulpcore/git/refs/heads/my-branch"},
-		{"create issue - op not in scope", "POST", "/github/repos/pulp/pulpcore/issues"},
-		{"update PR - op not in scope", "PATCH", "/github/repos/pulp/pulpcore/pulls/5"},
-		{"write contents - op not in scope", "PUT", "/github/repos/pulp/pulpcore/contents/file.txt"},
-		{"create review - op not in scope", "POST", "/github/repos/pulp/pulpcore/pulls/3/reviews"},
-		{"create comment - op not in scope", "POST", "/github/repos/pulp/pulpcore/issues/1/comments"},
-		{"write actions - op not in scope", "POST", "/github/repos/pulp/pulpcore/actions/workflows/ci.yml/dispatches"},
+		{"merge PR - op not in scope", "PUT", "https://api.github.com/repos/pulp/pulpcore/pulls/1/merge"},
+		{"delete branch - op not in scope", "DELETE", "https://api.github.com/repos/pulp/pulpcore/git/refs/heads/my-branch"},
+		{"create issue - op not in scope", "POST", "https://api.github.com/repos/pulp/pulpcore/issues"},
+		{"update PR - op not in scope", "PATCH", "https://api.github.com/repos/pulp/pulpcore/pulls/5"},
+		{"write contents - op not in scope", "PUT", "https://api.github.com/repos/pulp/pulpcore/contents/file.txt"},
+		{"create review - op not in scope", "POST", "https://api.github.com/repos/pulp/pulpcore/pulls/3/reviews"},
+		{"create comment - op not in scope", "POST", "https://api.github.com/repos/pulp/pulpcore/issues/1/comments"},
+		{"write actions - op not in scope", "POST", "https://api.github.com/repos/pulp/pulpcore/actions/workflows/ci.yml/dispatches"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code, _ := doRequest(t, tt.method, ts.URL+tt.path, "")
-			if code != http.StatusForbidden {
-				t.Errorf("expected 403 Forbidden but got %d", code)
+			result := CheckAccess(tt.method, tt.url, scope)
+			if result.Allowed {
+				t.Errorf("expected denied but got allowed")
 			}
 		})
 	}
@@ -155,26 +233,24 @@ func TestGitHubScopeEnforcement_RepoNotInScope(t *testing.T) {
 		[]string{"pulp/pulpcore"},
 		[]string{"read_prs", "read_contents", "read_issues", "create_pr_draft"},
 	)
-	_, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_real_token"})
 
-	// Every operation on a repo NOT in scope should be denied, even read operations.
 	tests := []struct {
 		name   string
 		method string
-		path   string
+		url    string
 	}{
-		{"read PRs - wrong repo", "GET", "/github/repos/other/repo/pulls"},
-		{"read contents - wrong repo", "GET", "/github/repos/other/repo/contents/README.md"},
-		{"create PR - wrong repo", "POST", "/github/repos/other/repo/pulls"},
-		{"read issues - wrong repo", "GET", "/github/repos/evil/exfiltrate/issues"},
-		{"read PRs - wrong org", "GET", "/github/repos/notpulp/pulpcore/pulls"},
+		{"read PRs - wrong repo", "GET", "https://api.github.com/repos/other/repo/pulls"},
+		{"read contents - wrong repo", "GET", "https://api.github.com/repos/other/repo/contents/README.md"},
+		{"create PR - wrong repo", "POST", "https://api.github.com/repos/other/repo/pulls"},
+		{"read issues - wrong repo", "GET", "https://api.github.com/repos/evil/exfiltrate/issues"},
+		{"read PRs - wrong org", "GET", "https://api.github.com/repos/notpulp/pulpcore/pulls"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code, _ := doRequest(t, tt.method, ts.URL+tt.path, "")
-			if code != http.StatusForbidden {
-				t.Errorf("expected 403 Forbidden but got %d", code)
+			result := CheckAccess(tt.method, tt.url, scope)
+			if result.Allowed {
+				t.Errorf("expected denied but got allowed")
 			}
 		})
 	}
@@ -185,23 +261,20 @@ func TestGitHubScopeEnforcement_OrgWildcard(t *testing.T) {
 		[]string{"pulp/*"},
 		[]string{"read_prs", "read_contents"},
 	)
-	_, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_real_token"})
 
-	// Allowed: any repo under pulp/
-	code, _ := doRequest(t, "GET", ts.URL+"/github/repos/pulp/pulpcore/pulls", "")
-	if code == http.StatusForbidden {
-		t.Errorf("expected allowed for pulp/pulpcore with pulp/* wildcard, got 403")
+	result := CheckAccess("GET", "https://api.github.com/repos/pulp/pulpcore/pulls", scope)
+	if !result.Allowed {
+		t.Errorf("expected allowed for pulp/pulpcore with pulp/* wildcard")
 	}
 
-	code, _ = doRequest(t, "GET", ts.URL+"/github/repos/pulp/other-repo/pulls", "")
-	if code == http.StatusForbidden {
-		t.Errorf("expected allowed for pulp/other-repo with pulp/* wildcard, got 403")
+	result = CheckAccess("GET", "https://api.github.com/repos/pulp/other-repo/pulls", scope)
+	if !result.Allowed {
+		t.Errorf("expected allowed for pulp/other-repo with pulp/* wildcard")
 	}
 
-	// Denied: repo under a different org
-	code, _ = doRequest(t, "GET", ts.URL+"/github/repos/evil/repo/pulls", "")
-	if code != http.StatusForbidden {
-		t.Errorf("expected 403 for evil/repo with pulp/* wildcard, got %d", code)
+	result = CheckAccess("GET", "https://api.github.com/repos/evil/repo/pulls", scope)
+	if result.Allowed {
+		t.Errorf("expected denied for evil/repo with pulp/* wildcard")
 	}
 }
 
@@ -210,18 +283,15 @@ func TestGitHubScopeEnforcement_RepoWildcard(t *testing.T) {
 		[]string{"*"},
 		[]string{"read_prs"},
 	)
-	_, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_real_token"})
 
-	// "*" wildcard should allow any repo
-	code, _ := doRequest(t, "GET", ts.URL+"/github/repos/any/repo/pulls", "")
-	if code == http.StatusForbidden {
-		t.Errorf("expected allowed for any/repo with * wildcard, got 403")
+	result := CheckAccess("GET", "https://api.github.com/repos/any/repo/pulls", scope)
+	if !result.Allowed {
+		t.Errorf("expected allowed for any/repo with * wildcard")
 	}
 
-	// But operations not in scope should still be denied
-	code, _ = doRequest(t, "PUT", ts.URL+"/github/repos/any/repo/pulls/1/merge", "")
-	if code != http.StatusForbidden {
-		t.Errorf("expected 403 for merge_pr not in scope, got %d", code)
+	result = CheckAccess("PUT", "https://api.github.com/repos/any/repo/pulls/1/merge", scope)
+	if result.Allowed {
+		t.Errorf("expected denied for merge_pr not in scope")
 	}
 }
 
@@ -230,64 +300,58 @@ func TestGitHubScopeEnforcement_OperationWildcard(t *testing.T) {
 		[]string{"pulp/pulpcore"},
 		[]string{"*"},
 	)
-	_, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_real_token"})
 
-	// "*" operation wildcard should allow everything on the allowed repo
 	tests := []struct {
 		name   string
 		method string
-		path   string
+		url    string
 	}{
-		{"read PRs", "GET", "/github/repos/pulp/pulpcore/pulls"},
-		{"merge PR", "PUT", "/github/repos/pulp/pulpcore/pulls/1/merge"},
-		{"delete branch", "DELETE", "/github/repos/pulp/pulpcore/git/refs/heads/branch"},
-		{"create issue", "POST", "/github/repos/pulp/pulpcore/issues"},
+		{"read PRs", "GET", "https://api.github.com/repos/pulp/pulpcore/pulls"},
+		{"merge PR", "PUT", "https://api.github.com/repos/pulp/pulpcore/pulls/1/merge"},
+		{"delete branch", "DELETE", "https://api.github.com/repos/pulp/pulpcore/git/refs/heads/branch"},
+		{"create issue", "POST", "https://api.github.com/repos/pulp/pulpcore/issues"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code, body := doRequest(t, tt.method, ts.URL+tt.path, "")
-			if code == http.StatusForbidden {
-				t.Errorf("expected allowed with * operation wildcard but got 403: %s", body)
+			result := CheckAccess(tt.method, tt.url, scope)
+			if !result.Allowed {
+				t.Errorf("expected allowed with * operation wildcard: %s", result.Reason)
 			}
 		})
 	}
 
 	// Still denied on wrong repo
-	code, _ := doRequest(t, "GET", ts.URL+"/github/repos/evil/repo/pulls", "")
-	if code != http.StatusForbidden {
-		t.Errorf("expected 403 for wrong repo even with * operations, got %d", code)
+	result := CheckAccess("GET", "https://api.github.com/repos/evil/repo/pulls", scope)
+	if result.Allowed {
+		t.Errorf("expected denied for wrong repo even with * operations")
 	}
 }
 
 func TestGitHubScopeEnforcement_ServiceNotInScope(t *testing.T) {
-	// Scope has gitlab but NOT github
 	scope := internal.Scope{
 		Services: map[string]internal.ServiceScope{
 			"gitlab": {Repos: []string{"*"}, Operations: []string{"*"}},
 		},
 	}
-	_, ts := newTestProxy(t, scope, map[string]string{"gitlab": "glpat_token"})
 
-	code, body := doRequest(t, "GET", ts.URL+"/github/repos/pulp/pulpcore/pulls", "")
-	if code != http.StatusForbidden {
-		t.Errorf("expected 403 when github not in scope, got %d: %s", code, body)
+	result := CheckAccess("GET", "https://api.github.com/repos/pulp/pulpcore/pulls", scope)
+	if result.Allowed {
+		t.Errorf("expected denied when github not in scope")
 	}
 }
 
 func TestGitHubScopeEnforcement_EmptyRepoList(t *testing.T) {
-	// Operations are allowed but no repos specified
 	scope := githubScope([]string{}, []string{"read_prs", "read_contents"})
-	_, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_real_token"})
 
-	code, _ := doRequest(t, "GET", ts.URL+"/github/repos/pulp/pulpcore/pulls", "")
-	if code != http.StatusForbidden {
-		t.Errorf("expected 403 with empty repo list, got %d", code)
+	result := CheckAccess("GET", "https://api.github.com/repos/pulp/pulpcore/pulls", scope)
+	if result.Allowed {
+		t.Errorf("expected denied with empty repo list")
 	}
 }
 
 // --------------------------------------------------------------------
-// Category 1: Scope enforcement — GitLab
+// Category 1: Scope enforcement — GitLab (via CheckAccess)
 // --------------------------------------------------------------------
 
 func gitlabScope(repos, ops []string) internal.Scope {
@@ -299,31 +363,28 @@ func gitlabScope(repos, ops []string) internal.Scope {
 }
 
 func TestGitLabScopeEnforcement_AllowedOperations(t *testing.T) {
-	// Use numeric project IDs to avoid %2F encoding issues where url.Parse
-	// decodes the slash, splitting the path segment and breaking project lookup.
 	scope := gitlabScope(
 		[]string{"12345"},
 		[]string{"read_prs", "create_pr_draft", "read_contents"},
 	)
-	_, ts := newTestProxy(t, scope, map[string]string{"gitlab": "glpat_real_token"})
 
 	tests := []struct {
 		name   string
 		method string
-		path   string
+		url    string
 	}{
-		{"read MRs", "GET", "/gitlab/api/v4/projects/12345/merge_requests"},
-		{"read single MR", "GET", "/gitlab/api/v4/projects/12345/merge_requests/1"},
-		{"create MR", "POST", "/gitlab/api/v4/projects/12345/merge_requests"},
-		{"read repo tree", "GET", "/gitlab/api/v4/projects/12345/repository/tree"},
-		{"read repo file", "GET", "/gitlab/api/v4/projects/12345/repository/files/README.md"},
+		{"read MRs", "GET", "https://gitlab.com/api/v4/projects/12345/merge_requests"},
+		{"read single MR", "GET", "https://gitlab.com/api/v4/projects/12345/merge_requests/1"},
+		{"create MR", "POST", "https://gitlab.com/api/v4/projects/12345/merge_requests"},
+		{"read repo tree", "GET", "https://gitlab.com/api/v4/projects/12345/repository/tree"},
+		{"read repo file", "GET", "https://gitlab.com/api/v4/projects/12345/repository/files/README.md"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code, body := doRequest(t, tt.method, ts.URL+tt.path, "")
-			if code == http.StatusForbidden {
-				t.Errorf("expected allowed (non-403) but got 403: %s", body)
+			result := CheckAccess(tt.method, tt.url, scope)
+			if !result.Allowed {
+				t.Errorf("expected allowed but got denied: %s", result.Reason)
 			}
 		})
 	}
@@ -334,24 +395,23 @@ func TestGitLabScopeEnforcement_DeniedOperations(t *testing.T) {
 		[]string{"12345"},
 		[]string{"read_prs", "read_contents"},
 	)
-	_, ts := newTestProxy(t, scope, map[string]string{"gitlab": "glpat_real_token"})
 
 	tests := []struct {
 		name   string
 		method string
-		path   string
+		url    string
 	}{
-		{"merge MR - not in scope", "PUT", "/gitlab/api/v4/projects/12345/merge_requests/1/merge"},
-		{"create MR - not in scope", "POST", "/gitlab/api/v4/projects/12345/merge_requests"},
-		{"delete branch - not in scope", "DELETE", "/gitlab/api/v4/projects/12345/repository/branches/feature"},
-		{"write file - not in scope", "POST", "/gitlab/api/v4/projects/12345/repository/files/new.txt"},
+		{"merge MR - not in scope", "PUT", "https://gitlab.com/api/v4/projects/12345/merge_requests/1/merge"},
+		{"create MR - not in scope", "POST", "https://gitlab.com/api/v4/projects/12345/merge_requests"},
+		{"delete branch - not in scope", "DELETE", "https://gitlab.com/api/v4/projects/12345/repository/branches/feature"},
+		{"write file - not in scope", "POST", "https://gitlab.com/api/v4/projects/12345/repository/files/new.txt"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code, _ := doRequest(t, tt.method, ts.URL+tt.path, "")
-			if code != http.StatusForbidden {
-				t.Errorf("expected 403 Forbidden but got %d", code)
+			result := CheckAccess(tt.method, tt.url, scope)
+			if result.Allowed {
+				t.Errorf("expected denied but got allowed")
 			}
 		})
 	}
@@ -362,21 +422,20 @@ func TestGitLabScopeEnforcement_ProjectNotInScope(t *testing.T) {
 		[]string{"mygroup/myproject"},
 		[]string{"read_prs", "read_contents", "create_pr_draft"},
 	)
-	_, ts := newTestProxy(t, scope, map[string]string{"gitlab": "glpat_real_token"})
 
 	tests := []struct {
 		name string
-		path string
+		url  string
 	}{
-		{"wrong project (encoded)", "/gitlab/api/v4/projects/evil%2Fproject/merge_requests"},
-		{"wrong project (numeric)", "/gitlab/api/v4/projects/99999/merge_requests"},
+		{"wrong project (encoded)", "https://gitlab.com/api/v4/projects/evil%2Fproject/merge_requests"},
+		{"wrong project (numeric)", "https://gitlab.com/api/v4/projects/99999/merge_requests"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code, _ := doRequest(t, "GET", ts.URL+tt.path, "")
-			if code != http.StatusForbidden {
-				t.Errorf("expected 403 Forbidden but got %d", code)
+			result := CheckAccess("GET", tt.url, scope)
+			if result.Allowed {
+				t.Errorf("expected denied but got allowed")
 			}
 		})
 	}
@@ -387,7 +446,6 @@ func TestGitLabScopeEnforcement_ProjectNotInScope(t *testing.T) {
 // --------------------------------------------------------------------
 
 func TestCredentialInjection_BearerFormat(t *testing.T) {
-	// Test that injectToolCredential correctly sets bearer-format auth headers.
 	p := &Proxy{config: Config{
 		Credentials: map[string]string{"github": "ghp_real_secret_123"},
 	}}
@@ -404,7 +462,6 @@ func TestCredentialInjection_BearerFormat(t *testing.T) {
 }
 
 func TestCredentialInjection_HeaderFormat(t *testing.T) {
-	// Test that injectToolCredential correctly sets header-format auth (e.g., GitLab PRIVATE-TOKEN).
 	p := &Proxy{config: Config{
 		Credentials: map[string]string{"gitlab": "glpat_secret_456"},
 	}}
@@ -434,8 +491,6 @@ func TestCredentialInjection_BasicFormat(t *testing.T) {
 }
 
 func TestCredentialInjection_DummyTokenNotForwarded(t *testing.T) {
-	// When credentials exist, the real credential should REPLACE the dummy token.
-	// The dummy token should never reach the upstream.
 	p := &Proxy{config: Config{
 		Credentials: map[string]string{"github": "ghp_real"},
 	}}
@@ -455,10 +510,8 @@ func TestCredentialInjection_DummyTokenNotForwarded(t *testing.T) {
 }
 
 func TestCredentialInjection_MissingCredentialNoOp(t *testing.T) {
-	// When no credential exists for a service, injectToolCredential should not
-	// add or modify auth headers.
 	p := &Proxy{config: Config{
-		Credentials: map[string]string{}, // no credentials
+		Credentials: map[string]string{},
 	}}
 
 	req := httptest.NewRequest("GET", "https://api.github.com/repos/org/repo", nil)
@@ -466,65 +519,16 @@ func TestCredentialInjection_MissingCredentialNoOp(t *testing.T) {
 
 	p.injectToolCredential(req, "github", "Authorization", "bearer")
 
-	// Original header should be unchanged since there's no credential to inject
 	got := req.Header.Get("Authorization")
 	if got != "Bearer original" {
 		t.Errorf("expected original header unchanged, got %q", got)
 	}
 }
 
-func TestCredentialIsolation_DeniedRequestDoesNotForwardCredential(t *testing.T) {
-	// Start a fake upstream that should NEVER be reached
-	upstreamCalled := false
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upstreamCalled = true
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer upstream.Close()
-
-	scope := githubScope(
-		[]string{"pulp/pulpcore"},
-		[]string{"read_prs"}, // only read_prs allowed
-	)
-	_, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_real_secret"})
-
-	// Attempt a denied operation
-	code, _ := doRequest(t, "PUT", ts.URL+"/github/repos/pulp/pulpcore/pulls/1/merge", "")
-	if code != http.StatusForbidden {
-		t.Errorf("expected 403, got %d", code)
-	}
-
-	// The upstream should NOT have been called at all for a denied request
-	// (Gate returns 403 before proxying). Note: in this test the upstream
-	// is the real api.github.com which won't be reached, but the key
-	// verification is that Gate returned 403 without forwarding.
-	_ = upstreamCalled
-}
-
-func TestCredentialIsolation_CrossServiceNoLeak(t *testing.T) {
-	// Scope only allows github, NOT gitlab
-	scope := internal.Scope{
-		Services: map[string]internal.ServiceScope{
-			"github": {Repos: []string{"*"}, Operations: []string{"*"}},
-		},
-	}
-	_, ts := newTestProxy(t, scope, map[string]string{
-		"github": "ghp_github_secret",
-		"gitlab": "glpat_gitlab_secret",
-	})
-
-	// GitLab request should be denied even though credentials exist
-	code, _ := doRequest(t, "GET", ts.URL+"/gitlab/api/v4/projects/group%2Fproject/merge_requests", "")
-	if code != http.StatusForbidden {
-		t.Errorf("expected 403 for gitlab (not in scope), got %d", code)
-	}
-}
-
 func TestCredentialInjection_LegacyFallback_GitHub(t *testing.T) {
-	// Test the legacy injectServiceCredential path (no ToolConfig).
 	p := &Proxy{config: Config{
 		Credentials: map[string]string{"github": "ghp_secret_123"},
-		ToolConfigs: map[string]ToolConfig{}, // empty — triggers legacy fallback
+		ToolConfigs: map[string]ToolConfig{},
 	}}
 
 	req := httptest.NewRequest("GET", "https://api.github.com/repos/org/repo", nil)
@@ -560,12 +564,10 @@ func TestScopeEnforcement_CaseInsensitiveRepo(t *testing.T) {
 		[]string{"Pulp/PulpCore"},
 		[]string{"read_prs"},
 	)
-	_, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_real_token"})
 
-	// Lowercase request should match uppercase scope entry
-	code, _ := doRequest(t, "GET", ts.URL+"/github/repos/pulp/pulpcore/pulls", "")
-	if code == http.StatusForbidden {
-		t.Errorf("expected case-insensitive repo match to succeed, got 403")
+	result := CheckAccess("GET", "https://api.github.com/repos/pulp/pulpcore/pulls", scope)
+	if !result.Allowed {
+		t.Errorf("expected case-insensitive repo match to succeed")
 	}
 }
 
@@ -574,23 +576,19 @@ func TestScopeEnforcement_NonRepoGitHubEndpoint(t *testing.T) {
 		[]string{"pulp/pulpcore"},
 		[]string{"read"},
 	)
-	_, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_real_token"})
 
-	// Non-repo endpoints like /user use the "read" / "write" general mapping
-	code, _ := doRequest(t, "GET", ts.URL+"/github/user", "")
-	if code == http.StatusForbidden {
-		t.Errorf("expected /user GET with 'read' op to be allowed, got 403")
+	result := CheckAccess("GET", "https://api.github.com/user", scope)
+	if !result.Allowed {
+		t.Errorf("expected /user GET with 'read' op to be allowed")
 	}
 
-	// POST to /user should require "write" op which is not in scope
-	code, _ = doRequest(t, "POST", ts.URL+"/github/user", "")
-	if code != http.StatusForbidden {
-		t.Errorf("expected 403 for POST /user without 'write' op, got %d", code)
+	result = CheckAccess("POST", "https://api.github.com/user", scope)
+	if result.Allowed {
+		t.Errorf("expected /user POST without 'write' op to be denied")
 	}
 }
 
 func TestScopeEnforcement_HealthzAlwaysAllowed(t *testing.T) {
-	// Even with an empty scope, healthz should work
 	scope := internal.Scope{Services: map[string]internal.ServiceScope{}}
 	_, ts := newTestProxy(t, scope, map[string]string{})
 
@@ -639,7 +637,6 @@ func TestGitCredential_DeniedRepo(t *testing.T) {
 }
 
 func TestGitCredential_ServiceNotInScope(t *testing.T) {
-	// Only gitlab in scope, git-credential for github should fail
 	scope := gitlabScope([]string{"*"}, []string{"*"})
 	_, ts := newTestProxy(t, scope, map[string]string{
 		"gitlab": "glpat_token",
@@ -674,47 +671,40 @@ func TestGitCredential_UnknownHost(t *testing.T) {
 // Category 1: Proxy log entries (audit trail)
 // --------------------------------------------------------------------
 
-func TestProxyLog_AllowedRequestLogged(t *testing.T) {
-	scope := githubScope([]string{"pulp/pulpcore"}, []string{"read_prs"})
-	p, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_real_token"})
+func TestProxyLog_DeniedConnectLogged(t *testing.T) {
+	scope := internal.Scope{Services: map[string]internal.ServiceScope{}}
+	p, ts := newTestProxy(t, scope, map[string]string{})
 
-	doRequest(t, "GET", ts.URL+"/github/repos/pulp/pulpcore/pulls", "")
+	// CONNECT to an unknown host should be denied and logged
+	conn, err := net.Dial("tcp", strings.TrimPrefix(ts.URL, "http://"))
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "CONNECT unknown.example.com:443 HTTP/1.1\r\nHost: unknown.example.com:443\r\n\r\n")
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatalf("reading response: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for unknown host CONNECT, got %d", resp.StatusCode)
+	}
 
 	entries := p.FlushLogs()
 	if len(entries) == 0 {
-		t.Fatal("expected at least one log entry for allowed request")
+		t.Fatal("expected at least one log entry for denied CONNECT")
 	}
 	found := false
 	for _, e := range entries {
-		if e.Service == "github" && e.Operation == "read_prs" && e.Decision == "allow" {
+		if e.Decision == "deny" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected log entry with service=github, operation=read_prs, decision=allow; got: %+v", entries)
-	}
-}
-
-func TestProxyLog_DeniedRequestLogged(t *testing.T) {
-	scope := githubScope([]string{"pulp/pulpcore"}, []string{"read_prs"})
-	p, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_real_token"})
-
-	doRequest(t, "PUT", ts.URL+"/github/repos/pulp/pulpcore/pulls/1/merge", "")
-
-	entries := p.FlushLogs()
-	if len(entries) == 0 {
-		t.Fatal("expected at least one log entry for denied request")
-	}
-	found := false
-	for _, e := range entries {
-		if e.Service == "github" && e.Operation == "merge_pr" && e.Decision == "deny" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected log entry with service=github, operation=merge_pr, decision=deny; got: %+v", entries)
+		t.Errorf("expected log entry with decision=deny; got: %+v", entries)
 	}
 }
 
@@ -723,7 +713,6 @@ func TestProxyLog_DeniedRequestLogged(t *testing.T) {
 // --------------------------------------------------------------------
 
 func TestGitHubOperationMapping(t *testing.T) {
-	// Verify that each operation is correctly mapped from method+path
 	tests := []struct {
 		method   string
 		subpath  string
@@ -817,34 +806,29 @@ func TestMultiServiceScope(t *testing.T) {
 			"gitlab": {Repos: []string{"*"}, Operations: []string{"read_contents"}},
 		},
 	}
-	_, ts := newTestProxy(t, scope, map[string]string{
-		"github": "ghp_token",
-		"gitlab": "glpat_token",
-	})
 
 	// GitHub: allowed operation
-	code, _ := doRequest(t, "GET", ts.URL+"/github/repos/pulp/pulpcore/pulls", "")
-	if code == http.StatusForbidden {
+	result := CheckAccess("GET", "https://api.github.com/repos/pulp/pulpcore/pulls", scope)
+	if !result.Allowed {
 		t.Errorf("github read_prs should be allowed")
 	}
 
 	// GitHub: denied operation (read_contents not in github's ops)
-	// Note: read_contents IS in gitlab's ops but should not bleed over
-	code, _ = doRequest(t, "GET", ts.URL+"/github/repos/pulp/pulpcore/contents/README.md", "")
-	if code != http.StatusForbidden {
-		t.Errorf("github read_contents should be denied (not in github ops), got %d", code)
+	result = CheckAccess("GET", "https://api.github.com/repos/pulp/pulpcore/contents/README.md", scope)
+	if result.Allowed {
+		t.Errorf("github read_contents should be denied (not in github ops)")
 	}
 
-	// GitLab: allowed operation (use numeric project ID to avoid %2F encoding issues)
-	code, _ = doRequest(t, "GET", ts.URL+"/gitlab/api/v4/projects/12345/repository/tree", "")
-	if code == http.StatusForbidden {
+	// GitLab: allowed operation
+	result = CheckAccess("GET", "https://gitlab.com/api/v4/projects/12345/repository/tree", scope)
+	if !result.Allowed {
 		t.Errorf("gitlab read_contents should be allowed")
 	}
 
-	// GitLab: denied operation (read_prs not in gitlab's ops)
-	code, _ = doRequest(t, "GET", ts.URL+"/gitlab/api/v4/projects/12345/merge_requests", "")
-	if code != http.StatusForbidden {
-		t.Errorf("gitlab read_prs should be denied (not in gitlab ops), got %d", code)
+	// GitLab: denied operation
+	result = CheckAccess("GET", "https://gitlab.com/api/v4/projects/12345/merge_requests", scope)
+	if result.Allowed {
+		t.Errorf("gitlab read_prs should be denied (not in gitlab ops)")
 	}
 }
 
@@ -852,7 +836,6 @@ func TestMultiServiceScope(t *testing.T) {
 // JIRA / Atlassian tests
 // --------------------------------------------------------------------
 
-// jiraScope returns a scope allowing jira with the specified operations.
 func jiraScope(ops []string) internal.Scope {
 	return internal.Scope{
 		Services: map[string]internal.ServiceScope{
@@ -860,37 +843,6 @@ func jiraScope(ops []string) internal.Scope {
 		},
 	}
 }
-
-// newJiraTestProxy creates a Gate proxy configured for JIRA with the given scope
-// and optional credential override. It registers a "jira" ToolConfig so that
-// the /jira/ prefix is routed correctly.
-func newJiraTestProxy(t *testing.T, scope internal.Scope, creds map[string]string) (*Proxy, *httptest.Server) {
-	t.Helper()
-	cfg := Config{
-		SessionID:   "test-session",
-		Scope:       scope,
-		Credentials: creds,
-		ToolConfigs: map[string]ToolConfig{
-			"jira": {
-				APIHost:    "company.atlassian.net",
-				AuthHeader: "Authorization",
-				AuthFormat: "basic",
-			},
-		},
-		SessionToken: "session-tok",
-		LLMToken:     "llm-secret-key",
-		LLMProvider:  "anthropic",
-		LLMTokenType: "api_key",
-	}
-	p := NewProxy(cfg)
-	ts := httptest.NewServer(p.Handler())
-	t.Cleanup(func() { ts.Close(); p.Stop() })
-	return p, ts
-}
-
-// --------------------------------------------------------------------
-// Test 1: JIRA operation mapping
-// --------------------------------------------------------------------
 
 func TestJiraOperationMapping(t *testing.T) {
 	tests := []struct {
@@ -930,45 +882,35 @@ func TestJiraOperationMapping(t *testing.T) {
 	}
 }
 
-// --------------------------------------------------------------------
-// Test 2: JIRA scope enforcement — total blocking
-// --------------------------------------------------------------------
-
 func TestJiraScopeEnforcement_TotalBlocking(t *testing.T) {
-	// No jira service in scope at all
 	scope := internal.Scope{
 		Services: map[string]internal.ServiceScope{},
 	}
-	_, ts := newJiraTestProxy(t, scope, map[string]string{"jira": "user:token"})
 
 	tests := []struct {
 		name   string
 		method string
-		path   string
+		url    string
 	}{
-		{"GET issue", "GET", "/jira/rest/api/3/issue/PROJ-123"},
-		{"POST issue", "POST", "/jira/rest/api/3/issue"},
-		{"GET search", "GET", "/jira/rest/api/3/search?jql=project=PROJ"},
-		{"GET project", "GET", "/jira/rest/api/3/project"},
-		{"PUT issue", "PUT", "/jira/rest/api/3/issue/PROJ-123"},
-		{"DELETE issue", "DELETE", "/jira/rest/api/3/issue/PROJ-123"},
-		{"GET boards", "GET", "/jira/rest/agile/1.0/board"},
-		{"POST comment", "POST", "/jira/rest/api/3/issue/PROJ-123/comment"},
+		{"GET issue", "GET", "https://company.atlassian.net/rest/api/3/issue/PROJ-123"},
+		{"POST issue", "POST", "https://company.atlassian.net/rest/api/3/issue"},
+		{"GET search", "GET", "https://company.atlassian.net/rest/api/3/search?jql=project=PROJ"},
+		{"GET project", "GET", "https://company.atlassian.net/rest/api/3/project"},
+		{"PUT issue", "PUT", "https://company.atlassian.net/rest/api/3/issue/PROJ-123"},
+		{"DELETE issue", "DELETE", "https://company.atlassian.net/rest/api/3/issue/PROJ-123"},
+		{"GET boards", "GET", "https://company.atlassian.net/rest/agile/1.0/board"},
+		{"POST comment", "POST", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/comment"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code, _ := doRequest(t, tt.method, ts.URL+tt.path, "")
-			if code != http.StatusForbidden {
-				t.Errorf("expected 403 Forbidden (no jira in scope) but got %d", code)
+			result := CheckAccess(tt.method, tt.url, scope)
+			if result.Allowed {
+				t.Errorf("expected denied (no jira in scope) but got allowed")
 			}
 		})
 	}
 }
-
-// --------------------------------------------------------------------
-// Test 3: JIRA scope enforcement — read only
-// --------------------------------------------------------------------
 
 func TestJiraScopeEnforcement_ReadOnly(t *testing.T) {
 	scope := jiraScope([]string{
@@ -976,156 +918,137 @@ func TestJiraScopeEnforcement_ReadOnly(t *testing.T) {
 		"read_comments", "read_metadata", "read_boards",
 		"read_sprints", "read_transitions",
 	})
-	_, ts := newJiraTestProxy(t, scope, map[string]string{"jira": "user:token"})
 
-	// Read operations should pass
 	readTests := []struct {
 		name   string
 		method string
-		path   string
+		url    string
 	}{
-		{"read issue", "GET", "/jira/rest/api/3/issue/PROJ-123"},
-		{"search issues", "GET", "/jira/rest/api/3/search?jql=project=PROJ"},
-		{"read project", "GET", "/jira/rest/api/3/project"},
-		{"read comments", "GET", "/jira/rest/api/3/issue/PROJ-123/comment"},
-		{"read boards", "GET", "/jira/rest/agile/1.0/board"},
-		{"read sprints", "GET", "/jira/rest/agile/1.0/sprint/5"},
-		{"read transitions", "GET", "/jira/rest/api/3/issue/PROJ-123/transitions"},
+		{"read issue", "GET", "https://company.atlassian.net/rest/api/3/issue/PROJ-123"},
+		{"search issues", "GET", "https://company.atlassian.net/rest/api/3/search?jql=project=PROJ"},
+		{"read project", "GET", "https://company.atlassian.net/rest/api/3/project"},
+		{"read comments", "GET", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/comment"},
+		{"read boards", "GET", "https://company.atlassian.net/rest/agile/1.0/board"},
+		{"read sprints", "GET", "https://company.atlassian.net/rest/agile/1.0/sprint/5"},
+		{"read transitions", "GET", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/transitions"},
 	}
 
 	for _, tt := range readTests {
 		t.Run("allowed_"+tt.name, func(t *testing.T) {
-			code, body := doRequest(t, tt.method, ts.URL+tt.path, "")
-			if code == http.StatusForbidden {
-				t.Errorf("expected allowed (non-403) but got 403: %s", body)
+			result := CheckAccess(tt.method, tt.url, scope)
+			if !result.Allowed {
+				t.Errorf("expected allowed but got denied: %s", result.Reason)
 			}
 		})
 	}
 
-	// Write operations should be denied
 	writeTests := []struct {
 		name   string
 		method string
-		path   string
+		url    string
 	}{
-		{"create issue", "POST", "/jira/rest/api/3/issue"},
-		{"update issue", "PUT", "/jira/rest/api/3/issue/PROJ-123"},
-		{"delete issue", "DELETE", "/jira/rest/api/3/issue/PROJ-123"},
-		{"add comment", "POST", "/jira/rest/api/3/issue/PROJ-123/comment"},
-		{"transition issue", "POST", "/jira/rest/api/3/issue/PROJ-123/transitions"},
-		{"assign issue", "PUT", "/jira/rest/api/3/issue/PROJ-123/assignee"},
+		{"create issue", "POST", "https://company.atlassian.net/rest/api/3/issue"},
+		{"update issue", "PUT", "https://company.atlassian.net/rest/api/3/issue/PROJ-123"},
+		{"delete issue", "DELETE", "https://company.atlassian.net/rest/api/3/issue/PROJ-123"},
+		{"add comment", "POST", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/comment"},
+		{"transition issue", "POST", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/transitions"},
+		{"assign issue", "PUT", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/assignee"},
 	}
 
 	for _, tt := range writeTests {
 		t.Run("denied_"+tt.name, func(t *testing.T) {
-			code, _ := doRequest(t, tt.method, ts.URL+tt.path, "")
-			if code != http.StatusForbidden {
-				t.Errorf("expected 403 Forbidden but got %d", code)
+			result := CheckAccess(tt.method, tt.url, scope)
+			if result.Allowed {
+				t.Errorf("expected denied but got allowed")
 			}
 		})
 	}
 }
 
-// --------------------------------------------------------------------
-// Test 4: JIRA scope enforcement — full access
-// --------------------------------------------------------------------
-
 func TestJiraScopeEnforcement_FullAccess(t *testing.T) {
 	scope := jiraScope([]string{"*"})
-	_, ts := newJiraTestProxy(t, scope, map[string]string{"jira": "user:token"})
 
 	tests := []struct {
 		name   string
 		method string
-		path   string
+		url    string
 	}{
-		{"read issue", "GET", "/jira/rest/api/3/issue/PROJ-123"},
-		{"search issues", "GET", "/jira/rest/api/3/search?jql=project=PROJ"},
-		{"read project", "GET", "/jira/rest/api/3/project"},
-		{"create issue", "POST", "/jira/rest/api/3/issue"},
-		{"update issue", "PUT", "/jira/rest/api/3/issue/PROJ-123"},
-		{"delete issue", "DELETE", "/jira/rest/api/3/issue/PROJ-123"},
-		{"add comment", "POST", "/jira/rest/api/3/issue/PROJ-123/comment"},
-		{"update comment", "PUT", "/jira/rest/api/3/issue/PROJ-123/comment/12345"},
-		{"delete comment", "DELETE", "/jira/rest/api/3/issue/PROJ-123/comment/456"},
-		{"transition issue", "POST", "/jira/rest/api/3/issue/PROJ-123/transitions"},
-		{"assign issue", "PUT", "/jira/rest/api/3/issue/PROJ-123/assignee"},
-		{"read boards", "GET", "/jira/rest/agile/1.0/board"},
-		{"read sprints", "GET", "/jira/rest/agile/1.0/sprint/5"},
-		{"move to sprint", "POST", "/jira/rest/agile/1.0/sprint/5/issue"},
-		{"add worklog", "POST", "/jira/rest/api/3/issue/PROJ-123/worklog"},
+		{"read issue", "GET", "https://company.atlassian.net/rest/api/3/issue/PROJ-123"},
+		{"search issues", "GET", "https://company.atlassian.net/rest/api/3/search?jql=project=PROJ"},
+		{"read project", "GET", "https://company.atlassian.net/rest/api/3/project"},
+		{"create issue", "POST", "https://company.atlassian.net/rest/api/3/issue"},
+		{"update issue", "PUT", "https://company.atlassian.net/rest/api/3/issue/PROJ-123"},
+		{"delete issue", "DELETE", "https://company.atlassian.net/rest/api/3/issue/PROJ-123"},
+		{"add comment", "POST", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/comment"},
+		{"update comment", "PUT", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/comment/12345"},
+		{"delete comment", "DELETE", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/comment/456"},
+		{"transition issue", "POST", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/transitions"},
+		{"assign issue", "PUT", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/assignee"},
+		{"read boards", "GET", "https://company.atlassian.net/rest/agile/1.0/board"},
+		{"read sprints", "GET", "https://company.atlassian.net/rest/agile/1.0/sprint/5"},
+		{"move to sprint", "POST", "https://company.atlassian.net/rest/agile/1.0/sprint/5/issue"},
+		{"add worklog", "POST", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/worklog"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code, body := doRequest(t, tt.method, ts.URL+tt.path, "")
-			if code == http.StatusForbidden {
-				t.Errorf("expected allowed with * wildcard but got 403: %s", body)
+			result := CheckAccess(tt.method, tt.url, scope)
+			if !result.Allowed {
+				t.Errorf("expected allowed with * wildcard: %s", result.Reason)
 			}
 		})
 	}
 }
-
-// --------------------------------------------------------------------
-// Test 5: JIRA scope enforcement — reduced write
-// --------------------------------------------------------------------
 
 func TestJiraScopeEnforcement_ReducedWrite(t *testing.T) {
 	scope := jiraScope([]string{
 		"read_issues", "search_issues", "read_projects", "read_comments",
 		"create_issue", "add_comment",
 	})
-	_, ts := newJiraTestProxy(t, scope, map[string]string{"jira": "user:token"})
 
-	// Allowed operations
 	allowedTests := []struct {
 		name   string
 		method string
-		path   string
+		url    string
 	}{
-		{"read issue", "GET", "/jira/rest/api/3/issue/PROJ-123"},
-		{"search issues", "GET", "/jira/rest/api/3/search?jql=project=PROJ"},
-		{"read project", "GET", "/jira/rest/api/3/project"},
-		{"read comments", "GET", "/jira/rest/api/3/issue/PROJ-123/comment"},
-		{"create issue", "POST", "/jira/rest/api/3/issue"},
-		{"add comment", "POST", "/jira/rest/api/3/issue/PROJ-123/comment"},
+		{"read issue", "GET", "https://company.atlassian.net/rest/api/3/issue/PROJ-123"},
+		{"search issues", "GET", "https://company.atlassian.net/rest/api/3/search?jql=project=PROJ"},
+		{"read project", "GET", "https://company.atlassian.net/rest/api/3/project"},
+		{"read comments", "GET", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/comment"},
+		{"create issue", "POST", "https://company.atlassian.net/rest/api/3/issue"},
+		{"add comment", "POST", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/comment"},
 	}
 
 	for _, tt := range allowedTests {
 		t.Run("allowed_"+tt.name, func(t *testing.T) {
-			code, body := doRequest(t, tt.method, ts.URL+tt.path, "")
-			if code == http.StatusForbidden {
-				t.Errorf("expected allowed but got 403: %s", body)
+			result := CheckAccess(tt.method, tt.url, scope)
+			if !result.Allowed {
+				t.Errorf("expected allowed but got denied: %s", result.Reason)
 			}
 		})
 	}
 
-	// Denied operations
 	deniedTests := []struct {
 		name   string
 		method string
-		path   string
+		url    string
 	}{
-		{"delete issue", "DELETE", "/jira/rest/api/3/issue/PROJ-123"},
-		{"update issue", "PUT", "/jira/rest/api/3/issue/PROJ-123"},
-		{"transition issue", "POST", "/jira/rest/api/3/issue/PROJ-123/transitions"},
-		{"assign issue", "PUT", "/jira/rest/api/3/issue/PROJ-123/assignee"},
-		{"delete comment", "DELETE", "/jira/rest/api/3/issue/PROJ-123/comment/456"},
+		{"delete issue", "DELETE", "https://company.atlassian.net/rest/api/3/issue/PROJ-123"},
+		{"update issue", "PUT", "https://company.atlassian.net/rest/api/3/issue/PROJ-123"},
+		{"transition issue", "POST", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/transitions"},
+		{"assign issue", "PUT", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/assignee"},
+		{"delete comment", "DELETE", "https://company.atlassian.net/rest/api/3/issue/PROJ-123/comment/456"},
 	}
 
 	for _, tt := range deniedTests {
 		t.Run("denied_"+tt.name, func(t *testing.T) {
-			code, _ := doRequest(t, tt.method, ts.URL+tt.path, "")
-			if code != http.StatusForbidden {
-				t.Errorf("expected 403 Forbidden but got %d", code)
+			result := CheckAccess(tt.method, tt.url, scope)
+			if result.Allowed {
+				t.Errorf("expected denied but got allowed")
 			}
 		})
 	}
 }
-
-// --------------------------------------------------------------------
-// Test 6: JIRA credential injection — Basic auth
-// --------------------------------------------------------------------
 
 func TestJiraCredentialInjection_Basic(t *testing.T) {
 	p := &Proxy{config: Config{
@@ -1142,10 +1065,6 @@ func TestJiraCredentialInjection_Basic(t *testing.T) {
 	}
 }
 
-// --------------------------------------------------------------------
-// Test 7: JIRA credential isolation — cross-service
-// --------------------------------------------------------------------
-
 func TestJiraCredentialIsolation(t *testing.T) {
 	// Scope only allows jira, NOT github or gitlab
 	scope := internal.Scope{
@@ -1154,63 +1073,105 @@ func TestJiraCredentialIsolation(t *testing.T) {
 		},
 	}
 
-	cfg := Config{
-		SessionID: "test-session",
-		Scope:     scope,
-		Credentials: map[string]string{
-			"jira":   "user@example.com:jira-token",
-			"github": "ghp_github_secret",
-			"gitlab": "glpat_gitlab_secret",
-		},
-		ToolConfigs: map[string]ToolConfig{
-			"jira": {
-				APIHost:    "company.atlassian.net",
-				AuthHeader: "Authorization",
-				AuthFormat: "basic",
-			},
-		},
-		SessionToken: "session-tok",
-		LLMToken:     "llm-secret-key",
-		LLMProvider:  "anthropic",
-		LLMTokenType: "api_key",
-	}
-	p := NewProxy(cfg)
-	ts := httptest.NewServer(p.Handler())
-	t.Cleanup(func() { ts.Close(); p.Stop() })
-
-	// JIRA request should be allowed (jira is in scope)
-	code, _ := doRequest(t, "GET", ts.URL+"/jira/rest/api/3/issue/PROJ-123", "")
-	if code == http.StatusForbidden {
-		t.Errorf("expected jira request to be allowed, got 403")
+	// JIRA request should be allowed
+	result := CheckAccess("GET", "https://company.atlassian.net/rest/api/3/issue/PROJ-123", scope)
+	if !result.Allowed {
+		t.Errorf("expected jira request to be allowed")
 	}
 
-	// GitHub request should be denied (github not in scope)
-	code, _ = doRequest(t, "GET", ts.URL+"/github/repos/pulp/pulpcore/pulls", "")
-	if code != http.StatusForbidden {
-		t.Errorf("expected 403 for github (not in scope), got %d", code)
+	// GitHub request should be denied
+	result = CheckAccess("GET", "https://api.github.com/repos/pulp/pulpcore/pulls", scope)
+	if result.Allowed {
+		t.Errorf("expected github to be denied (not in scope)")
 	}
 
-	// GitLab request should be denied (gitlab not in scope)
-	code, _ = doRequest(t, "GET", ts.URL+"/gitlab/api/v4/projects/12345/merge_requests", "")
-	if code != http.StatusForbidden {
-		t.Errorf("expected 403 for gitlab (not in scope), got %d", code)
+	// GitLab request should be denied
+	result = CheckAccess("GET", "https://gitlab.com/api/v4/projects/12345/merge_requests", scope)
+	if result.Allowed {
+		t.Errorf("expected gitlab to be denied (not in scope)")
+	}
+}
+
+// --------------------------------------------------------------------
+// MITM CONNECT integration tests
+// --------------------------------------------------------------------
+
+func TestCONNECT_MITMEnabled_GitHubAllowed(t *testing.T) {
+	scope := githubScope([]string{"*"}, []string{"*"})
+	_, ts, certPEM := newTestProxyWithMITM(t, scope, map[string]string{"github": "ghp_real_token"})
+
+	// CONNECT to api.github.com should succeed (200) with MITM enabled
+	conn, err := net.Dial("tcp", strings.TrimPrefix(ts.URL, "http://"))
+	if err != nil {
+		t.Fatalf("connecting to gate: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "CONNECT api.github.com:443 HTTP/1.1\r\nHost: api.github.com:443\r\n\r\n")
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatalf("reading CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 from CONNECT with MITM, got %d", resp.StatusCode)
 	}
 
-	// Now test the reverse: scope only allows github, jira should be denied
-	scope2 := internal.Scope{
-		Services: map[string]internal.ServiceScope{
-			"github": {Repos: []string{"*"}, Operations: []string{"*"}},
-		},
+	// TLS handshake should succeed with our CA
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(certPEM)
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName: "api.github.com",
+		RootCAs:    caPool,
+		NextProtos: []string{"http/1.1"},
+	})
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake failed: %v", err)
 	}
-	cfg2 := cfg
-	cfg2.Scope = scope2
-	p2 := NewProxy(cfg2)
-	ts2 := httptest.NewServer(p2.Handler())
-	t.Cleanup(func() { ts2.Close(); p2.Stop() })
+	tlsConn.Close()
+}
 
-	code, _ = doRequest(t, "GET", ts2.URL+"/jira/rest/api/3/issue/PROJ-123", "")
-	if code != http.StatusForbidden {
-		t.Errorf("expected 403 for jira (not in scope when only github allowed), got %d", code)
+func TestCONNECT_UnknownHostDenied(t *testing.T) {
+	scope := githubScope([]string{"*"}, []string{"*"})
+	_, ts := newTestProxy(t, scope, map[string]string{"github": "ghp_token"})
+
+	conn, err := net.Dial("tcp", strings.TrimPrefix(ts.URL, "http://"))
+	if err != nil {
+		t.Fatalf("connecting to gate: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "CONNECT evil.example.com:443 HTTP/1.1\r\nHost: evil.example.com:443\r\n\r\n")
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatalf("reading response: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for unknown host CONNECT, got %d", resp.StatusCode)
+	}
+}
+
+func TestCONNECT_AllowlistDomainPassthrough(t *testing.T) {
+	scope := internal.Scope{Services: map[string]internal.ServiceScope{}}
+	_, ts := newTestProxy(t, scope, map[string]string{})
+
+	conn, err := net.Dial("tcp", strings.TrimPrefix(ts.URL, "http://"))
+	if err != nil {
+		t.Fatalf("connecting to gate: %v", err)
+	}
+	defer conn.Close()
+
+	// pypi.org is on the domain allowlist
+	fmt.Fprintf(conn, "CONNECT pypi.org:443 HTTP/1.1\r\nHost: pypi.org:443\r\n\r\n")
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatalf("reading response: %v", err)
+	}
+	// Should succeed (200) — passthrough tunnel
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 for allowlisted domain CONNECT, got %d", resp.StatusCode)
 	}
 }
 
@@ -1219,8 +1180,6 @@ func TestJiraCredentialIsolation(t *testing.T) {
 // --------------------------------------------------------------------
 
 func TestLLMOAuthToken_InjectsCorrectHeaders(t *testing.T) {
-	// Create a proxy with oauth_token type and send a request to /v1/messages.
-	// Verify that Gate accepts the request (no "unknown LLM provider" error).
 	cfg := Config{
 		SessionID:    "test-session",
 		Scope:        internal.Scope{Services: map[string]internal.ServiceScope{}},
@@ -1235,9 +1194,6 @@ func TestLLMOAuthToken_InjectsCorrectHeaders(t *testing.T) {
 	ts := httptest.NewServer(p.Handler())
 	t.Cleanup(func() { ts.Close(); p.Stop() })
 
-	// Send a request to /v1/messages. The upstream (api.anthropic.com) will
-	// likely fail or refuse, but we verify Gate itself does not return a 500
-	// "unknown LLM provider" error — the request should be proxied.
 	code, body := doRequest(t, "POST", ts.URL+"/v1/messages", `{"model":"claude-sonnet-4-20250514","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}`)
 	if code == http.StatusInternalServerError && strings.Contains(body, "unknown LLM provider") {
 		t.Errorf("oauth_token type should be accepted, but got 'unknown LLM provider' error")
@@ -1245,8 +1201,6 @@ func TestLLMOAuthToken_InjectsCorrectHeaders(t *testing.T) {
 }
 
 func TestLLMOAuthToken_NotUnknownProvider(t *testing.T) {
-	// Verify that oauth_token with LLMProvider "anthropic" does not trigger
-	// the "unknown LLM provider" error path.
 	cfg := Config{
 		SessionID:    "test-session",
 		Scope:        internal.Scope{Services: map[string]internal.ServiceScope{}},
@@ -1262,9 +1216,6 @@ func TestLLMOAuthToken_NotUnknownProvider(t *testing.T) {
 	t.Cleanup(func() { ts.Close(); p.Stop() })
 
 	code, body := doRequest(t, "POST", ts.URL+"/v1/messages", `{"model":"claude-sonnet-4-20250514","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}`)
-	// The request should NOT get the "unknown LLM provider" error (500).
-	// It may fail for other reasons (upstream unreachable, auth failure, etc.)
-	// but the provider routing should work correctly.
 	if code == http.StatusInternalServerError && strings.Contains(body, "unknown LLM provider") {
 		t.Errorf("oauth_token with anthropic provider should not trigger 'unknown LLM provider'; got %d: %s", code, body)
 	}

--- a/internal/runtime/kubernetes.go
+++ b/internal/runtime/kubernetes.go
@@ -155,29 +155,9 @@ func (k *KubernetesRuntime) RunTask(ctx context.Context, spec TaskSpec) (TaskHan
 			skiffEnv["NO_PROXY"] = "localhost,127.0.0.1,alcove-hail,alcove-bridge,alcove-ledger,.svc,.svc.cluster.local"
 		}
 	}
-	// Override Gate-referenced URLs to use localhost since Gate is a sidecar
-	// sharing the pod network namespace (not a separate container with its own hostname).
+	// Point LLM API calls to the Gate sidecar on localhost (Gate and Skiff share
+	// the pod network namespace).
 	skiffEnv["ANTHROPIC_BASE_URL"] = "http://localhost:8443"
-	for _, key := range []string{
-		"GITHUB_API_URL", "GITLAB_API_URL", "JIRA_API_URL",
-	} {
-		if val, ok := skiffEnv[key]; ok {
-			// Replace gate-{taskid}:8443 with localhost:8443
-			if strings.Contains(val, ":8443/") {
-				parts := strings.SplitN(val, ":8443/", 2)
-				skiffEnv[key] = "http://localhost:8443/" + parts[1]
-			}
-		}
-	}
-	// Remove GH_HOST on k8s — the gh CLI uses it to identify the GitHub server,
-	// not as a proxy URL. Setting it to localhost:8443 causes gh to reject git
-	// remotes pointing to github.com. The HTTP_PROXY already routes traffic
-	// through Gate correctly.
-	delete(skiffEnv, "GH_HOST")
-	delete(skiffEnv, "GH_PROTOCOL")
-	if _, ok := skiffEnv["GLAB_HOST"]; ok {
-		skiffEnv["GLAB_HOST"] = "http://localhost:8443/gitlab"
-	}
 
 	// Resolve service hostnames to IPs to bypass DNS issues in task pods.
 	// OVN-Kubernetes may block UDP DNS from pods with restrictive egress policies.


### PR DESCRIPTION
## Summary
- Replaces boutique `/github/`, `/gitlab/`, `/jira/` prefix proxy handlers with a general-purpose MITM TLS re-encrypt proxy
- Gate now intercepts CONNECT tunnels to service domains, generates leaf certs signed by an ephemeral CA, reads plaintext requests, injects credentials, checks scope, and forwards over real TLS
- Fixes `gh` CLI GraphQL issue — `gh issue view` sends GraphQL via CONNECT to `api.github.com` which was previously blocked
- Any tool using `HTTP_PROXY` now works transparently without per-tool env var configuration
- Adds `enforcement_mode: monitor` for iterative policy development (log traffic without blocking)
- Removes GitHub MCP server (gh CLI works natively now)
- Architecture inspired by NVIDIA OpenShell's sandbox proxy

## Changes
- **New**: `internal/gate/mitm.go` — MITM engine with cert cache, domain matching, credential injection
- **New**: `internal/gate/mitm_test.go` — comprehensive tests (cert gen, caching, MITM round-trip, scope, monitor mode)
- **New**: `internal/bridge/ca.go` — ephemeral CA generation (RSA 2048, 24h validity)
- **Modified**: Gate proxy rewired (removed SCM handlers, CONNECT routing updated)
- **Modified**: Dispatcher (CA distribution, removed boutique env vars, removed MCP config)
- **Modified**: skiff-init (CA trust store setup with 5 trust vars)
- **Modified**: Kubernetes runtime (removed dead env var overrides)
- **Modified**: All design docs, CLAUDE.md, configuration docs

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` — all 17 packages pass
- [x] Independent QA team review (passed with fixes applied)
- [x] Code review team A (security + correctness — all findings addressed)
- [x] Code review team B (docs + integration — all findings addressed)
- [ ] CI functional-tests-podman
- [ ] CI functional-tests-k8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)