### PR TITLE
Fix CLI repo derivation and scope nil-operations semantics

### DIFF
--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -27,6 +27,7 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -191,10 +192,20 @@ func (a *API) handleSessions(w http.ResponseWriter, r *http.Request) {
 		var body struct {
 			TaskRequest
 			AgentDefinition string `json:"agent_definition,omitempty"`
+			Repo            string `json:"repo,omitempty"` // Legacy single-repo from CLI
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 			return
+		}
+
+		// Convert legacy single "repo" field to multi-repo format.
+		if body.Repo != "" && len(body.Repos) == 0 {
+			repoURL := body.Repo
+			if !strings.Contains(repoURL, "://") {
+				repoURL = "https://github.com/" + repoURL
+			}
+			body.Repos = []internal.RepoSpec{{URL: repoURL, Name: path.Base(repoURL)}}
 		}
 
 		submitter := r.Header.Get("X-Alcove-User")

--- a/internal/gate/scope.go
+++ b/internal/gate/scope.go
@@ -61,8 +61,8 @@ func CheckAccess(method, rawURL string, scope internal.Scope) AccessResult {
 
 	host := u.Hostname()
 
-	// GitHub API
-	if host == "api.github.com" {
+	// GitHub API and web (git clone uses github.com, API uses api.github.com)
+	if host == "api.github.com" || host == "github.com" {
 		return checkGitHub(method, u.Path, scope)
 	}
 
@@ -681,6 +681,9 @@ func extractJiraProjectKey(path string) string {
 
 // repoAllowed checks if a repo is in the allowed list. Supports wildcard "*".
 func repoAllowed(repo string, allowed []string) bool {
+	if allowed == nil {
+		return true // nil means all repos allowed (no restrictions)
+	}
 	if len(allowed) == 0 {
 		return false
 	}
@@ -701,6 +704,9 @@ func repoAllowed(repo string, allowed []string) bool {
 
 // operationAllowed checks if an operation is in the allowed list. Supports wildcard "*".
 func operationAllowed(op string, allowed []string) bool {
+	if allowed == nil {
+		return true // nil means all operations allowed (no restrictions)
+	}
 	for _, a := range allowed {
 		if a == "*" || a == op {
 			return true


### PR DESCRIPTION
## Summary
- **Fix CLI repo conversion**: CLI sends `{"repo": "org/name"}` but `TaskRequest.Repos` expects array of RepoSpec. The single "repo" field was silently ignored, so CLI-dispatched sessions had no repos, no service derivation, no credentials.
- **Fix scope nil semantics**: When `scope.services.github.operations` is `null` (Go nil), treat it as "all operations allowed" (no restrictions), not "deny all". Same for `repos`.
- **Add github.com to GitHub host check**: `CheckAccess` only recognized `api.github.com`, not `github.com` (used by git clone).

## Root cause
Two independent bugs both causing credential/scope issues:
1. Multi-repo migration changed `Repo string` to `Repos []RepoSpec` but API never added conversion from the legacy field
2. Bespoke scope checker used `len(allowed) == 0` which returns false for nil slices — nil should mean unrestricted

## Test plan
- [x] All tests pass
- [x] `go vet` clean
- [ ] Dispatch CLI session with `--repo` and verify credentials work
- [ ] Verify nil operations allows requests through scope check

🤖 Generated with [Claude Code](https://claude.com/claude-code)