### PR TITLE
Generic HTTP-primitive policy rules for Gate

### DIFF
--- a/.alcove/policy-rules/github.yml
+++ b/.alcove/policy-rules/github.yml
@@ -1,0 +1,418 @@
+# GitHub API policy rule sets
+#
+# Each rule set maps to one or more HTTP method+host+path combinations that
+# correspond to the operations previously defined in internal/gate/scope.go's
+# mapGitHubOperation() and mapGitHubGeneral() functions.
+#
+# Path patterns use "*" to match a single path segment and "**" to match
+# one or more segments.
+
+rule_sets:
+  # ---------------------------------------------------------------------------
+  # Git credential operations (handled via git credential helpers, not HTTP proxy)
+  # ---------------------------------------------------------------------------
+  - name: github-clone
+    rules:
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*"
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/**"
+
+  - name: github-push-branch
+    rules:
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/git/refs"
+      - allow:
+          method: PATCH
+          host: api.github.com
+          path: "/repos/*/git/refs/**"
+
+  # ---------------------------------------------------------------------------
+  # Read operations
+  # ---------------------------------------------------------------------------
+  - name: github-read-issues
+    rules:
+      # GET /repos/{owner}/{repo}/issues
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/issues"
+      # GET /repos/{owner}/{repo}/issues/{number}
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/issues/*"
+      # GET /repos/{owner}/{repo}/issues/{number}/comments
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/issues/*/comments"
+      # GET /repos/{owner}/{repo}/issues/{number}/comments/{id}
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/issues/*/comments/*"
+      # GET /repos/{owner}/{repo}/issues/{number}/labels
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/issues/*/labels"
+      # GET /repos/{owner}/{repo}/labels
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/labels"
+      # GET /repos/{owner}/{repo}/labels/{name}
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/labels/*"
+
+  - name: github-read-prs
+    rules:
+      # GET /repos/{owner}/{repo}/pulls
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/pulls"
+      # GET /repos/{owner}/{repo}/pulls/{number}
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/pulls/*"
+      # GET /repos/{owner}/{repo}/pulls/{number}/**
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/pulls/**"
+
+  - name: github-read-contents
+    rules:
+      # GET /repos/{owner}/{repo}/contents/{path}
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/contents/**"
+
+  - name: github-read-commits
+    rules:
+      # GET /repos/{owner}/{repo}/commits
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/commits"
+      # GET /repos/{owner}/{repo}/commits/{sha}
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/commits/*"
+      # GET /repos/{owner}/{repo}/commits/**
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/commits/**"
+
+  - name: github-read-branches
+    rules:
+      # GET /repos/{owner}/{repo}/branches
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/branches"
+      # GET /repos/{owner}/{repo}/branches/{branch}
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/branches/*"
+
+  - name: github-read-git
+    rules:
+      # GET /repos/{owner}/{repo}/git/**
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/git/**"
+
+  - name: github-read-actions
+    rules:
+      # GET /repos/{owner}/{repo}/actions/**
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/actions/**"
+
+  - name: github-read-releases
+    rules:
+      # GET /repos/{owner}/{repo}/releases
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/releases"
+      # GET /repos/{owner}/{repo}/releases/{id}
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/releases/*"
+      # GET /repos/{owner}/{repo}/releases/**
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/repos/*/*/releases/**"
+
+  # ---------------------------------------------------------------------------
+  # Write operations — issues and PRs
+  # ---------------------------------------------------------------------------
+  - name: github-create-comment
+    rules:
+      # POST /repos/{owner}/{repo}/issues/{number}/comments
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/issues/*/comments"
+      # POST /repos/{owner}/{repo}/pulls/{number}/comments
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/pulls/*/comments"
+
+  - name: github-create-issue
+    rules:
+      # POST /repos/{owner}/{repo}/issues
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/issues"
+
+  - name: github-update-issue
+    rules:
+      # PATCH /repos/{owner}/{repo}/issues/{number}
+      - allow:
+          method: PATCH
+          host: api.github.com
+          path: "/repos/*/*/issues/*"
+      # POST /repos/{owner}/{repo}/issues/{number}/labels
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/issues/*/labels"
+      # DELETE /repos/{owner}/{repo}/issues/{number}/labels/{name}
+      - allow:
+          method: DELETE
+          host: api.github.com
+          path: "/repos/*/*/issues/*/labels/*"
+
+  - name: github-create-pr
+    rules:
+      # POST /repos/{owner}/{repo}/pulls (create_pr_draft)
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/pulls"
+
+  - name: github-update-pr
+    rules:
+      # PATCH /repos/{owner}/{repo}/pulls/{number}
+      - allow:
+          method: PATCH
+          host: api.github.com
+          path: "/repos/*/*/pulls/*"
+
+  - name: github-merge-pr
+    rules:
+      # PUT /repos/{owner}/{repo}/pulls/{number}/merge
+      - allow:
+          method: PUT
+          host: api.github.com
+          path: "/repos/*/*/pulls/*/merge"
+
+  - name: github-create-review
+    rules:
+      # POST /repos/{owner}/{repo}/pulls/{number}/reviews
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/pulls/*/reviews"
+      # POST /repos/{owner}/{repo}/pulls/{number}/reviews/{id}/**
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/pulls/*/reviews/**"
+
+  # ---------------------------------------------------------------------------
+  # Write operations — contents and git
+  # ---------------------------------------------------------------------------
+  - name: github-write-contents
+    rules:
+      # PUT /repos/{owner}/{repo}/contents/{path}
+      - allow:
+          method: PUT
+          host: api.github.com
+          path: "/repos/*/*/contents/**"
+      # POST /repos/{owner}/{repo}/contents/{path}
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/contents/**"
+
+  - name: github-write-git
+    rules:
+      # POST /repos/{owner}/{repo}/git/**
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/git/**"
+      # PATCH /repos/{owner}/{repo}/git/**
+      - allow:
+          method: PATCH
+          host: api.github.com
+          path: "/repos/*/*/git/**"
+      # PUT /repos/{owner}/{repo}/git/**
+      - allow:
+          method: PUT
+          host: api.github.com
+          path: "/repos/*/*/git/**"
+
+  - name: github-create-branch
+    rules:
+      # POST /repos/{owner}/{repo}/git/refs
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/git/refs"
+
+  - name: github-delete-branch
+    rules:
+      # DELETE /repos/{owner}/{repo}/git/refs/**
+      - allow:
+          method: DELETE
+          host: api.github.com
+          path: "/repos/*/*/git/refs/**"
+      # DELETE /repos/{owner}/{repo}/branches/{branch}
+      - allow:
+          method: DELETE
+          host: api.github.com
+          path: "/repos/*/*/branches/*"
+
+  - name: github-write-branches
+    rules:
+      # POST /repos/{owner}/{repo}/branches/**
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/branches/**"
+      # PUT /repos/{owner}/{repo}/branches/**
+      - allow:
+          method: PUT
+          host: api.github.com
+          path: "/repos/*/*/branches/**"
+      # PATCH /repos/{owner}/{repo}/branches/**
+      - allow:
+          method: PATCH
+          host: api.github.com
+          path: "/repos/*/*/branches/**"
+
+  # ---------------------------------------------------------------------------
+  # Write operations — actions, releases
+  # ---------------------------------------------------------------------------
+  - name: github-write-actions
+    rules:
+      # POST /repos/{owner}/{repo}/actions/**
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/actions/**"
+      # PUT /repos/{owner}/{repo}/actions/**
+      - allow:
+          method: PUT
+          host: api.github.com
+          path: "/repos/*/*/actions/**"
+      # PATCH /repos/{owner}/{repo}/actions/**
+      - allow:
+          method: PATCH
+          host: api.github.com
+          path: "/repos/*/*/actions/**"
+      # DELETE /repos/{owner}/{repo}/actions/**
+      - allow:
+          method: DELETE
+          host: api.github.com
+          path: "/repos/*/*/actions/**"
+
+  - name: github-write-releases
+    rules:
+      # POST /repos/{owner}/{repo}/releases
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/releases"
+      # PATCH /repos/{owner}/{repo}/releases/{id}
+      - allow:
+          method: PATCH
+          host: api.github.com
+          path: "/repos/*/*/releases/*"
+      # DELETE /repos/{owner}/{repo}/releases/{id}
+      - allow:
+          method: DELETE
+          host: api.github.com
+          path: "/repos/*/*/releases/*"
+      # POST /repos/{owner}/{repo}/releases/{id}/assets
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/releases/*/assets"
+
+  - name: github-create-release
+    rules:
+      # POST /repos/{owner}/{repo}/releases
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/repos/*/*/releases"
+
+  # ---------------------------------------------------------------------------
+  # GraphQL API
+  # ---------------------------------------------------------------------------
+  - name: github-graphql
+    rules:
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/graphql"
+
+  # ---------------------------------------------------------------------------
+  # General read/write (non-repo endpoints like /user, /search)
+  # ---------------------------------------------------------------------------
+  - name: github-read
+    rules:
+      - allow:
+          method: GET
+          host: api.github.com
+          path: "/**"
+      - allow:
+          method: HEAD
+          host: api.github.com
+          path: "/**"
+
+  - name: github-write
+    rules:
+      - allow:
+          method: POST
+          host: api.github.com
+          path: "/**"
+      - allow:
+          method: PUT
+          host: api.github.com
+          path: "/**"
+      - allow:
+          method: PATCH
+          host: api.github.com
+          path: "/**"
+      - allow:
+          method: DELETE
+          host: api.github.com
+          path: "/**"

