### PR TITLE
Fix missing GH_TOKEN when using policy rules without security profiles

### DIFF
--- a/.alcove/policy-rules/github.yml
+++ b/.alcove/policy-rules/github.yml
@@ -21,6 +21,10 @@ rule_sets:
           method: GET
           host: api.github.com
           path: "/repos/*/*/**"
+      - allow:
+          method: "*"
+          host: github.com
+          path: "/**"
 
   - name: github-push-branch
     rules:

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -404,10 +404,28 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 		gateEnv["GATE_ENFORCEMENT_MODE"] = "monitor"
 	}
 
-	// Resolve SCM credentials for services in scope.
+	// Resolve SCM credentials for services in scope or policy rules.
 	scmCredentials := make(map[string]string)
 	scmDummyTokens := make(map[string]string)
+	servicesNeeded := make(map[string]bool)
 	for service := range scope.Services {
+		servicesNeeded[service] = true
+	}
+	// Derive services from resolved policy rules (host → service mapping).
+	if resolvedRules, err := ResolvePolicyRules(ctx, d.policyRuleStore, profileRules, activeTeamID); err == nil {
+		for _, rule := range resolvedRules {
+			host := strings.ToLower(rule.Allow.Host)
+			switch {
+			case strings.Contains(host, "github"):
+				servicesNeeded["github"] = true
+			case strings.Contains(host, "gitlab"):
+				servicesNeeded["gitlab"] = true
+			case strings.HasSuffix(host, ".atlassian.net"):
+				servicesNeeded["jira"] = true
+			}
+		}
+	}
+	for service := range servicesNeeded {
 		if service == "github" || service == "gitlab" || service == "jira" || service == "splunk" {
 			realToken, _, err := d.credStore.AcquireSCMTokenWithHost(ctx, service)
 			if err != nil {


### PR DESCRIPTION
## Summary
- Derive needed SCM services from policy rule hosts (not just scope.Services)
- Add github.com to github-clone rule set for git HTTPS transport

## Root cause
When security profiles were removed (monitor mode), scope.Services was empty. The dispatcher only created dummy tokens for services in scope, so GH_TOKEN was never set. gh CLI couldn't authenticate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)