### PR TITLE
Fix scheduler: use full agent definition for cron dispatch

### DIFF
--- a/internal/bridge/agentdef.go
+++ b/internal/bridge/agentdef.go
@@ -336,6 +336,17 @@ func (s *AgentDefStore) GetAgentDefinition(ctx context.Context, id, teamID strin
 	return &td, nil
 }
 
+// GetAgentDefinitionBySourceKey looks up an agent definition by its source_key
+// (used by the scheduler to resolve the full definition for cron-triggered sessions).
+func (s *AgentDefStore) GetAgentDefinitionBySourceKey(ctx context.Context, sourceKey, teamID string) (*AgentDefinition, error) {
+	var id string
+	err := s.db.QueryRow(ctx, `SELECT id FROM agent_definitions WHERE source_key = $1 AND team_id = $2`, sourceKey, teamID).Scan(&id)
+	if err != nil {
+		return nil, fmt.Errorf("agent definition not found for source_key %s: %w", sourceKey, err)
+	}
+	return s.GetAgentDefinition(ctx, id, teamID)
+}
+
 // UpsertAgentDefinition inserts or updates a agent definition by source_key.
 func (s *AgentDefStore) UpsertAgentDefinition(ctx context.Context, def *AgentDefinition) error {
 	if def.ID == "" {

--- a/internal/bridge/scheduler.go
+++ b/internal/bridge/scheduler.go
@@ -237,6 +237,7 @@ type Scheduler struct {
 	db            *pgxpool.Pool
 	dispatcher    *Dispatcher
 	cfg           *Config
+	defStore      *AgentDefStore
 	settingsStore *SettingsStore
 	poller        *GitHubPoller
 	stopCh        chan struct{}
@@ -255,6 +256,7 @@ func NewScheduler(db *pgxpool.Pool, dispatcher *Dispatcher, cfg *Config, credSto
 		db:            db,
 		dispatcher:    dispatcher,
 		cfg:           cfg,
+		defStore:      defStore,
 		settingsStore: settingsStore,
 		poller: &GitHubPoller{
 			db:         db,
@@ -369,15 +371,36 @@ func (s *Scheduler) tick(ctx context.Context) {
 	for _, sched := range due {
 		log.Printf("scheduler: dispatching schedule %s (%s)", sched.Name, sched.ID)
 
-		req := TaskRequest{
-			Prompt:      sched.Prompt,
-			Repos:       sched.Repos,
-			Provider:    sched.Provider,
-			Timeout:     sched.Timeout,
-			Debug:       sched.Debug,
-			TaskName:    sched.Name,
-			TriggerType: "cron",
+		var req TaskRequest
+
+		// For YAML-sourced schedules (from agent definitions), load the full
+		// agent definition to get all fields (direct_outbound, enforcement_mode,
+		// profiles, plugins, credentials, dev_container, etc.).
+		if sched.Source == "yaml" && sched.SourceKey != "" {
+			def, err := s.defStore.GetAgentDefinitionBySourceKey(ctx, sched.SourceKey, sched.TeamID)
+			if err == nil {
+				req = def.ToTaskRequest()
+			} else {
+				log.Printf("scheduler: agent definition not found for source_key %s, using schedule fields", sched.SourceKey)
+			}
 		}
+
+		// Override/set fields from the schedule row (these are always authoritative).
+		if sched.Prompt != "" {
+			req.Prompt = sched.Prompt
+		}
+		if len(sched.Repos) > 0 {
+			req.Repos = sched.Repos
+		}
+		if sched.Provider != "" {
+			req.Provider = sched.Provider
+		}
+		if sched.Timeout > 0 {
+			req.Timeout = sched.Timeout
+		}
+		req.Debug = sched.Debug
+		req.TaskName = sched.Name
+		req.TriggerType = "cron"
 
 		if _, err := s.dispatcher.DispatchTask(ctx, req, "scheduler", sched.TeamID); err != nil {
 			log.Printf("scheduler: error dispatching schedule %s: %v", sched.ID, err)


### PR DESCRIPTION
## Summary
Cron-triggered sessions were missing agent definition fields like `direct_outbound`, `enforcement_mode`, `profiles`, `plugins`, `credentials`, `dev_container`, `triple_team`, and `repo_group`. The scheduler built TaskRequest manually from the schedule row which only has a subset of fields.

Now when a schedule is backed by an agent definition (source=yaml), the scheduler looks up the full definition and uses `ToTaskRequest()`.

## Root cause
The Splunk Log Analyzer agent has `direct_outbound: true` in its YAML. Manual dispatch worked (used the agent definition). Cron dispatch failed silently (no direct outbound = traffic blocked by Gate).

## Reproduction
Locally verified: cron-dispatched sessions now include `direct_outbound`, `triple_team`, `repo_group` from the agent definition.

## Test plan
- [x] `go build && go test && go vet` — all clean
- [x] Reproduced locally: cron session missing direct_outbound
- [x] Verified fix: cron session now includes all agent def fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)