### PR TITLE
Fix monitor mode: MITM service domains for credential injection

### DIFF
--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -445,6 +445,10 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 			scmCredentials[service] = realToken
 			dummyToken := "alcove-session-" + uuid.New().String()
 			scmDummyTokens[service] = dummyToken
+			// Ensure the service is in scope so Gate's MITM handler knows to intercept it.
+			if _, ok := scope.Services[service]; !ok {
+				scope.Services[service] = internal.ServiceScope{}
+			}
 		}
 	}
 

--- a/internal/gate/mitm.go
+++ b/internal/gate/mitm.go
@@ -323,7 +323,7 @@ func (m *MITMHandler) HandleCONNECT(w http.ResponseWriter, r *http.Request, targ
 }
 
 func (m *MITMHandler) handleMITMRequest(clientConn net.Conn, req *http.Request, hostname, targetHost string) {
-	// Check scope (skip enforcement in monitor mode)
+	// Check scope
 	var result AccessResult
 	if len(m.config.PolicyRules) > 0 {
 		result = CheckPolicyRules(req.Method, req.URL.String(), m.config.PolicyRules)
@@ -331,17 +331,23 @@ func (m *MITMHandler) handleMITMRequest(clientConn net.Conn, req *http.Request, 
 		result = CheckAccess(req.Method, req.URL.String(), m.config.Scope)
 	}
 	if !result.Allowed {
-		resp := &http.Response{
-			StatusCode: http.StatusForbidden,
-			ProtoMajor: 1,
-			ProtoMinor: 1,
-			Header:     make(http.Header),
-			Body:       io.NopCloser(strings.NewReader("Forbidden: " + result.Reason)),
+		if m.config.EnforcementMode == "monitor" {
+			// Monitor mode: log the violation but allow the request through
+			log.Printf("gate: MITM monitor: would deny %s %s: %s (allowing)", req.Method, req.URL.String(), result.Reason)
+		} else {
+			// Enforce mode: deny the request
+			resp := &http.Response{
+				StatusCode: http.StatusForbidden,
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("Forbidden: " + result.Reason)),
+			}
+			resp.Header.Set("Content-Type", "text/plain")
+			_ = resp.Write(clientConn)
+			log.Printf("gate: MITM denied %s %s: %s", req.Method, req.URL.String(), result.Reason)
+			return
 		}
-		resp.Header.Set("Content-Type", "text/plain")
-		_ = resp.Write(clientConn)
-		log.Printf("gate: MITM denied %s %s: %s", req.Method, req.URL.String(), result.Reason)
-		return
 	}
 
 	// Inject credentials

--- a/internal/gate/proxy.go
+++ b/internal/gate/proxy.go
@@ -176,7 +176,11 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	if p.config.EnforcementMode == "monitor" {
 		if isLLMHost(hostname) {
 			p.tunnelToLLM(w, r, host)
+		} else if p.MITMHandler != nil && p.MITMHandler.IsMITMDomain(hostname) {
+			// Service domains: MITM for credential injection (scope check skipped inside handler)
+			p.MITMHandler.HandleCONNECT(w, r, host)
 		} else {
+			// Unknown domains: passthrough
 			log.Printf("gate: monitor: CONNECT %s", host)
 			p.tunnelDirect(w, r, host)
 			p.logEntry("CONNECT", host, identifyService(hostname), "monitor", "allow", http.StatusOK)

--- a/internal/gate/proxy_test.go
+++ b/internal/gate/proxy_test.go
@@ -1384,3 +1384,70 @@ func TestProxyRequest_MonitorMode_AllowsUnknownHost(t *testing.T) {
 		t.Errorf("expected forwarded-ok body, got %q", string(body))
 	}
 }
+
+// newTestProxyWithMonitorAndMITM creates a Gate proxy in monitor mode with MITM enabled.
+func newTestProxyWithMonitorAndMITM(t *testing.T, scope internal.Scope, creds map[string]string) (*Proxy, *httptest.Server, []byte) {
+	t.Helper()
+	certPEM, keyPEM, err := GenerateTestCA()
+	if err != nil {
+		t.Fatalf("generating test CA: %v", err)
+	}
+	cfg := Config{
+		SessionID:       "test-session",
+		Scope:           scope,
+		Credentials:     creds,
+		ToolConfigs:     map[string]ToolConfig{},
+		SessionToken:    "session-tok",
+		LLMToken:        "llm-secret-key",
+		LLMProvider:     "anthropic",
+		LLMTokenType:    "api_key",
+		CACertPEM:       certPEM,
+		CAKeyPEM:        keyPEM,
+		EnforcementMode: "monitor",
+	}
+	p := NewProxy(cfg)
+	ts := httptest.NewServer(p.Handler())
+	t.Cleanup(func() { ts.Close(); p.Stop() })
+	return p, ts, certPEM
+}
+
+func TestCONNECT_MonitorMode_MITMsServiceHost(t *testing.T) {
+	// In monitor mode with MITM enabled, a CONNECT to api.github.com should
+	// go through the MITM handler (TLS interception for credential injection)
+	// rather than tunnelDirect (raw passthrough).
+	scope := githubScope([]string{"*"}, []string{"*"})
+	_, ts, certPEM := newTestProxyWithMonitorAndMITM(t, scope, map[string]string{"github": "ghp_real_token"})
+
+	conn, err := net.Dial("tcp", strings.TrimPrefix(ts.URL, "http://"))
+	if err != nil {
+		t.Fatalf("connecting to gate: %v", err)
+	}
+	defer conn.Close()
+
+	// Send CONNECT to api.github.com — this is a service domain that should be MITM'd
+	fmt.Fprintf(conn, "CONNECT api.github.com:443 HTTP/1.1\r\nHost: api.github.com:443\r\n\r\n")
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatalf("reading CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 from CONNECT in monitor+MITM mode, got %d", resp.StatusCode)
+	}
+
+	// If MITM is active, the TLS handshake should succeed with our test CA cert.
+	// If it fell through to tunnelDirect, the handshake would fail because the
+	// upstream is the real api.github.com and our CA cert is not in its chain.
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(certPEM)
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName: "api.github.com",
+		RootCAs:    caPool,
+		NextProtos: []string{"http/1.1"},
+	})
+	err = tlsConn.Handshake()
+	if err != nil {
+		t.Fatalf("TLS handshake failed — MITM not active in monitor mode for service domain: %v", err)
+	}
+	tlsConn.Close()
+}


### PR DESCRIPTION
## Summary
Monitor mode now uses MITM for service domains (credential injection) while skipping scope enforcement. Previously, monitor mode bypassed MITM entirely, so dummy tokens reached GitHub unchanged.

## Verified locally
- Gate logs show `MITM monitor: would deny ... (allowing)` — MITM intercepts, injects credentials, logs what would be denied
- `GATE_SCOPE` now includes derived services from repo URLs
- `gh` CLI authenticates successfully through Gate MITM in monitor mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)