### PR TITLE
Fix credential team isolation — scope SCM token lookup to active team

### DIFF
--- a/internal/bridge/credentials.go
+++ b/internal/bridge/credentials.go
@@ -404,8 +404,7 @@ func (cs *CredentialStore) AcquireSCMTokenForOwner(ctx context.Context, service,
 		ORDER BY created_at DESC LIMIT 1`,
 		service, teamID).Scan(&encrypted, &host)
 	if err != nil {
-		// Fall back to any available credential for this service.
-		return cs.AcquireSCMTokenWithHost(ctx, service)
+		return "", "", fmt.Errorf("no credential found for service %q in team %q: %w", service, teamID, err)
 	}
 	raw, err := decrypt(cs.key, encrypted)
 	if err != nil {

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -437,7 +437,7 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 	}
 	for service := range servicesNeeded {
 		if service == "github" || service == "gitlab" || service == "jira" || service == "splunk" {
-			realToken, _, err := d.credStore.AcquireSCMTokenWithHost(ctx, service)
+			realToken, _, err := d.credStore.AcquireSCMTokenForOwner(ctx, service, activeTeamID)
 			if err != nil {
 				log.Printf("warning: no credential for %s: %v", service, err)
 				continue
@@ -479,7 +479,7 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 			}
 
 			// Resolve credential for this tool.
-			realToken, _, err := d.credStore.AcquireSCMTokenWithHost(ctx, toolName)
+			realToken, _, err := d.credStore.AcquireSCMTokenForOwner(ctx, toolName, activeTeamID)
 			dummyToken := "alcove-session-" + uuid.New().String()
 
 			if err != nil {
@@ -631,7 +631,7 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 			continue
 		}
 		// Fall back to SCM token path.
-		token, _, err := d.credStore.AcquireSCMTokenWithHost(ctx, credName)
+		token, _, err := d.credStore.AcquireSCMTokenForOwner(ctx, credName, activeTeamID)
 		if err != nil {
 			log.Printf("warning: credential %q not found for env var %s", credName, envVar)
 			continue


### PR DESCRIPTION
## Summary
AcquireSCMTokenWithHost had no team_id filter, returning the most recently created credential across ALL teams. Team A could use Team B's GitHub token.

## Root cause
```sql
-- Old (broken): no team filter
SELECT credential FROM provider_credentials WHERE provider = $1 ORDER BY created_at DESC LIMIT 1

-- New (fixed): scoped to active team
SELECT credential FROM provider_credentials WHERE (provider = $1) AND team_id = $2 ORDER BY created_at DESC LIMIT 1
```

## Changes
- All 3 dispatcher credential lookups now use `AcquireSCMTokenForOwner` with `activeTeamID`
- Removed cross-team fallback in `AcquireSCMTokenForOwner`

## Verified locally
- Two teams with different GitHub credentials
- Old code: returned Team 2's credential for Team 1 dispatch
- Fixed code: returns Team 1's credential correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)