--- a/.alcove/policy-rules/gitlab.yml
+++ b/.alcove/policy-rules/gitlab.yml
@@ -1,0 +1,263 @@
+# GitLab API policy rule sets
+#
+# Each rule set maps to one or more HTTP method+host+path combinations that
+# correspond to the operations previously defined in internal/gate/scope.go's
+# mapGitLabOperation() function.
+#
+# Path patterns use "*" to match a single path segment and "**" to match
+# one or more segments. The host uses "*" to match any GitLab instance
+# (gitlab.com, gitlab.example.com, etc.).
+
+rule_sets:
+  # ---------------------------------------------------------------------------
+  # Read operations
+  # ---------------------------------------------------------------------------
+  - name: gitlab-read-prs
+    rules:
+      # GET /api/v4/projects/{id}/merge_requests
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/merge_requests"
+      # GET /api/v4/projects/{id}/merge_requests/{iid}
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/merge_requests/*"
+      # GET /api/v4/projects/{id}/merge_requests/{iid}/**
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/merge_requests/**"
+
+  - name: gitlab-read-issues
+    rules:
+      # GET /api/v4/projects/{id}/issues
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/issues"
+      # GET /api/v4/projects/{id}/issues/{iid}
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/issues/*"
+      # GET /api/v4/projects/{id}/issues/{iid}/**
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/issues/**"
+
+  - name: gitlab-read-contents
+    rules:
+      # GET /api/v4/projects/{id}/repository/**
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/repository/**"
+
+  - name: gitlab-read-releases
+    rules:
+      # GET /api/v4/projects/{id}/releases
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/releases"
+      # GET /api/v4/projects/{id}/releases/{tag}
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/releases/*"
+      # GET /api/v4/projects/{id}/releases/**
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/releases/**"
+
+  - name: gitlab-read-actions
+    rules:
+      # GET /api/v4/projects/{id}/pipelines
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/pipelines"
+      # GET /api/v4/projects/{id}/pipelines/{id}
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/pipelines/*"
+      # GET /api/v4/projects/{id}/pipelines/**
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/pipelines/**"
+
+  # ---------------------------------------------------------------------------
+  # Write operations — merge requests
+  # ---------------------------------------------------------------------------
+  - name: gitlab-create-pr
+    rules:
+      # POST /api/v4/projects/{id}/merge_requests
+      - allow:
+          method: POST
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/merge_requests"
+
+  - name: gitlab-update-pr
+    rules:
+      # PUT /api/v4/projects/{id}/merge_requests/{iid}
+      - allow:
+          method: PUT
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/merge_requests/*"
+
+  - name: gitlab-merge-pr
+    rules:
+      # PUT /api/v4/projects/{id}/merge_requests/{iid}/merge
+      - allow:
+          method: PUT
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/merge_requests/*/merge"
+
+  - name: gitlab-create-review
+    rules:
+      # POST /api/v4/projects/{id}/merge_requests/{iid}/approve
+      - allow:
+          method: POST
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/merge_requests/*/approve"
+
+  # ---------------------------------------------------------------------------
+  # Write operations — issues
+  # ---------------------------------------------------------------------------
+  - name: gitlab-create-issue
+    rules:
+      # POST /api/v4/projects/{id}/issues
+      - allow:
+          method: POST
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/issues"
+
+  - name: gitlab-update-issue
+    rules:
+      # PUT /api/v4/projects/{id}/issues/{iid}
+      - allow:
+          method: PUT
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/issues/*"
+
+  # ---------------------------------------------------------------------------
+  # Write operations — comments / notes
+  # ---------------------------------------------------------------------------
+  - name: gitlab-create-comment
+    rules:
+      # POST /api/v4/projects/{id}/merge_requests/{iid}/notes
+      - allow:
+          method: POST
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/merge_requests/*/notes"
+      # POST /api/v4/projects/{id}/issues/{iid}/notes
+      - allow:
+          method: POST
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/issues/*/notes"
+      # POST /api/v4/projects/{id}/notes (generic)
+      - allow:
+          method: POST
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/notes"
+
+  # ---------------------------------------------------------------------------
+  # Write operations — repository (branches, contents)
+  # ---------------------------------------------------------------------------
+  - name: gitlab-create-branch
+    rules:
+      # POST /api/v4/projects/{id}/repository/branches
+      - allow:
+          method: POST
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/repository/branches"
+
+  - name: gitlab-delete-branch
+    rules:
+      # DELETE /api/v4/projects/{id}/repository/branches/{branch}
+      - allow:
+          method: DELETE
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/repository/branches/*"
+
+  - name: gitlab-write-contents
+    rules:
+      # POST /api/v4/projects/{id}/repository/**
+      - allow:
+          method: POST
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/repository/**"
+      # PUT /api/v4/projects/{id}/repository/**
+      - allow:
+          method: PUT
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/repository/**"
+
+  # ---------------------------------------------------------------------------
+  # Write operations — releases, pipelines
+  # ---------------------------------------------------------------------------
+  - name: gitlab-write-releases
+    rules:
+      # POST /api/v4/projects/{id}/releases
+      - allow:
+          method: POST
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/releases"
+      # PUT /api/v4/projects/{id}/releases/{tag}
+      - allow:
+          method: PUT
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/releases/*"
+      # DELETE /api/v4/projects/{id}/releases/{tag}
+      - allow:
+          method: DELETE
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/releases/*"
+
+  - name: gitlab-write-actions
+    rules:
+      # POST /api/v4/projects/{id}/pipelines
+      - allow:
+          method: POST
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/pipelines"
+      # POST /api/v4/projects/{id}/pipelines/**
+      - allow:
+          method: POST
+          host: "*.gitlab.*"
+          path: "/api/v4/projects/*/pipelines/**"
+
+  # ---------------------------------------------------------------------------
+  # General read/write (non-project endpoints)
+  # ---------------------------------------------------------------------------
+  - name: gitlab-read
+    rules:
+      - allow:
+          method: GET
+          host: "*.gitlab.*"
+          path: "/api/v4/**"
+      - allow:
+          method: HEAD
+          host: "*.gitlab.*"
+          path: "/api/v4/**"
+
+  - name: gitlab-write
+    rules:
+      - allow:
+          method: POST
+          host: "*.gitlab.*"
+          path: "/api/v4/**"
+      - allow:
+          method: PUT
+          host: "*.gitlab.*"
+          path: "/api/v4/**"
+      - allow:
+          method: DELETE
+          host: "*.gitlab.*"
+          path: "/api/v4/**"

--- a/.alcove/policy-rules/jira.yml
+++ b/.alcove/policy-rules/jira.yml
@@ -1,0 +1,312 @@
+# Jira (Atlassian) API policy rule sets
+#
+# Each rule set maps to one or more HTTP method+host+path combinations that
+# correspond to the operations previously defined in internal/gate/scope.go's
+# mapJiraOperation() function.
+#
+# Path patterns use "*" to match a single path segment and "**" to match
+# one or more segments. The host "*.atlassian.net" matches any Atlassian
+# Cloud instance.
+
+rule_sets:
+  # ---------------------------------------------------------------------------
+  # Read operations
+  # ---------------------------------------------------------------------------
+  - name: jira-read-issues
+    rules:
+      # GET /rest/api/3/issue
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue"
+      # GET /rest/api/3/issue/{issueIdOrKey}
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/*"
+      # GET /rest/api/3/issue/{issueIdOrKey}/** (sub-resources)
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/**"
+
+  - name: jira-search-issues
+    rules:
+      # GET /rest/api/3/search
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/search"
+      # GET /rest/api/3/search/**
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/search/**"
+      # POST /rest/api/3/search (JQL search)
+      - allow:
+          method: POST
+          host: "*.atlassian.net"
+          path: "/rest/api/*/search"
+      # POST /rest/api/3/search/**
+      - allow:
+          method: POST
+          host: "*.atlassian.net"
+          path: "/rest/api/*/search/**"
+
+  - name: jira-read-comments
+    rules:
+      # GET /rest/api/3/issue/{issueIdOrKey}/comment
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/*/comment"
+      # GET /rest/api/3/issue/{issueIdOrKey}/comment/{id}
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/*/comment/*"
+
+  - name: jira-read-transitions
+    rules:
+      # GET /rest/api/3/issue/{issueIdOrKey}/transitions
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/*/transitions"
+
+  - name: jira-read-projects
+    rules:
+      # GET /rest/api/3/project
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/project"
+      # GET /rest/api/3/project/{projectIdOrKey}
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/project/*"
+      # GET /rest/api/3/project/**
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/project/**"
+
+  - name: jira-read-boards
+    rules:
+      # GET /rest/agile/1.0/board
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/agile/*/board"
+      # GET /rest/agile/1.0/board/{boardId}
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/agile/*/board/*"
+      # GET /rest/agile/1.0/board/**
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/agile/*/board/**"
+
+  - name: jira-read-sprints
+    rules:
+      # GET /rest/agile/1.0/sprint
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/agile/*/sprint"
+      # GET /rest/agile/1.0/sprint/{sprintId}
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/agile/*/sprint/*"
+      # GET /rest/agile/1.0/sprint/**
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/agile/*/sprint/**"
+
+  - name: jira-read-metadata
+    rules:
+      # GET /rest/api/3/issuetype
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issuetype"
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issuetype/**"
+      # GET /rest/api/3/priority
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/priority"
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/priority/**"
+      # GET /rest/api/3/status
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/status"
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/status/**"
+      # GET /rest/api/3/field
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/field"
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/field/**"
+      # GET /rest/api/3/label
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/label"
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/label/**"
+      # GET /rest/api/3/myself
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/myself"
+      # GET /rest/api/3/user
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/user"
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/api/*/user/**"
+
+  # ---------------------------------------------------------------------------
+  # Write operations — issues
+  # ---------------------------------------------------------------------------
+  - name: jira-create-issue
+    rules:
+      # POST /rest/api/3/issue
+      - allow:
+          method: POST
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue"
+
+  - name: jira-update-issue
+    rules:
+      # PUT /rest/api/3/issue/{issueIdOrKey}
+      - allow:
+          method: PUT
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/*"
+
+  - name: jira-delete-issue
+    rules:
+      # DELETE /rest/api/3/issue/{issueIdOrKey}
+      - allow:
+          method: DELETE
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/*"
+
+  - name: jira-assign-issue
+    rules:
+      # PUT /rest/api/3/issue/{issueIdOrKey}/assignee
+      - allow:
+          method: PUT
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/*/assignee"
+
+  - name: jira-transition-issue
+    rules:
+      # POST /rest/api/3/issue/{issueIdOrKey}/transitions
+      - allow:
+          method: POST
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/*/transitions"
+
+  # ---------------------------------------------------------------------------
+  # Write operations — comments
+  # ---------------------------------------------------------------------------
+  - name: jira-add-comment
+    rules:
+      # POST /rest/api/3/issue/{issueIdOrKey}/comment
+      - allow:
+          method: POST
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/*/comment"
+
+  - name: jira-update-comment
+    rules:
+      # PUT /rest/api/3/issue/{issueIdOrKey}/comment/{id}
+      - allow:
+          method: PUT
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/*/comment/*"
+
+  - name: jira-delete-comment
+    rules:
+      # DELETE /rest/api/3/issue/{issueIdOrKey}/comment/{id}
+      - allow:
+          method: DELETE
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/*/comment/*"
+
+  # ---------------------------------------------------------------------------
+  # Write operations — worklogs
+  # ---------------------------------------------------------------------------
+  - name: jira-add-worklog
+    rules:
+      # POST /rest/api/3/issue/{issueIdOrKey}/worklog
+      - allow:
+          method: POST
+          host: "*.atlassian.net"
+          path: "/rest/api/*/issue/*/worklog"
+
+  # ---------------------------------------------------------------------------
+  # Write operations — sprints
+  # ---------------------------------------------------------------------------
+  - name: jira-move-to-sprint
+    rules:
+      # POST /rest/agile/1.0/sprint/{sprintId}/issue
+      - allow:
+          method: POST
+          host: "*.atlassian.net"
+          path: "/rest/agile/*/sprint/*/issue"
+
+  # ---------------------------------------------------------------------------
+  # General read/write (catch-all for any rest/* path)
+  # ---------------------------------------------------------------------------
+  - name: jira-read
+    rules:
+      - allow:
+          method: GET
+          host: "*.atlassian.net"
+          path: "/rest/**"
+      - allow:
+          method: HEAD
+          host: "*.atlassian.net"
+          path: "/rest/**"
+
+  - name: jira-write
+    rules:
+      - allow:
+          method: POST
+          host: "*.atlassian.net"
+          path: "/rest/**"
+      - allow:
+          method: PUT
+          host: "*.atlassian.net"
+          path: "/rest/**"
+      - allow:
+          method: DELETE
+          host: "*.atlassian.net"
+          path: "/rest/**"

--- a/.alcove/policy-rules/splunk.yml
+++ b/.alcove/policy-rules/splunk.yml
@@ -1,0 +1,157 @@
+# Splunk API policy rule sets
+#
+# Each rule set maps to one or more HTTP method+host+path combinations that
+# correspond to the operations previously defined in internal/gate/scope.go's
+# mapSplunkOperation() function.
+#
+# Path patterns use "*" to match a single path segment and "**" to match
+# one or more segments. The host uses "*" to match any Splunk instance
+# since Splunk hosts vary by deployment.
+
+rule_sets:
+  # ---------------------------------------------------------------------------
+  # Search operations
+  # ---------------------------------------------------------------------------
+  - name: splunk-search
+    rules:
+      # POST /services/search/jobs (create search job)
+      - allow:
+          method: POST
+          host: "*"
+          path: "/services/search/jobs"
+      # GET /services/search/jobs/{sid} (read search status)
+      - allow:
+          method: GET
+          host: "*"
+          path: "/services/search/jobs/*"
+      # GET /services/search/jobs
+      - allow:
+          method: GET
+          host: "*"
+          path: "/services/search/jobs"
+      # POST /servicesNS/{user}/{app}/search/jobs
+      - allow:
+          method: POST
+          host: "*"
+          path: "/servicesNS/*/*/search/jobs"
+      # GET /servicesNS/{user}/{app}/search/jobs/{sid}
+      - allow:
+          method: GET
+          host: "*"
+          path: "/servicesNS/*/*/search/jobs/*"
+      # GET /servicesNS/{user}/{app}/search/jobs
+      - allow:
+          method: GET
+          host: "*"
+          path: "/servicesNS/*/*/search/jobs"
+
+  - name: splunk-read-results
+    rules:
+      # GET /services/search/jobs/{sid}/results
+      - allow:
+          method: GET
+          host: "*"
+          path: "/services/search/jobs/*/results"
+      # GET /servicesNS/{user}/{app}/search/jobs/{sid}/results
+      - allow:
+          method: GET
+          host: "*"
+          path: "/servicesNS/*/*/search/jobs/*/results"
+
+  # ---------------------------------------------------------------------------
+  # Read operations
+  # ---------------------------------------------------------------------------
+  - name: splunk-read-saved-searches
+    rules:
+      # GET /services/saved/searches
+      - allow:
+          method: GET
+          host: "*"
+          path: "/services/saved/searches"
+      # GET /services/saved/searches/{name}
+      - allow:
+          method: GET
+          host: "*"
+          path: "/services/saved/searches/*"
+      # GET /services/saved/searches/**
+      - allow:
+          method: GET
+          host: "*"
+          path: "/services/saved/searches/**"
+      # GET /servicesNS/{user}/{app}/saved/searches
+      - allow:
+          method: GET
+          host: "*"
+          path: "/servicesNS/*/*/saved/searches"
+      # GET /servicesNS/{user}/{app}/saved/searches/{name}
+      - allow:
+          method: GET
+          host: "*"
+          path: "/servicesNS/*/*/saved/searches/*"
+      # GET /servicesNS/{user}/{app}/saved/searches/**
+      - allow:
+          method: GET
+          host: "*"
+          path: "/servicesNS/*/*/saved/searches/**"
+
+  - name: splunk-read-alerts
+    rules:
+      # GET /services/alerts/**
+      - allow:
+          method: GET
+          host: "*"
+          path: "/services/alerts/**"
+      # GET /servicesNS/{user}/{app}/alerts/**
+      - allow:
+          method: GET
+          host: "*"
+          path: "/servicesNS/*/*/alerts/**"
+
+  # ---------------------------------------------------------------------------
+  # General read/write
+  # ---------------------------------------------------------------------------
+  - name: splunk-read
+    rules:
+      - allow:
+          method: GET
+          host: "*"
+          path: "/services/**"
+      - allow:
+          method: HEAD
+          host: "*"
+          path: "/services/**"
+      - allow:
+          method: GET
+          host: "*"
+          path: "/servicesNS/**"
+      - allow:
+          method: HEAD
+          host: "*"
+          path: "/servicesNS/**"
+
+  - name: splunk-write
+    rules:
+      - allow:
+          method: POST
+          host: "*"
+          path: "/services/**"
+      - allow:
+          method: PUT
+          host: "*"
+          path: "/services/**"
+      - allow:
+          method: DELETE
+          host: "*"
+          path: "/services/**"
+      - allow:
+          method: POST
+          host: "*"
+          path: "/servicesNS/**"
+      - allow:
+          method: PUT
+          host: "*"
+          path: "/servicesNS/**"
+      - allow:
+          method: DELETE
+          host: "*"
+          path: "/servicesNS/**"

