### PR TITLE
Remove leaked GitHub credentials from agent definitions

### DIFF
--- a/.alcove/agents/autonomous-dev.yml
+++ b/.alcove/agents/autonomous-dev.yml
@@ -21,8 +21,6 @@ prompt: |
 repos:
   - url: https://github.com/bmbouter/alcove.git
 timeout: 7200
-credentials:
-  GITHUB_TOKEN: github
 enforcement_mode: monitor
 
 dev_container:

--- a/.alcove/agents/changelog.yml
+++ b/.alcove/agents/changelog.yml
@@ -36,8 +36,6 @@ prompt: |
 repos:
   - url: https://github.com/bmbouter/alcove.git
 timeout: 1800
-credentials:
-  GITHUB_TOKEN: github
 enforcement_mode: monitor
 
 outputs:

--- a/.alcove/agents/planning.yml
+++ b/.alcove/agents/planning.yml
@@ -87,8 +87,6 @@ repos:
   - name: alcove
     url: https://github.com/bmbouter/alcove.git
 
-credentials:
-  GITHUB_TOKEN: github
 
 timeout: 900
 enforcement_mode: monitor

--- a/.alcove/agents/release.yml
+++ b/.alcove/agents/release.yml
@@ -27,8 +27,6 @@ prompt: |
 repos:
   - url: https://github.com/bmbouter/alcove.git
 timeout: 300
-credentials:
-  GITHUB_TOKEN: github
 enforcement_mode: monitor
 
 outputs:

--- a/.alcove/agents/reviewer.yml
+++ b/.alcove/agents/reviewer.yml
@@ -15,8 +15,6 @@ prompt: |
 repos:
   - url: https://github.com/bmbouter/alcove.git
 timeout: 1800
-credentials:
-  GITHUB_TOKEN: github
 enforcement_mode: monitor
 
 dev_container:

--- a/.alcove/agents/security-reviewer.yml
+++ b/.alcove/agents/security-reviewer.yml
@@ -17,8 +17,6 @@ prompt: |
 repos:
   - url: https://github.com/bmbouter/alcove.git
 timeout: 1800
-credentials:
-  GITHUB_TOKEN: github
 enforcement_mode: monitor
 
 dev_container:


### PR DESCRIPTION
credentials: GITHUB_TOKEN: github bypasses Gate. Repos-based derivation handles it properly now.