### PR TITLE
Derive SCM services from repo URLs for credential resolution

### DIFF
--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -425,6 +425,16 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 			}
 		}
 	}
+	// Derive services from repo URLs.
+	for _, repo := range req.Repos {
+		u := strings.ToLower(repo.URL)
+		switch {
+		case strings.Contains(u, "github.com"):
+			servicesNeeded["github"] = true
+		case strings.Contains(u, "gitlab"):
+			servicesNeeded["gitlab"] = true
+		}
+	}
 	for service := range servicesNeeded {
 		if service == "github" || service == "gitlab" || service == "jira" || service == "splunk" {
 			realToken, _, err := d.credStore.AcquireSCMTokenWithHost(ctx, service)


### PR DESCRIPTION
## Summary
Agents with `repos:` pointing at github.com but no profiles/rules got no GH_TOKEN because nothing added "github" to servicesNeeded. Now derives services from repo URLs.

## Reproduced locally
Without fix: `warning: no credential for github` in Bridge logs, session had no GitHub tokens.
With fix: no warning, credential resolved successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)