--- a/.alcove/security-profiles/alcove-planner.yml
+++ b/.alcove/security-profiles/alcove-planner.yml
@@ -1,6 +1,21 @@
 name: alcove-planner
 display_name: Alcove Planner
 description: Read-only code access plus issue reading and commenting on bmbouter/alcove
+
+rules:
+  - github-clone
+  - github-read-issues
+  - github-read-prs
+  - github-read-contents
+  - github-read-commits
+  - github-read-branches
+  - github-read-git
+  - github-read-actions
+  - github-read-releases
+  - github-create-comment
+  - github-update-issue
+  - github-graphql
+
 tools:
   github:
     rules:

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -173,6 +173,9 @@ func main() {
 	// Create security profile store.
 	profileStore := bridge.NewProfileStore(dbpool)
 
+	// Create policy rule store.
+	policyRuleStore := bridge.NewPolicyRuleStore(dbpool)
+
 	// Create settings store for admin settings.
 	settingsStore := bridge.NewSettingsStore(dbpool)
 
@@ -185,7 +188,7 @@ func main() {
 	}
 
 	// Create dispatcher and API.
-	dispatcher := bridge.NewDispatcher(nc, dbpool, rt, cfg, credStore, toolStore, profileStore, settingsStore)
+	dispatcher := bridge.NewDispatcher(nc, dbpool, rt, cfg, credStore, toolStore, profileStore, settingsStore, policyRuleStore)
 
 	// Create CI Gate monitor for automated CI retry.
 	ciGateMonitor := bridge.NewCIGateMonitor(dbpool, dispatcher, credStore, bridgeLLM)
@@ -235,7 +238,7 @@ func main() {
 	}()
 
 	// Create agent repo syncer.
-	syncer := bridge.NewAgentRepoSyncer(dbpool, settingsStore, scheduler, defStore, dispatcher, profileStore, workflowStore)
+	syncer := bridge.NewAgentRepoSyncer(dbpool, settingsStore, scheduler, defStore, dispatcher, profileStore, policyRuleStore, workflowStore)
 	syncer.Start(context.Background())
 	defer func() {
 		log.Println("shutting down agent repo syncer...")

--- a/cmd/gate/main.go
+++ b/cmd/gate/main.go
@@ -49,6 +49,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/bmbouter/alcove/internal"
 	"github.com/bmbouter/alcove/internal/gate"
 )
 
@@ -219,6 +220,14 @@ func loadConfig() (gate.Config, error) {
 		log.Printf("gate: enforcement mode = monitor (log-only, all requests allowed)")
 	}
 
+	var policyRules []internal.PolicyRule
+	if prJSON := os.Getenv("GATE_POLICY_RULES"); prJSON != "" {
+		if err := json.Unmarshal([]byte(prJSON), &policyRules); err != nil {
+			return gate.Config{}, fmt.Errorf("invalid GATE_POLICY_RULES: %w", err)
+		}
+		log.Printf("gate: loaded %d policy rules", len(policyRules))
+	}
+
 	return gate.Config{
 		SessionID:          sessionID,
 		Scope:              scope,
@@ -237,5 +246,6 @@ func loadConfig() (gate.Config, error) {
 		CACertPEM:          caCertPEM,
 		CAKeyPEM:           caKeyPEM,
 		EnforcementMode:    enforcementMode,
+		PolicyRules:        policyRules,
 	}, nil
 }

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -36,32 +36,34 @@ import (
 // Dispatcher manages task lifecycle: creation, dispatch to Skiff pods,
 // and status tracking.
 type Dispatcher struct {
-	nc             *nats.Conn
-	db             *pgxpool.Pool
-	rt             runtime.Runtime
-	cfg            *Config
-	credStore      *CredentialStore
-	toolStore      *ToolStore
-	profileStore   *ProfileStore
-	settingsStore  *SettingsStore
-	mu             sync.Mutex
-	handles        map[string]runtime.TaskHandle // sessionID -> handle
-	ciGate         *CIGateMonitor
-	workflowEngine *WorkflowEngine
+	nc              *nats.Conn
+	db              *pgxpool.Pool
+	rt              runtime.Runtime
+	cfg             *Config
+	credStore       *CredentialStore
+	toolStore       *ToolStore
+	profileStore    *ProfileStore
+	settingsStore   *SettingsStore
+	policyRuleStore *PolicyRuleStore
+	mu              sync.Mutex
+	handles         map[string]runtime.TaskHandle // sessionID -> handle
+	ciGate          *CIGateMonitor
+	workflowEngine  *WorkflowEngine
 }
 
 // NewDispatcher creates a Dispatcher with the given dependencies.
-func NewDispatcher(nc *nats.Conn, db *pgxpool.Pool, rt runtime.Runtime, cfg *Config, credStore *CredentialStore, toolStore *ToolStore, profileStore *ProfileStore, settingsStore *SettingsStore) *Dispatcher {
+func NewDispatcher(nc *nats.Conn, db *pgxpool.Pool, rt runtime.Runtime, cfg *Config, credStore *CredentialStore, toolStore *ToolStore, profileStore *ProfileStore, settingsStore *SettingsStore, policyRuleStore *PolicyRuleStore) *Dispatcher {
 	return &Dispatcher{
-		nc:            nc,
-		db:            db,
-		rt:            rt,
-		cfg:           cfg,
-		credStore:     credStore,
-		toolStore:     toolStore,
-		profileStore:  profileStore,
-		settingsStore: settingsStore,
-		handles:       make(map[string]runtime.TaskHandle),
+		nc:              nc,
+		db:              db,
+		rt:              rt,
+		cfg:             cfg,
+		credStore:       credStore,
+		toolStore:       toolStore,
+		profileStore:    profileStore,
+		settingsStore:   settingsStore,
+		policyRuleStore: policyRuleStore,
+		handles:         make(map[string]runtime.TaskHandle),
 	}
 }
 
@@ -168,12 +170,14 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		scope = *req.Scope
 	}
 
-	// Resolve security profiles into scope and tools.
+	// Resolve security profiles into scope, tools, and policy rules.
+	var profileRules []ProfileRuleEntry
 	if len(req.Profiles) > 0 {
-		profileScope, profileTools, err := d.profileStore.MergeProfiles(ctx, req.Profiles, activeTeamID)
+		profileScope, profileTools, mergedRules, err := d.profileStore.MergeProfiles(ctx, req.Profiles, activeTeamID)
 		if err != nil {
 			return nil, fmt.Errorf("resolving profiles: %w", err)
 		}
+		profileRules = mergedRules
 
 		// Merge profile scope into task scope.
 		for svc, svcScope := range profileScope.Services {
@@ -509,6 +513,18 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 	// Re-marshal scope after tool resolution may have added services.
 	scopeBytes, _ = json.Marshal(scope)
 	gateEnv["GATE_SCOPE"] = string(scopeBytes)
+
+	// Resolve HTTP policy rules from profiles.
+	if d.policyRuleStore != nil && len(profileRules) > 0 {
+		resolvedRules, err := ResolvePolicyRules(ctx, d.policyRuleStore, profileRules, activeTeamID)
+		if err != nil {
+			log.Printf("warning: resolving policy rules: %v", err)
+		}
+		if len(resolvedRules) > 0 {
+			rulesJSON, _ := json.Marshal(resolvedRules)
+			gateEnv["GATE_POLICY_RULES"] = string(rulesJSON)
+		}
+	}
 
 	// Set SCM environment for Skiff tools (dummy tokens so tools don't prompt for auth).
 	// Tools reach upstream hosts via HTTP_PROXY -> Gate MITM, so no custom API URLs needed.

--- a/internal/bridge/migrations/033_policy_rule_sets.sql
+++ b/internal/bridge/migrations/033_policy_rule_sets.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS policy_rule_sets (
+    id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+    name TEXT NOT NULL,
+    rules JSONB NOT NULL DEFAULT '[]',
+    team_id TEXT NOT NULL DEFAULT '',
+    source_repo TEXT NOT NULL DEFAULT '',
+    source_file TEXT NOT NULL DEFAULT '',
+    source_key TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_policy_rule_sets_name_team ON policy_rule_sets (name, team_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_policy_rule_sets_source_key ON policy_rule_sets (source_key) WHERE source_key IS NOT NULL;

--- a/internal/bridge/migrations/034_profile_rules.sql
+++ b/internal/bridge/migrations/034_profile_rules.sql
@@ -1,0 +1,3 @@
+-- 034_profile_rules.sql
+-- Add rules column to security_profiles for HTTP-primitive policy rules.
+ALTER TABLE security_profiles ADD COLUMN IF NOT EXISTS rules JSONB NOT NULL DEFAULT '[]';

--- a/internal/bridge/policyrules.go
+++ b/internal/bridge/policyrules.go
@@ -1,0 +1,228 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/bmbouter/alcove/internal"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"gopkg.in/yaml.v3"
+)
+
+// NamedRuleSet is a named collection of HTTP policy rules that can be
+// referenced by security profiles.
+type NamedRuleSet struct {
+	Name  string                `json:"name" yaml:"name"`
+	Rules []internal.PolicyRule `json:"rules" yaml:"rules"`
+}
+
+// PolicyRuleFile is the top-level structure of a .alcove/policy-rules/*.yml file.
+type PolicyRuleFile struct {
+	RuleSets []NamedRuleSet `json:"rule_sets" yaml:"rule_sets"`
+}
+
+// ProfileRuleEntry represents a single entry in a security profile's rules list.
+// It can be either a string reference to a named rule set, or an inline rule object.
+type ProfileRuleEntry struct {
+	Ref   string             // named rule set reference (when YAML entry is a string)
+	Allow *internal.HTTPRule // inline rule (when YAML entry is a map with "allow")
+}
+
+// UnmarshalYAML implements custom YAML unmarshaling for ProfileRuleEntry.
+// A string value becomes a Ref; an object with "allow" becomes an inline rule.
+func (e *ProfileRuleEntry) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		e.Ref = value.Value
+		return nil
+	}
+	if value.Kind == yaml.MappingNode {
+		var rule internal.PolicyRule
+		if err := value.Decode(&rule); err != nil {
+			return fmt.Errorf("decoding inline policy rule: %w", err)
+		}
+		e.Allow = &rule.Allow
+		return nil
+	}
+	return fmt.Errorf("policy rule entry must be a string or an object, got %v", value.Kind)
+}
+
+// MarshalJSON implements custom JSON marshaling for ProfileRuleEntry.
+func (e ProfileRuleEntry) MarshalJSON() ([]byte, error) {
+	if e.Ref != "" {
+		return json.Marshal(e.Ref)
+	}
+	if e.Allow != nil {
+		return json.Marshal(internal.PolicyRule{Allow: *e.Allow})
+	}
+	return []byte("null"), nil
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for ProfileRuleEntry.
+func (e *ProfileRuleEntry) UnmarshalJSON(data []byte) error {
+	// Try string first.
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		e.Ref = s
+		return nil
+	}
+	// Try inline rule object.
+	var rule internal.PolicyRule
+	if err := json.Unmarshal(data, &rule); err == nil && rule.Allow.Host != "" {
+		e.Allow = &rule.Allow
+		return nil
+	}
+	return fmt.Errorf("policy rule entry must be a string or an object with 'allow'")
+}
+
+// PolicyRuleStore manages named policy rule sets in the database.
+type PolicyRuleStore struct {
+	db *pgxpool.Pool
+}
+
+// NewPolicyRuleStore creates a PolicyRuleStore with the given database pool.
+func NewPolicyRuleStore(db *pgxpool.Pool) *PolicyRuleStore {
+	return &PolicyRuleStore{db: db}
+}
+
+// UpsertRuleSet inserts or updates a named rule set, keyed by source_key.
+func (s *PolicyRuleStore) UpsertRuleSet(ctx context.Context, name, rulesJSON, teamID, sourceRepo, sourceFile, sourceKey string) error {
+	id := uuid.New().String()
+	_, err := s.db.Exec(ctx,
+		`INSERT INTO policy_rule_sets (id, name, rules, team_id, source_repo, source_file, source_key, created_at, updated_at)
+		VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7, NOW(), NOW())
+		ON CONFLICT (source_key) WHERE source_key IS NOT NULL DO UPDATE SET
+			name = EXCLUDED.name,
+			rules = EXCLUDED.rules,
+			team_id = EXCLUDED.team_id,
+			source_repo = EXCLUDED.source_repo,
+			source_file = EXCLUDED.source_file,
+			updated_at = NOW()`,
+		id, name, rulesJSON, teamID, sourceRepo, sourceFile, sourceKey)
+	if err != nil {
+		return fmt.Errorf("upserting policy rule set %q: %w", name, err)
+	}
+	return nil
+}
+
+// GetRuleSet looks up a named rule set by name and team.
+func (s *PolicyRuleStore) GetRuleSet(ctx context.Context, name, teamID string) (*NamedRuleSet, error) {
+	var rulesJSON string
+	var rsName string
+	err := s.db.QueryRow(ctx,
+		`SELECT name, rules FROM policy_rule_sets WHERE name = $1 AND team_id = $2`,
+		name, teamID).Scan(&rsName, &rulesJSON)
+	if err != nil {
+		return nil, fmt.Errorf("rule set %q not found: %w", name, err)
+	}
+
+	var rules []internal.PolicyRule
+	if err := json.Unmarshal([]byte(rulesJSON), &rules); err != nil {
+		return nil, fmt.Errorf("unmarshaling rules for %q: %w", name, err)
+	}
+
+	return &NamedRuleSet{Name: rsName, Rules: rules}, nil
+}
+
+// ListRuleSets returns all named rule sets for a team.
+func (s *PolicyRuleStore) ListRuleSets(ctx context.Context, teamID string) ([]NamedRuleSet, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT name, rules FROM policy_rule_sets WHERE team_id = $1 ORDER BY name ASC`, teamID)
+	if err != nil {
+		return nil, fmt.Errorf("querying rule sets: %w", err)
+	}
+	defer rows.Close()
+
+	var result []NamedRuleSet
+	for rows.Next() {
+		var name, rulesJSON string
+		if err := rows.Scan(&name, &rulesJSON); err != nil {
+			return nil, fmt.Errorf("scanning rule set: %w", err)
+		}
+		var rules []internal.PolicyRule
+		if err := json.Unmarshal([]byte(rulesJSON), &rules); err != nil {
+			return nil, fmt.Errorf("unmarshaling rules for %q: %w", name, err)
+		}
+		result = append(result, NamedRuleSet{Name: name, Rules: rules})
+	}
+	if result == nil {
+		result = []NamedRuleSet{}
+	}
+	return result, rows.Err()
+}
+
+// DeleteByRepo removes all rule sets from a given source repo and team.
+func (s *PolicyRuleStore) DeleteByRepo(ctx context.Context, sourceRepo, teamID string) error {
+	_, err := s.db.Exec(ctx,
+		`DELETE FROM policy_rule_sets WHERE source_repo = $1 AND team_id = $2`,
+		sourceRepo, teamID)
+	return err
+}
+
+// ListSourceKeysByRepo returns source_keys for all rule sets from a given repo and team.
+func (s *PolicyRuleStore) ListSourceKeysByRepo(ctx context.Context, sourceRepo, teamID string) ([]string, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT source_key FROM policy_rule_sets WHERE source_repo = $1 AND team_id = $2`, sourceRepo, teamID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, rows.Err()
+}
+
+// StoredRuleSet represents a rule set as stored in the database, including metadata.
+type StoredRuleSet struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	Rules      string    `json:"rules"` // raw JSON
+	TeamID     string    `json:"team_id"`
+	SourceRepo string    `json:"source_repo"`
+	SourceFile string    `json:"source_file"`
+	SourceKey  string    `json:"source_key"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// ResolvePolicyRules expands profile rule entries (named references and inline rules)
+// into a flat list of PolicyRule values. For each entry: if it's a string reference,
+// look up the named rule set and append its rules. If it's an inline rule, append directly.
+func ResolvePolicyRules(ctx context.Context, store *PolicyRuleStore, profileRules []ProfileRuleEntry, teamID string) ([]internal.PolicyRule, error) {
+	var result []internal.PolicyRule
+	for _, entry := range profileRules {
+		if entry.Ref != "" {
+			rs, err := store.GetRuleSet(ctx, entry.Ref, teamID)
+			if err != nil {
+				return nil, fmt.Errorf("resolving rule set %q: %w", entry.Ref, err)
+			}
+			result = append(result, rs.Rules...)
+		} else if entry.Allow != nil {
+			result = append(result, internal.PolicyRule{Allow: *entry.Allow})
+		}
+	}
+	return result, nil
+}

--- a/internal/bridge/security.go
+++ b/internal/bridge/security.go
@@ -34,6 +34,7 @@ type SecurityProfile struct {
 	DisplayName string                       `json:"display_name,omitempty" yaml:"display_name"`
 	Description string                       `json:"description,omitempty" yaml:"description"`
 	Tools       map[string]ProfileToolConfig `json:"tools" yaml:"tools"`
+	Rules       []ProfileRuleEntry           `json:"rules,omitempty" yaml:"rules"`
 	TeamID      string                       `json:"team_id,omitempty"`
 	IsBuiltin   bool                         `json:"is_builtin"`
 	Source      string                       `json:"source"`
@@ -128,12 +129,16 @@ func (ps *ProfileStore) CreateProfile(ctx context.Context, profile *SecurityProf
 	if err != nil {
 		return fmt.Errorf("marshaling tools: %w", err)
 	}
+	rulesJSON, err := json.Marshal(profile.Rules)
+	if err != nil {
+		return fmt.Errorf("marshaling rules: %w", err)
+	}
 
 	_, err = ps.db.Exec(ctx,
-		`INSERT INTO security_profiles (id, name, display_name, description, tools, team_id, is_builtin, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		`INSERT INTO security_profiles (id, name, display_name, description, tools, rules, team_id, is_builtin, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
 		profile.ID, profile.Name, profile.DisplayName, profile.Description,
-		string(toolsJSON), profile.TeamID, profile.IsBuiltin,
+		string(toolsJSON), string(rulesJSON), profile.TeamID, profile.IsBuiltin,
 		profile.CreatedAt, profile.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("inserting profile: %w", err)
@@ -143,7 +148,7 @@ func (ps *ProfileStore) CreateProfile(ctx context.Context, profile *SecurityProf
 
 // ListProfiles returns the given team's profiles.
 func (ps *ProfileStore) ListProfiles(ctx context.Context, teamID string) ([]SecurityProfile, error) {
-	query := `SELECT id, name, display_name, description, tools, team_id, is_builtin, source, source_repo, source_key, created_at, updated_at
+	query := `SELECT id, name, display_name, description, tools, rules, team_id, is_builtin, source, source_repo, source_key, created_at, updated_at
 		FROM security_profiles
 		WHERE team_id = $1
 		ORDER BY name ASC`
@@ -172,7 +177,7 @@ func (ps *ProfileStore) ListProfiles(ctx context.Context, teamID string) ([]Secu
 
 // GetProfile looks up a profile by name, scoped to the given team.
 func (ps *ProfileStore) GetProfile(ctx context.Context, name, teamID string) (*SecurityProfile, error) {
-	query := `SELECT id, name, display_name, description, tools, team_id, is_builtin, source, source_repo, source_key, created_at, updated_at
+	query := `SELECT id, name, display_name, description, tools, rules, team_id, is_builtin, source, source_repo, source_key, created_at, updated_at
 		FROM security_profiles
 		WHERE name = $1 AND team_id = $2
 		ORDER BY source ASC
@@ -188,13 +193,17 @@ func (ps *ProfileStore) UpdateProfile(ctx context.Context, profile *SecurityProf
 	if err != nil {
 		return fmt.Errorf("marshaling tools: %w", err)
 	}
+	rulesJSON, err := json.Marshal(profile.Rules)
+	if err != nil {
+		return fmt.Errorf("marshaling rules: %w", err)
+	}
 
 	now := time.Now().UTC()
 	result, err := ps.db.Exec(ctx,
 		`UPDATE security_profiles
-		SET display_name = $1, description = $2, tools = $3, updated_at = $4
-		WHERE name = $5 AND team_id = $6 AND source != 'yaml'`,
-		profile.DisplayName, profile.Description, string(toolsJSON), now,
+		SET display_name = $1, description = $2, tools = $3, rules = $4, updated_at = $5
+		WHERE name = $6 AND team_id = $7 AND source != 'yaml'`,
+		profile.DisplayName, profile.Description, string(toolsJSON), string(rulesJSON), now,
 		profile.Name, teamID)
 	if err != nil {
 		return fmt.Errorf("updating profile: %w", err)
@@ -220,17 +229,22 @@ func (ps *ProfileStore) DeleteProfile(ctx context.Context, name, teamID string) 
 	return nil
 }
 
-// MergeProfiles takes multiple profile names, looks them up, and returns a merged Scope
-// and merged tool config map. Union merge: operations unioned, repos unioned, wildcard wins.
-func (ps *ProfileStore) MergeProfiles(ctx context.Context, names []string, teamID string) (internal.Scope, map[string]ProfileToolConfig, error) {
+// MergeProfiles takes multiple profile names, looks them up, and returns a merged Scope,
+// merged tool config map, and collected policy rule entries.
+// Union merge: operations unioned, repos unioned, wildcard wins.
+func (ps *ProfileStore) MergeProfiles(ctx context.Context, names []string, teamID string) (internal.Scope, map[string]ProfileToolConfig, []ProfileRuleEntry, error) {
 	scope := internal.Scope{Services: make(map[string]internal.ServiceScope)}
 	merged := make(map[string]ProfileToolConfig)
+	var policyRules []ProfileRuleEntry
 
 	for _, name := range names {
 		profile, err := ps.GetProfile(ctx, name, teamID)
 		if err != nil {
-			return scope, nil, fmt.Errorf("profile %q not found: %w", name, err)
+			return scope, nil, nil, fmt.Errorf("profile %q not found: %w", name, err)
 		}
+
+		// Collect policy rule entries from this profile.
+		policyRules = append(policyRules, profile.Rules...)
 
 		for tool, cfg := range profile.Tools {
 			existing := merged[tool]
@@ -277,22 +291,27 @@ func (ps *ProfileStore) MergeProfiles(ctx context.Context, names []string, teamI
 		}
 	}
 
-	return scope, merged, nil
+	return scope, merged, policyRules, nil
 }
 
 // scanProfile scans a SecurityProfile from a rows result.
 func scanProfile(rows interface{ Scan(dest ...any) error }) (*SecurityProfile, error) {
 	var p SecurityProfile
-	var toolsJSON string
+	var toolsJSON, rulesJSON string
 
 	if err := rows.Scan(&p.ID, &p.Name, &p.DisplayName, &p.Description,
-		&toolsJSON, &p.TeamID, &p.IsBuiltin, &p.Source, &p.SourceRepo, &p.SourceKey,
+		&toolsJSON, &rulesJSON, &p.TeamID, &p.IsBuiltin, &p.Source, &p.SourceRepo, &p.SourceKey,
 		&p.CreatedAt, &p.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("scanning profile: %w", err)
 	}
 
 	if err := json.Unmarshal([]byte(toolsJSON), &p.Tools); err != nil {
 		return nil, fmt.Errorf("unmarshaling profile tools: %w", err)
+	}
+	if rulesJSON != "" && rulesJSON != "[]" {
+		if err := json.Unmarshal([]byte(rulesJSON), &p.Rules); err != nil {
+			return nil, fmt.Errorf("unmarshaling profile rules: %w", err)
+		}
 	}
 
 	return &p, nil
@@ -328,19 +347,25 @@ func (ps *ProfileStore) UpsertYAMLProfile(ctx context.Context, profile *Security
 		return fmt.Errorf("marshaling tools: %w", err)
 	}
 
+	rulesJSON, err := json.Marshal(profile.Rules)
+	if err != nil {
+		return fmt.Errorf("marshaling rules: %w", err)
+	}
+
 	_, err = ps.db.Exec(ctx,
-		`INSERT INTO security_profiles (id, name, display_name, description, tools, team_id, is_builtin, source, source_repo, source_key, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, false, 'yaml', $7, $8, NOW(), NOW())
+		`INSERT INTO security_profiles (id, name, display_name, description, tools, rules, team_id, is_builtin, source, source_repo, source_key, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, false, 'yaml', $8, $9, NOW(), NOW())
 		ON CONFLICT (source_key) WHERE source_key != '' DO UPDATE SET
 			name = EXCLUDED.name,
 			display_name = EXCLUDED.display_name,
 			description = EXCLUDED.description,
 			tools = EXCLUDED.tools,
+			rules = EXCLUDED.rules,
 			team_id = EXCLUDED.team_id,
 			source_repo = EXCLUDED.source_repo,
 			updated_at = NOW()`,
 		profile.ID, profile.Name, profile.DisplayName, profile.Description,
-		string(toolsJSON), profile.TeamID, profile.SourceRepo, profile.SourceKey)
+		string(toolsJSON), string(rulesJSON), profile.TeamID, profile.SourceRepo, profile.SourceKey)
 	if err != nil {
 		return fmt.Errorf("upserting YAML profile: %w", err)
 	}

--- a/internal/bridge/tasksync.go
+++ b/internal/bridge/tasksync.go
@@ -29,10 +29,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/sync/semaphore"
+	"gopkg.in/yaml.v3"
 )
 
 // AgentRepoSyncer periodically clones/pulls agent repos and syncs YAML agent
-// definitions, workflow definitions, and security profiles into the database, reconciling schedules as needed.
+// definitions, workflow definitions, security profiles, and policy rules into the database, reconciling schedules as needed.
 type AgentRepoSyncer struct {
 	db               *pgxpool.Pool
 	settingsStore    *SettingsStore
@@ -40,6 +41,7 @@ type AgentRepoSyncer struct {
 	defStore         *AgentDefStore
 	dispatcher       *Dispatcher
 	profileStore     *ProfileStore
+	policyRuleStore  *PolicyRuleStore
 	workflowStore    *WorkflowStore
 	catalogItemStore *CatalogItemStore
 	interval         time.Duration
@@ -51,7 +53,7 @@ type AgentRepoSyncer struct {
 }
 
 // NewAgentRepoSyncer creates a AgentRepoSyncer with the given dependencies.
-func NewAgentRepoSyncer(db *pgxpool.Pool, settingsStore *SettingsStore, scheduler *Scheduler, defStore *AgentDefStore, dispatcher *Dispatcher, profileStore *ProfileStore, workflowStore *WorkflowStore) *AgentRepoSyncer {
+func NewAgentRepoSyncer(db *pgxpool.Pool, settingsStore *SettingsStore, scheduler *Scheduler, defStore *AgentDefStore, dispatcher *Dispatcher, profileStore *ProfileStore, policyRuleStore *PolicyRuleStore, workflowStore *WorkflowStore) *AgentRepoSyncer {
 	interval := 15 * time.Minute
 	if v := os.Getenv("AGENT_REPO_SYNC_INTERVAL"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
@@ -66,6 +68,7 @@ func NewAgentRepoSyncer(db *pgxpool.Pool, settingsStore *SettingsStore, schedule
 		defStore:         defStore,
 		dispatcher:       dispatcher,
 		profileStore:     profileStore,
+		policyRuleStore:  policyRuleStore,
 		workflowStore:    workflowStore,
 		catalogItemStore: NewCatalogItemStore(db),
 		interval:         interval,
@@ -212,9 +215,10 @@ func (s *AgentRepoSyncer) SyncAll(ctx context.Context) error {
 			removedRepos := make(map[string]bool)
 			for _, def := range teamDefs {
 				if !configuredURLs[def.SourceRepo] && !removedRepos[def.SourceRepo] {
-					log.Printf("agent-repo-syncer: removing agent definitions, workflows, and profiles from %s for team %s (no longer configured)", def.SourceRepo, teamID)
+					log.Printf("agent-repo-syncer: removing agent definitions, workflows, profiles, and policy rules from %s for team %s (no longer configured)", def.SourceRepo, teamID)
 					_ = s.defStore.DeleteAgentDefinitionsByRepo(ctx, def.SourceRepo, teamID)
 					_ = s.profileStore.DeleteYAMLProfilesByRepo(ctx, def.SourceRepo, teamID)
+					_ = s.policyRuleStore.DeleteByRepo(ctx, def.SourceRepo, teamID)
 					_ = s.workflowStore.DeleteWorkflowsByRepo(ctx, def.SourceRepo, teamID)
 					// Also clean up schedules from this repo.
 					s.db.Exec(ctx, `DELETE FROM schedules WHERE source_key LIKE $1 AND team_id = $2`, username+"::%", teamID)
@@ -402,6 +406,9 @@ func (s *AgentRepoSyncer) syncRepo(ctx context.Context, repo SkillRepo, username
 	// Sync security profiles from .alcove/security-profiles/*.yml.
 	s.syncSecurityProfiles(ctx, cloneDir, repo, username, teamID)
 
+	// Sync policy rules from .alcove/policy-rules/*.yml.
+	s.syncPolicyRules(ctx, cloneDir, repo, username, teamID)
+
 	// Read all .alcove/agents/*.yml files. Fall back to .alcove/tasks/ for
 	// backward compatibility with repos that haven't been updated yet.
 	agentsDir := filepath.Join(cloneDir, ".alcove", "agents")
@@ -574,6 +581,77 @@ func (s *AgentRepoSyncer) syncSecurityProfiles(ctx context.Context, cloneDir str
 	}
 
 	log.Printf("agent-repo-syncer: synced %d security profile(s) from %s", len(seenKeys), repo.URL)
+}
+
+// syncPolicyRules syncs .alcove/policy-rules/*.yml from a cloned repo for the given user.
+func (s *AgentRepoSyncer) syncPolicyRules(ctx context.Context, cloneDir string, repo SkillRepo, username, teamID string) {
+	rulesDir := filepath.Join(cloneDir, ".alcove", "policy-rules")
+	entries, err := os.ReadDir(rulesDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("agent-repo-syncer: error reading policy-rules dir: %v", err)
+		}
+		// No policy-rules dir — clean up any previously synced rule sets from this repo.
+		_ = s.policyRuleStore.DeleteByRepo(ctx, repo.URL, teamID)
+		return
+	}
+
+	seenKeys := make(map[string]bool)
+
+	for _, entry := range entries {
+		if entry.IsDir() || (!strings.HasSuffix(entry.Name(), ".yml") && !strings.HasSuffix(entry.Name(), ".yaml")) {
+			continue
+		}
+
+		filePath := filepath.Join(rulesDir, entry.Name())
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			log.Printf("agent-repo-syncer: error reading %s: %v", filePath, err)
+			continue
+		}
+
+		var ruleFile PolicyRuleFile
+		if err := yaml.Unmarshal(data, &ruleFile); err != nil {
+			log.Printf("agent-repo-syncer: error parsing policy rules in %s/%s: %v", repo.URL, entry.Name(), err)
+			continue
+		}
+
+		for _, rs := range ruleFile.RuleSets {
+			if rs.Name == "" {
+				log.Printf("agent-repo-syncer: skipping unnamed rule set in %s/%s", repo.URL, entry.Name())
+				continue
+			}
+
+			sourceKey := fmt.Sprintf("%s::%s::policy-rules/%s::%s", username, repo.URL, entry.Name(), rs.Name)
+			seenKeys[sourceKey] = true
+
+			rulesJSON, err := json.Marshal(rs.Rules)
+			if err != nil {
+				log.Printf("agent-repo-syncer: error marshaling rules for %s: %v", rs.Name, err)
+				continue
+			}
+
+			if err := s.policyRuleStore.UpsertRuleSet(ctx, rs.Name, string(rulesJSON), teamID, repo.URL, entry.Name(), sourceKey); err != nil {
+				log.Printf("agent-repo-syncer: rule set upsert error for %s: %v", sourceKey, err)
+			}
+		}
+	}
+
+	// Delete stale rule sets from this repo.
+	existingKeys, err := s.policyRuleStore.ListSourceKeysByRepo(ctx, repo.URL, teamID)
+	if err != nil {
+		log.Printf("agent-repo-syncer: error listing existing rule set keys: %v", err)
+		return
+	}
+	for _, key := range existingKeys {
+		if !seenKeys[key] {
+			if _, err := s.db.Exec(ctx, `DELETE FROM policy_rule_sets WHERE source_key = $1`, key); err != nil {
+				log.Printf("agent-repo-syncer: error deleting stale rule set %s: %v", key, err)
+			}
+		}
+	}
+
+	log.Printf("agent-repo-syncer: synced %d policy rule set(s) from %s", len(seenKeys), repo.URL)
 }
 
 // validateProfileReferences checks that all profile references in agent definitions

--- a/internal/gate/mitm.go
+++ b/internal/gate/mitm.go
@@ -34,6 +34,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bmbouter/alcove/internal"
 )
 
 const certCacheMaxSize = 256
@@ -148,11 +150,12 @@ func generateLeafCert(hostname string, caCert *x509.Certificate, caKey crypto.Pr
 // MITMHandler handles CONNECT requests by performing TLS interception,
 // credential injection, and scope enforcement.
 type MITMHandler struct {
-	caCert    *x509.Certificate
-	caKey     crypto.PrivateKey
-	certCache *CertCache
-	config    *Config
-	domains   map[string]bool // set of MITM-eligible hostnames
+	caCert          *x509.Certificate
+	caKey           crypto.PrivateKey
+	certCache       *CertCache
+	config          *Config
+	domains         map[string]bool          // set of MITM-eligible hostnames (exact)
+	policyRuleHosts []internal.PolicyRule     // for wildcard host matching
 }
 
 // NewMITMHandler parses the PEM-encoded CA cert+key and initializes the handler.
@@ -208,6 +211,14 @@ func NewMITMHandler(caCertPEM, caKeyPEM []byte, config *Config) (*MITMHandler, e
 		}
 	}
 
+	// Add hosts from PolicyRules (store wildcard patterns separately)
+	for _, rule := range config.PolicyRules {
+		if rule.Allow.Host != "" {
+			m.domains[rule.Allow.Host] = true
+		}
+	}
+	m.policyRuleHosts = config.PolicyRules
+
 	return m, nil
 }
 
@@ -240,6 +251,13 @@ func (m *MITMHandler) IsMITMDomain(hostname string) bool {
 	// Wildcard matching for Jira/Atlassian
 	if _, ok := m.config.Scope.Services["jira"]; ok {
 		if strings.HasSuffix(hostname, ".atlassian.net") {
+			return true
+		}
+	}
+
+	// Check policy rule hosts with wildcard matching
+	for _, rule := range m.policyRuleHosts {
+		if matchHost(hostname, rule.Allow.Host) {
 			return true
 		}
 	}
@@ -306,7 +324,12 @@ func (m *MITMHandler) HandleCONNECT(w http.ResponseWriter, r *http.Request, targ
 
 func (m *MITMHandler) handleMITMRequest(clientConn net.Conn, req *http.Request, hostname, targetHost string) {
 	// Check scope (skip enforcement in monitor mode)
-	result := CheckAccess(req.Method, req.URL.String(), m.config.Scope)
+	var result AccessResult
+	if len(m.config.PolicyRules) > 0 {
+		result = CheckPolicyRules(req.Method, req.URL.String(), m.config.PolicyRules)
+	} else {
+		result = CheckAccess(req.Method, req.URL.String(), m.config.Scope)
+	}
 	if !result.Allowed {
 		if m.config.EnforcementMode == "monitor" {
 			log.Printf("gate: MITM monitor: would deny %s %s: %s (allowing)", req.Method, req.URL.String(), result.Reason)

--- a/internal/gate/policy.go
+++ b/internal/gate/policy.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gate
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/bmbouter/alcove/internal"
+)
+
+// CheckPolicyRules evaluates an HTTP request against resolved policy rules.
+// Default-deny: if no rule matches, the request is denied.
+func CheckPolicyRules(method, requestURL string, rules []internal.PolicyRule) AccessResult {
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return AccessResult{Allowed: false, Reason: "invalid URL"}
+	}
+
+	host := u.Hostname()
+	path := u.Path
+
+	for _, rule := range rules {
+		if matchesRule(method, host, path, rule.Allow) {
+			return AccessResult{
+				Allowed:   true,
+				Service:   host,
+				Operation: method + " " + path,
+			}
+		}
+	}
+
+	return AccessResult{
+		Allowed: false,
+		Reason:  fmt.Sprintf("no policy rule allows %s %s", method, requestURL),
+	}
+}
+
+// matchesRule checks if a request matches a single HTTP rule.
+func matchesRule(method, host, path string, rule internal.HTTPRule) bool {
+	// Method match: "*" matches any, otherwise case-insensitive exact
+	if rule.Method != "*" && !strings.EqualFold(method, rule.Method) {
+		return false
+	}
+
+	// Host match: exact or wildcard prefix (*.example.com)
+	if !matchHost(host, rule.Host) {
+		return false
+	}
+
+	// Path match: glob
+	if !matchPathGlob(path, rule.Path) {
+		return false
+	}
+
+	return true
+}
+
+// matchHost matches a hostname against a pattern. Supports:
+// - Exact match: "api.github.com"
+// - Wildcard prefix: "*.atlassian.net" (matches any subdomain)
+// - Full wildcard: "*" (matches any host)
+func matchHost(host, pattern string) bool {
+	if pattern == "*" {
+		return true
+	}
+	if strings.HasPrefix(pattern, "*.") {
+		suffix := strings.ToLower(pattern[1:]) // ".atlassian.net"
+		return strings.HasSuffix(strings.ToLower(host), suffix)
+	}
+	return strings.EqualFold(host, pattern)
+}
+
+// matchPathGlob matches a URL path against a glob pattern.
+// * matches exactly one path segment, ** matches zero or more segments.
+func matchPathGlob(path, pattern string) bool {
+	pathSegs := splitPath(path)
+	patSegs := splitPath(pattern)
+	return matchSegments(pathSegs, patSegs)
+}
+
+// splitPath splits a path by "/" and removes empty segments from the middle,
+// but preserves the overall structure.
+func splitPath(p string) []string {
+	p = strings.TrimPrefix(p, "/")
+	if p == "" {
+		return nil
+	}
+	return strings.Split(p, "/")
+}
+
+// matchSegments recursively matches path segments against pattern segments.
+func matchSegments(pathSegs, patSegs []string) bool {
+	pi := 0 // path index
+	pp := 0 // pattern index
+
+	for pp < len(patSegs) {
+		if patSegs[pp] == "**" {
+			// ** matches zero or more segments (greedy, try all positions)
+			// Try matching the rest of the pattern starting from each position
+			remaining := patSegs[pp+1:]
+			// Try matching zero segments through all remaining path segments
+			for i := pi; i <= len(pathSegs); i++ {
+				if matchSegments(pathSegs[i:], remaining) {
+					return true
+				}
+			}
+			return false
+		}
+
+		// Need a path segment to match against
+		if pi >= len(pathSegs) {
+			return false
+		}
+
+		if patSegs[pp] == "*" {
+			// * matches exactly one segment
+			pi++
+			pp++
+			continue
+		}
+
+		// Exact match (case-sensitive for paths)
+		if pathSegs[pi] != patSegs[pp] {
+			return false
+		}
+
+		pi++
+		pp++
+	}
+
+	// Both must be exhausted
+	return pi == len(pathSegs)
+}

--- a/internal/gate/policy_test.go
+++ b/internal/gate/policy_test.go
@@ -1,0 +1,326 @@
+// Copyright 2026 Brian Bouterse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gate
+
+import (
+	"testing"
+
+	"github.com/bmbouter/alcove/internal"
+)
+
+func TestMatchPathGlob(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		pattern string
+		want    bool
+	}{
+		// Exact paths
+		{"exact match", "/repos/owner/repo/issues", "/repos/owner/repo/issues", true},
+		{"exact mismatch", "/repos/owner/repo/issues", "/repos/owner/repo/pulls", false},
+		{"root path", "/", "/", true},
+		{"exact with trailing slash", "/repos/", "/repos/", true},
+
+		// Single-segment wildcard (*)
+		{"star matches one segment", "/repos/owner/repo/issues", "/repos/*/repo/issues", true},
+		{"star matches owner and repo", "/repos/owner/repo/issues", "/repos/*/*/issues", true},
+		{"star does not match zero segments", "/repos/issues", "/repos/*/issues", false},
+		{"star does not match multiple segments", "/repos/owner/sub/repo/issues", "/repos/*/repo/issues", false},
+		{"star at end matches one segment", "/repos/owner", "/repos/*", true},
+		{"star at end does not match two segments", "/repos/owner/repo", "/repos/*", false},
+
+		// Multi-segment wildcard (**)
+		{"doublestar matches zero segments", "/repos/issues", "/repos/**/issues", true},
+		{"doublestar matches one segment", "/repos/owner/issues", "/repos/**/issues", true},
+		{"doublestar matches multiple segments", "/repos/owner/repo/sub/issues", "/repos/**/issues", true},
+		{"doublestar at end matches everything", "/repos/owner/repo/anything", "/repos/**", true},
+		{"doublestar at end matches zero", "/repos", "/repos/**", true},
+		{"doublestar at start", "/a/b/c/end", "/**/end", true},
+		{"doublestar matches entire path", "/any/path/here", "/**", true},
+
+		// Edge cases
+		{"empty path vs empty pattern", "", "", true},
+		{"empty path vs non-empty pattern", "", "/repos", false},
+		{"non-empty path vs empty pattern", "/repos", "", false},
+		{"double slash in path", "/repos//issues", "/repos//issues", true},
+		{"trailing slash pattern no trailing slash path", "/repos", "/repos/", false},
+
+		// Combined wildcards
+		{"star and doublestar", "/repos/owner/repo/pulls/123/reviews", "/repos/*/*/pulls/*/reviews", true},
+		{"star and doublestar combined", "/repos/owner/repo/a/b/c", "/repos/*/*/**", true},
+		{"doublestar then star", "/a/b/c/d", "/**/*/d", true},
+
+		// Real GitHub API patterns
+		{"github issues", "/repos/owner/repo/issues", "/repos/*/*/issues", true},
+		{"github pulls reviews", "/repos/owner/repo/pulls/42/reviews", "/repos/*/*/pulls/*/reviews", true},
+		{"github graphql", "/graphql", "/graphql", true},
+		{"github contents deep", "/repos/owner/repo/contents/src/main.go", "/repos/*/*/contents/**", true},
+		{"github contents root", "/repos/owner/repo/contents", "/repos/*/*/contents/**", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchPathGlob(tt.path, tt.pattern)
+			if got != tt.want {
+				t.Errorf("matchPathGlob(%q, %q) = %v, want %v", tt.path, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesRule(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		host   string
+		path   string
+		rule   internal.HTTPRule
+		want   bool
+	}{
+		// Method matching
+		{
+			"exact method match",
+			"GET", "api.github.com", "/repos/owner/repo",
+			internal.HTTPRule{Method: "GET", Host: "api.github.com", Path: "/repos/owner/repo"},
+			true,
+		},
+		{
+			"method wildcard",
+			"POST", "api.github.com", "/repos/owner/repo",
+			internal.HTTPRule{Method: "*", Host: "api.github.com", Path: "/repos/owner/repo"},
+			true,
+		},
+		{
+			"method case insensitive",
+			"get", "api.github.com", "/repos/owner/repo",
+			internal.HTTPRule{Method: "GET", Host: "api.github.com", Path: "/repos/owner/repo"},
+			true,
+		},
+		{
+			"method mismatch",
+			"POST", "api.github.com", "/repos/owner/repo",
+			internal.HTTPRule{Method: "GET", Host: "api.github.com", Path: "/repos/owner/repo"},
+			false,
+		},
+
+		// Host matching
+		{
+			"host case insensitive",
+			"GET", "API.GitHub.Com", "/repos/owner/repo",
+			internal.HTTPRule{Method: "GET", Host: "api.github.com", Path: "/repos/owner/repo"},
+			true,
+		},
+		{
+			"host mismatch",
+			"GET", "api.gitlab.com", "/repos/owner/repo",
+			internal.HTTPRule{Method: "GET", Host: "api.github.com", Path: "/repos/owner/repo"},
+			false,
+		},
+
+		// Path matching via glob
+		{
+			"path with glob",
+			"GET", "api.github.com", "/repos/owner/repo/issues",
+			internal.HTTPRule{Method: "GET", Host: "api.github.com", Path: "/repos/*/*/issues"},
+			true,
+		},
+		{
+			"path glob mismatch",
+			"GET", "api.github.com", "/repos/owner/repo/pulls",
+			internal.HTTPRule{Method: "GET", Host: "api.github.com", Path: "/repos/*/*/issues"},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesRule(tt.method, tt.host, tt.path, tt.rule)
+			if got != tt.want {
+				t.Errorf("matchesRule(%q, %q, %q, %+v) = %v, want %v",
+					tt.method, tt.host, tt.path, tt.rule, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckPolicyRules(t *testing.T) {
+	rules := []internal.PolicyRule{
+		{Allow: internal.HTTPRule{Method: "GET", Host: "api.github.com", Path: "/repos/*/*/issues"}},
+		{Allow: internal.HTTPRule{Method: "POST", Host: "api.github.com", Path: "/repos/*/*/issues"}},
+		{Allow: internal.HTTPRule{Method: "*", Host: "api.github.com", Path: "/repos/*/*/pulls/*/reviews"}},
+		{Allow: internal.HTTPRule{Method: "POST", Host: "api.github.com", Path: "/graphql"}},
+		{Allow: internal.HTTPRule{Method: "GET", Host: "api.github.com", Path: "/repos/*/*/contents/**"}},
+	}
+
+	tests := []struct {
+		name       string
+		method     string
+		url        string
+		rules      []internal.PolicyRule
+		wantAllow  bool
+		wantReason string // substring check for denied requests
+	}{
+		// Matching rules
+		{
+			"GET issues allowed",
+			"GET", "https://api.github.com/repos/owner/repo/issues",
+			rules, true, "",
+		},
+		{
+			"POST issues allowed",
+			"POST", "https://api.github.com/repos/owner/repo/issues",
+			rules, true, "",
+		},
+		{
+			"any method on reviews allowed",
+			"PUT", "https://api.github.com/repos/owner/repo/pulls/42/reviews",
+			rules, true, "",
+		},
+		{
+			"POST graphql allowed",
+			"POST", "https://api.github.com/graphql",
+			rules, true, "",
+		},
+		{
+			"GET deep contents allowed",
+			"GET", "https://api.github.com/repos/owner/repo/contents/src/main.go",
+			rules, true, "",
+		},
+		{
+			"GET root contents allowed",
+			"GET", "https://api.github.com/repos/owner/repo/contents",
+			rules, true, "",
+		},
+
+		// First match wins
+		{
+			"first matching rule wins",
+			"GET", "https://api.github.com/repos/owner/repo/issues",
+			rules, true, "",
+		},
+
+		// No match -> denied
+		{
+			"DELETE issues not allowed",
+			"DELETE", "https://api.github.com/repos/owner/repo/issues",
+			rules, false, "no policy rule allows",
+		},
+		{
+			"wrong host denied",
+			"GET", "https://api.gitlab.com/repos/owner/repo/issues",
+			rules, false, "no policy rule allows",
+		},
+		{
+			"wrong path denied",
+			"GET", "https://api.github.com/repos/owner/repo/actions",
+			rules, false, "no policy rule allows",
+		},
+
+		// Empty rules -> denied
+		{
+			"empty rules deny everything",
+			"GET", "https://api.github.com/repos/owner/repo/issues",
+			nil, false, "no policy rule allows",
+		},
+		{
+			"empty rules slice denies",
+			"GET", "https://api.github.com/anything",
+			[]internal.PolicyRule{}, false, "no policy rule allows",
+		},
+
+		// Invalid URL
+		{
+			"invalid URL denied",
+			"GET", "://invalid",
+			rules, false, "invalid URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckPolicyRules(tt.method, tt.url, tt.rules)
+			if result.Allowed != tt.wantAllow {
+				t.Errorf("CheckPolicyRules(%q, %q) allowed=%v, want %v (reason: %s)",
+					tt.method, tt.url, result.Allowed, tt.wantAllow, result.Reason)
+			}
+			if !tt.wantAllow && tt.wantReason != "" {
+				if !contains(result.Reason, tt.wantReason) {
+					t.Errorf("CheckPolicyRules(%q, %q) reason=%q, want to contain %q",
+						tt.method, tt.url, result.Reason, tt.wantReason)
+				}
+			}
+			if tt.wantAllow {
+				if result.Service == "" {
+					t.Errorf("CheckPolicyRules(%q, %q) service should not be empty on allow", tt.method, tt.url)
+				}
+				if result.Operation == "" {
+					t.Errorf("CheckPolicyRules(%q, %q) operation should not be empty on allow", tt.method, tt.url)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckPolicyRulesRealPatterns(t *testing.T) {
+	// Test with real-world GitHub API patterns
+	rules := []internal.PolicyRule{
+		// Read-only access to repos
+		{Allow: internal.HTTPRule{Method: "GET", Host: "api.github.com", Path: "/repos/**"}},
+		// Create and read PRs
+		{Allow: internal.HTTPRule{Method: "POST", Host: "api.github.com", Path: "/repos/*/*/pulls"}},
+		// GraphQL
+		{Allow: internal.HTTPRule{Method: "POST", Host: "api.github.com", Path: "/graphql"}},
+	}
+
+	tests := []struct {
+		name      string
+		method    string
+		url       string
+		wantAllow bool
+	}{
+		{"read repo", "GET", "https://api.github.com/repos/owner/repo", true},
+		{"read issues", "GET", "https://api.github.com/repos/owner/repo/issues", true},
+		{"read deep path", "GET", "https://api.github.com/repos/owner/repo/pulls/1/reviews/2", true},
+		{"create PR", "POST", "https://api.github.com/repos/owner/repo/pulls", true},
+		{"graphql query", "POST", "https://api.github.com/graphql", true},
+		{"delete not allowed", "DELETE", "https://api.github.com/repos/owner/repo", false},
+		{"POST issues not allowed", "POST", "https://api.github.com/repos/owner/repo/issues", false},
+		{"user endpoint not allowed", "GET", "https://api.github.com/user", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckPolicyRules(tt.method, tt.url, rules)
+			if result.Allowed != tt.wantAllow {
+				t.Errorf("CheckPolicyRules(%q, %q) allowed=%v, want %v (reason: %s)",
+					tt.method, tt.url, result.Allowed, tt.wantAllow, result.Reason)
+			}
+		})
+	}
+}
+
+// contains checks if s contains substr.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && containsStr(s, substr)
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gate/proxy.go
+++ b/internal/gate/proxy.go
@@ -73,9 +73,10 @@ type Config struct {
 	VertexProject      string // Vertex AI project ID
 	LedgerURL          string
 	GitLabHost         string // self-hosted GitLab hostname (default: "gitlab.com")
-	CACertPEM          []byte // PEM-encoded CA certificate for MITM TLS interception
-	CAKeyPEM           []byte // PEM-encoded CA private key for MITM TLS interception
-	EnforcementMode    string // "monitor" = log-only, "" or "enforce" = enforce scope
+	CACertPEM          []byte                  // PEM-encoded CA certificate for MITM TLS interception
+	CAKeyPEM           []byte                  // PEM-encoded CA private key for MITM TLS interception
+	EnforcementMode    string                  // "monitor" = log-only, "" or "enforce" = enforce scope
+	PolicyRules        []internal.PolicyRule    // Generic HTTP-primitive policy rules
 }
 
 // Proxy is the Gate authorization proxy.

--- a/internal/types.go
+++ b/internal/types.go
@@ -107,6 +107,18 @@ type ExecutableSpec struct {
 	Env  map[string]string `json:"env,omitempty" yaml:"env"`   // Additional environment variables
 }
 
+// HTTPRule defines a single HTTP-primitive policy rule.
+type HTTPRule struct {
+	Method string `json:"method" yaml:"method"` // HTTP method or "*" for any
+	Host   string `json:"host" yaml:"host"`     // Hostname (exact, case-insensitive)
+	Path   string `json:"path" yaml:"path"`     // Glob: * = single segment, ** = multi-segment
+}
+
+// PolicyRule wraps an HTTPRule as an allow directive.
+type PolicyRule struct {
+	Allow HTTPRule `json:"allow" yaml:"allow"`
+}
+
 // Provider holds LLM provider configuration.
 type Provider struct {
 	Name         string  `json:"name"`


### PR DESCRIPTION
## Summary
- Replaces bespoke per-service operation-name scope checking with generic HTTP method+host+path glob rules
- Named rule sets defined in `.alcove/policy-rules/*.yml`, synced to DB, referenced by security profiles
- Security profiles gain `rules:` key for named rule references and inline HTTP rules
- Ships with 73 named rule sets covering all GitHub/GitLab/Jira/Splunk operations from scope.go
- Full backward compatibility: existing `tools:` profiles still work unchanged

## Architecture
```
.alcove/policy-rules/github.yml  →  sync to DB  →  profile resolves refs
     ↓                                                    ↓
named rule sets                              flat []PolicyRule
     ↓                                                    ↓
security profile rules:                      GATE_POLICY_RULES env var
  - github-read-issues                              ↓
  - github-create-comment                    Gate CheckPolicyRules()
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` — all packages pass (including 60+ new policy tests)
- [x] DB migrations apply cleanly (policy_rule_sets table + security_profiles.rules column)
- [x] Bridge starts with new migrations
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)