### PR TITLE
Rename org: bmbouter → alcove-ai

### DIFF
--- a/.alcove/agents/autonomous-dev.yml
+++ b/.alcove/agents/autonomous-dev.yml
@@ -4,7 +4,7 @@ description: |
   Invoked by the Full SDLC Pipeline workflow when issues are labeled ready-for-dev.
 
 prompt: |
-  You are a developer for the Alcove project (bmbouter/alcove).
+  You are a developer for the Alcove project (alcove-ai/alcove).
 
   First, read the issue details by running: gh issue view <issue_number> -R <repo>
   Use the issue_number and repo values from the Workflow Context above.
@@ -19,12 +19,12 @@ prompt: |
   Output: {"summary": "what you implemented"}
 
 repos:
-  - url: https://github.com/bmbouter/alcove.git
+  - url: https://github.com/alcove-ai/alcove.git
 timeout: 7200
 enforcement_mode: monitor
 
 dev_container:
-  image: ghcr.io/bmbouter/alcove-dev:latest
+  image: ghcr.io/alcove-ai/alcove-dev:latest
 
 outputs:
   - summary

--- a/.alcove/agents/changelog.yml
+++ b/.alcove/agents/changelog.yml
@@ -4,7 +4,7 @@ description: |
   since the last tag. Determines the semver bump and updates docs/changelog.md.
 
 prompt: |
-  You are a changelog generator for Alcove (bmbouter/alcove).
+  You are a changelog generator for Alcove (alcove-ai/alcove).
 
   Check for unreleased commits on main since the last tag:
     git fetch --tags
@@ -34,7 +34,7 @@ prompt: |
   Replace vX.Y.Z with the actual version you determined. Do NOT skip this step.
 
 repos:
-  - url: https://github.com/bmbouter/alcove.git
+  - url: https://github.com/alcove-ai/alcove.git
 timeout: 1800
 enforcement_mode: monitor
 

--- a/.alcove/agents/planning.yml
+++ b/.alcove/agents/planning.yml
@@ -85,7 +85,7 @@ prompt: |
 
 repos:
   - name: alcove
-    url: https://github.com/bmbouter/alcove.git
+    url: https://github.com/alcove-ai/alcove.git
 
 
 timeout: 900

--- a/.alcove/agents/release.yml
+++ b/.alcove/agents/release.yml
@@ -5,7 +5,7 @@ description: |
   Workflow Context.
 
 prompt: |
-  You are the release tagger for Alcove (bmbouter/alcove). The changelog
+  You are the release tagger for Alcove (alcove-ai/alcove). The changelog
   has already been merged. The version to release is in the Workflow Context.
 
   ## Tag and Push
@@ -25,7 +25,7 @@ prompt: |
   Do NOT skip this step.
 
 repos:
-  - url: https://github.com/bmbouter/alcove.git
+  - url: https://github.com/alcove-ai/alcove.git
 timeout: 300
 enforcement_mode: monitor
 

--- a/.alcove/agents/reviewer.yml
+++ b/.alcove/agents/reviewer.yml
@@ -4,7 +4,7 @@ description: |
   Manages labels and merges approved PRs.
 
 prompt: |
-  You are a code reviewer for the Alcove project (bmbouter/alcove).
+  You are a code reviewer for the Alcove project (alcove-ai/alcove).
 
   Review the PR in your context for correctness, bugs, performance issues, and adherence to project conventions.
 
@@ -13,12 +13,12 @@ prompt: |
   Output: {"approved": true/false, "comments": "summary of review"}
 
 repos:
-  - url: https://github.com/bmbouter/alcove.git
+  - url: https://github.com/alcove-ai/alcove.git
 timeout: 1800
 enforcement_mode: monitor
 
 dev_container:
-  image: ghcr.io/bmbouter/alcove-dev:latest
+  image: ghcr.io/alcove-ai/alcove-dev:latest
 
 outputs:
   - approved

--- a/.alcove/agents/security-reviewer.yml
+++ b/.alcove/agents/security-reviewer.yml
@@ -4,7 +4,7 @@ description: |
   Focuses on Gate proxy bypass, credential handling, and network isolation.
 
 prompt: |
-  You are a security reviewer for the Alcove project (bmbouter/alcove).
+  You are a security reviewer for the Alcove project (alcove-ai/alcove).
 
   Review the PR in your context for security vulnerabilities: injection attacks, authentication/authorization bypass, credential exposure, unsafe deserialization, path traversal, and OWASP Top 10 issues.
 
@@ -15,12 +15,12 @@ prompt: |
   Output: {"approved": true/false, "comments": "security findings"}
 
 repos:
-  - url: https://github.com/bmbouter/alcove.git
+  - url: https://github.com/alcove-ai/alcove.git
 timeout: 1800
 enforcement_mode: monitor
 
 dev_container:
-  image: ghcr.io/bmbouter/alcove-dev:latest
+  image: ghcr.io/alcove-ai/alcove-dev:latest
 
 outputs:
   - approved

--- a/.alcove/workflows/feature-pipeline.yml
+++ b/.alcove/workflows/feature-pipeline.yml
@@ -4,7 +4,7 @@ trigger:
     events: [issues]
     actions: [labeled]
     labels: [ready-for-dev]
-    repos: [bmbouter/alcove]
+    repos: [alcove-ai/alcove]
     delivery_mode: polling
 
 workflow:
@@ -15,7 +15,7 @@ workflow:
     inputs:
       branch: "issue-{{trigger.issue_number}}-fix"
       issue_number: "{{trigger.issue_number}}"
-      repo: "bmbouter/alcove"
+      repo: "alcove-ai/alcove"
       issue_title: "{{trigger.issue_title}}"
       issue_body: "{{trigger.issue_body}}"
       issue_url: "{{trigger.issue_url}}"
@@ -26,7 +26,7 @@ workflow:
     action: create-merge-request
     depends: "implement.Succeeded"
     inputs:
-      repo: bmbouter/alcove
+      repo: alcove-ai/alcove
       branch: "{{steps.implement.inputs.branch}}"
       title: "Fix #{{trigger.issue_number}}"
       base: main
@@ -37,7 +37,7 @@ workflow:
     depends: "create-pr.Succeeded || ci-fix.Succeeded"
     max_iterations: 4
     inputs:
-      repo: bmbouter/alcove
+      repo: alcove-ai/alcove
       pr: "{{steps.create-pr.outputs.pr_number}}"
 
   - id: ci-fix
@@ -48,7 +48,7 @@ workflow:
     inputs:
       branch: "{{steps.implement.inputs.branch}}"
       issue_number: "{{trigger.issue_number}}"
-      repo: "bmbouter/alcove"
+      repo: "alcove-ai/alcove"
       issue_title: "{{trigger.issue_title}}"
       issue_body: "{{trigger.issue_body}}"
       issue_url: "{{trigger.issue_url}}"
@@ -81,7 +81,7 @@ workflow:
     inputs:
       branch: "{{steps.implement.inputs.branch}}"
       issue_number: "{{trigger.issue_number}}"
-      repo: "bmbouter/alcove"
+      repo: "alcove-ai/alcove"
       issue_title: "{{trigger.issue_title}}"
       issue_body: "{{trigger.issue_body}}"
       issue_url: "{{trigger.issue_url}}"
@@ -94,5 +94,5 @@ workflow:
     action: merge
     depends: "code-review.Succeeded && security-review.Succeeded"
     inputs:
-      repo: bmbouter/alcove
+      repo: alcove-ai/alcove
       pr: "{{steps.create-pr.outputs.pr_number}}"

--- a/.alcove/workflows/milestone-planner.yml
+++ b/.alcove/workflows/milestone-planner.yml
@@ -4,7 +4,7 @@ trigger:
     events: [issues, issue_comment]
     actions: [labeled, created]
     labels: [needs-planning]
-    repos: [bmbouter/alcove]
+    repos: [alcove-ai/alcove]
     delivery_mode: polling
 
 workflow:
@@ -14,4 +14,4 @@ workflow:
     inputs:
       issue_number: "{{trigger.issue_number}}"
       issue_url: "{{trigger.issue_url}}"
-      repo: "bmbouter/alcove"
+      repo: "alcove-ai/alcove"

--- a/.alcove/workflows/release-pipeline.yml
+++ b/.alcove/workflows/release-pipeline.yml
@@ -11,7 +11,7 @@ trigger:
     events: [issues]
     actions: [labeled]
     labels: [immediate-release]
-    repos: [bmbouter/alcove]
+    repos: [alcove-ai/alcove]
     delivery_mode: polling
 
 workflow:
@@ -27,7 +27,7 @@ workflow:
     action: create-merge-request
     depends: "changelog.Succeeded"
     inputs:
-      repo: bmbouter/alcove
+      repo: alcove-ai/alcove
       branch: "{{steps.changelog.inputs.branch}}"
       title: "Release {{steps.changelog.outputs.version}}"
       base: main
@@ -38,7 +38,7 @@ workflow:
     depends: "changelog-pr.Succeeded"
     max_iterations: 4
     inputs:
-      repo: bmbouter/alcove
+      repo: alcove-ai/alcove
       pr: "{{steps.changelog-pr.outputs.pr_number}}"
 
   - id: changelog-merge
@@ -46,7 +46,7 @@ workflow:
     action: merge
     depends: "changelog-ci.Succeeded"
     inputs:
-      repo: bmbouter/alcove
+      repo: alcove-ai/alcove
       pr: "{{steps.changelog-pr.outputs.pr_number}}"
 
   - id: tag-release
@@ -62,7 +62,7 @@ workflow:
     action: await-release
     depends: "tag-release.Succeeded"
     inputs:
-      repo: bmbouter/alcove
+      repo: alcove-ai/alcove
       tag: "{{steps.changelog.outputs.version}}"
       timeout: 900
 

--- a/.claude/skills/deploy-staging/SKILL.md
+++ b/.claude/skills/deploy-staging/SKILL.md
@@ -13,14 +13,14 @@ Automatically detect if a new Alcove release is available, audit the changes for
 
 **Latest release:**
 ```bash
-gh release view --repo bmbouter/alcove --json tagName -q '.tagName'
+gh release view --repo alcove-ai/alcove --json tagName -q '.tagName'
 ```
 
 **Currently deployed on staging:**
 ```bash
 oc get deployment alcove-bridge -o jsonpath='{.spec.template.spec.containers[0].image}'
 ```
-Extract the tag from the image URL (e.g., `ghcr.io/bmbouter/alcove-bridge:0.4.15` → `0.4.15`).
+Extract the tag from the image URL (e.g., `ghcr.io/alcove-ai/alcove-bridge:0.4.15` → `0.4.15`).
 
 If $ARGUMENTS is provided, use that version instead of auto-detecting.
 

--- a/.claude/skills/dev-up/SKILL.md
+++ b/.claude/skills/dev-up/SKILL.md
@@ -203,12 +203,12 @@ if r.returncode != 0:
 
 Verify it was created (should print JSON with an `id` field, not an error).
 
-## Step 7: Configure bmbouter/alcove-testing agent repo
+## Step 7: Configure alcove-ai/alcove-testing agent repo
 
 ```bash
 curl -s -X PUT http://localhost:8080/api/v1/user/settings/agent-repos \
   -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
-  -d '{"repos":[{"url":"https://github.com/bmbouter/alcove-testing.git","ref":"main","name":"alcove-testing"}]}'
+  -d '{"repos":[{"url":"https://github.com/alcove-ai/alcove-testing.git","ref":"main","name":"alcove-testing"}]}'
 ```
 
 Trigger sync:
@@ -256,7 +256,7 @@ If postgres auth is needed instead of the default memory backend, restart Bridge
 Three things configured:
 1. LLM credential (from .dev-credentials.yaml llm section -- supports anthropic, claude-oauth, or google-vertex)
 2. GitHub PAT (from .dev-credentials.yaml github_token, falling back to gh auth token)
-3. bmbouter/alcove-testing agent repo (synced)
+3. alcove-ai/alcove-testing agent repo (synced)
 
 One thing verified:
 - Agent repo sync shows N > 0 definitions

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -16,12 +16,12 @@ The release agent (`.alcove/agents/release.yml`) runs daily at 6 AM UTC and chec
 ### 1. Create or find an issue to tag
 If there's already an open issue, use it. Otherwise create one:
 ```bash
-gh issue create --repo bmbouter/alcove --title "Release vX.Y.Z" --body "Triggering immediate release."
+gh issue create --repo alcove-ai/alcove --title "Release vX.Y.Z" --body "Triggering immediate release."
 ```
 
 ### 2. Add the immediate-release label
 ```bash
-gh issue edit ISSUE_NUMBER --repo bmbouter/alcove --add-label "immediate-release"
+gh issue edit ISSUE_NUMBER --repo alcove-ai/alcove --add-label "immediate-release"
 ```
 
 The release agent will:
@@ -38,7 +38,7 @@ Watch for the release agent task to appear in the Alcove staging dashboard. It w
 ### 4. Verify
 After the release agent completes:
 ```bash
-gh release view --repo bmbouter/alcove
+gh release view --repo alcove-ai/alcove
 ```
 
 ## Notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   packages: write
 
 env:
-  REGISTRY: ghcr.io/bmbouter
+  REGISTRY: ghcr.io/alcove-ai
 
 jobs:
   # Job 1: Build all Go binaries + create the GitHub Release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ systemctl --user enable --now podman.socket
 ### Clone and Build
 
 ```bash
-git clone https://github.com/bmbouter/alcove.git
+git clone https://github.com/alcove-ai/alcove.git
 cd alcove
 make build
 ```
@@ -73,7 +73,7 @@ details.
 
 ## Reporting Bugs
 
-Open an issue at https://github.com/bmbouter/alcove/issues with:
+Open an issue at https://github.com/alcove-ai/alcove/issues with:
 
 - What you were trying to do
 - What happened instead

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ validation, and per-task NetworkPolicy enforcement on Kubernetes. See
 ## Quick Start
 
 ```bash
-git clone https://github.com/bmbouter/alcove.git
+git clone https://github.com/alcove-ai/alcove.git
 cd alcove
 make up
 # make up auto-generates alcove.yaml with a random database encryption key
@@ -88,18 +88,18 @@ make k3s-down                 # Stop port-forwards and delete namespace
 ### One-Line Install (Linux/macOS)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.sh | bash
 ```
 
 ### Windows (PowerShell)
 
 ```powershell
-iex (iwr -useb 'https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.ps1').Content
+iex (iwr -useb 'https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.ps1').Content
 ```
 
 ### Manual Download
 
-Download platform-specific binaries from [GitHub Releases](https://github.com/bmbouter/alcove/releases/latest):
+Download platform-specific binaries from [GitHub Releases](https://github.com/alcove-ai/alcove/releases/latest):
 
 - **Linux AMD64**: `alcove-linux-amd64`
 - **Linux ARM64**: `alcove-linux-arm64`  

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -26,8 +26,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/bmbouter/alcove/internal/auth"
-	"github.com/bmbouter/alcove/internal/bridge"
+	"github.com/alcove-ai/alcove/internal/auth"
+	"github.com/alcove-ai/alcove/internal/bridge"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go"
 )

--- a/cmd/gate/main.go
+++ b/cmd/gate/main.go
@@ -49,8 +49,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
-	"github.com/bmbouter/alcove/internal/gate"
+	"github.com/alcove-ai/alcove/internal"
+	"github.com/alcove-ai/alcove/internal/gate"
 )
 
 // Version is set at build time via -ldflags.

--- a/cmd/hashpw/main.go
+++ b/cmd/hashpw/main.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/bmbouter/alcove/internal/auth"
+	"github.com/alcove-ai/alcove/internal/auth"
 )
 
 func main() {

--- a/cmd/skiff-init/main.go
+++ b/cmd/skiff-init/main.go
@@ -36,9 +36,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
-	"github.com/bmbouter/alcove/internal/hail"
-	"github.com/bmbouter/alcove/internal/ledger"
+	"github.com/alcove-ai/alcove/internal"
+	"github.com/alcove-ai/alcove/internal/hail"
+	"github.com/alcove-ai/alcove/internal/ledger"
 )
 
 // Version is set at build time via -ldflags.

--- a/deploy/k8s/bridge.yaml
+++ b/deploy/k8s/bridge.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: alcove-bridge
       containers:
         - name: bridge
-          image: ghcr.io/bmbouter/alcove-bridge:latest
+          image: ghcr.io/alcove-ai/alcove-bridge:latest
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false
@@ -45,9 +45,9 @@ spec:
             - name: HAIL_URL
               value: "nats://alcove-hail:4222"
             - name: SKIFF_IMAGE
-              value: "ghcr.io/bmbouter/alcove-skiff-base:latest"
+              value: "ghcr.io/alcove-ai/alcove-skiff-base:latest"
             - name: GATE_IMAGE
-              value: "ghcr.io/bmbouter/alcove-gate:latest"
+              value: "ghcr.io/alcove-ai/alcove-gate:latest"
             - name: ALCOVE_DATABASE_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:

--- a/deploy/mr-description.md
+++ b/deploy/mr-description.md
@@ -1,6 +1,6 @@
 ## Summary
 
-Deploy [Alcove](https://github.com/bmbouter/alcove) into the `pulp-stage` namespace on `crcs02ue1`. Alcove runs sandboxed AI coding agents (Claude Code) in ephemeral, network-isolated containers on OpenShift.
+Deploy [Alcove](https://github.com/alcove-ai/alcove) into the `pulp-stage` namespace on `crcs02ue1`. Alcove runs sandboxed AI coding agents (Claude Code) in ephemeral, network-isolated containers on OpenShift.
 
 ## What is Alcove?
 
@@ -19,7 +19,7 @@ Each task gets a fresh container, a scoped authorization proxy, and a complete s
 
 | File | Purpose |
 |------|---------|
-| `data/services/pulp/deploy-alcove.yml` | SaaS file (saas-file-2 schema) deploying Alcove via the [OpenShift template](https://github.com/bmbouter/alcove/blob/main/deploy/openshift/template.yaml) from the Alcove GitHub repo |
+| `data/services/pulp/deploy-alcove.yml` | SaaS file (saas-file-2 schema) deploying Alcove via the [OpenShift template](https://github.com/alcove-ai/alcove/blob/main/deploy/openshift/template.yaml) from the Alcove GitHub repo |
 | `resources/terraform/resources/pulp/stage/rds-alcove-stage.yml` | RDS defaults — PostgreSQL 16, db.t3.medium, 20GB, encrypted, single-AZ for staging |
 | `resources/pulp-stage/alcove-config.secret.yaml` | Resource template (extracurlyjinja2) that constructs the `alcove-config` Secret from vault + ERv2 RDS outputs |
 
@@ -27,7 +27,7 @@ Each task gets a fresh container, a scoped authorization proxy, and a complete s
 
 | File | Change |
 |------|--------|
-| `data/services/pulp/app.yml` | Add `alcove` codeComponent pointing to github.com/bmbouter/alcove |
+| `data/services/pulp/app.yml` | Add `alcove` codeComponent pointing to github.com/alcove-ai/alcove |
 | `data/services/pulp/namespaces/pulp-stage.yml` | Add `alcove-stage` RDS external resource with ERv2. Output secret: `alcove-db` |
 | `data/services/pulp/namespaces/shared-resources/stage.yml` | Add `alcove-config` resource-template reference |
 
@@ -41,9 +41,9 @@ Bridge reads both values from the resulting Kubernetes Secret via `secretKeyRef`
 
 ## What gets deployed
 
-The [OpenShift template](https://github.com/bmbouter/alcove/blob/main/deploy/openshift/template.yaml) creates:
+The [OpenShift template](https://github.com/alcove-ai/alcove/blob/main/deploy/openshift/template.yaml) creates:
 
-- **Bridge Deployment** (1 replica) — `ghcr.io/bmbouter/alcove-bridge:0.1.0`
+- **Bridge Deployment** (1 replica) — `ghcr.io/alcove-ai/alcove-bridge:0.1.0`
 - **NATS Deployment** (1 replica) — `docker.io/library/nats:latest` (stateless messaging)
 - **Services** — `alcove-bridge:8080`, `alcove-hail:4222`
 - **RBAC** — ServiceAccount `alcove-bridge` with minimal Role (batch/jobs, pods, networkpolicies, secrets)
@@ -54,9 +54,9 @@ Bridge dynamically creates **k8s Jobs** for each task (Skiff worker + Gate sidec
 ## Container images
 
 All images are public on ghcr.io:
-- `ghcr.io/bmbouter/alcove-bridge:0.1.0`
-- `ghcr.io/bmbouter/alcove-gate:0.1.0`
-- `ghcr.io/bmbouter/alcove-skiff-base:0.1.0`
+- `ghcr.io/alcove-ai/alcove-bridge:0.1.0`
+- `ghcr.io/alcove-ai/alcove-gate:0.1.0`
+- `ghcr.io/alcove-ai/alcove-skiff-base:0.1.0`
 
 ## Prerequisites before merge
 

--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -4,13 +4,13 @@ metadata:
   name: alcove
 parameters:
 - name: BRIDGE_IMAGE
-  value: ghcr.io/bmbouter/alcove-bridge
+  value: ghcr.io/alcove-ai/alcove-bridge
 - name: BRIDGE_IMAGE_TAG
   value: latest
 - name: GATE_IMAGE
-  value: ghcr.io/bmbouter/alcove-gate
+  value: ghcr.io/alcove-ai/alcove-gate
 - name: SKIFF_IMAGE
-  value: ghcr.io/bmbouter/alcove-skiff-base
+  value: ghcr.io/alcove-ai/alcove-skiff-base
 - name: NATS_IMAGE
   value: docker.io/library/nats:latest
 - name: BRIDGE_REPLICAS

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2543,10 +2543,10 @@ List all catalog sources with category breakdown.
       "description": "Built-in agent collection for common development tasks",
       "category": "agents",
       "source_type": "git",
-      "source_url": "https://github.com/bmbouter/alcove-catalog.git",
+      "source_url": "https://github.com/alcove-ai/alcove-catalog.git",
       "source_path": "agents",
       "ref": "main",
-      "docs_url": "https://github.com/bmbouter/alcove-catalog",
+      "docs_url": "https://github.com/alcove-ai/alcove-catalog",
       "tags": ["official", "agents"]
     }
   ],

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -780,7 +780,7 @@ All notable changes to Alcove are documented here. This project uses
 ### CI/CD
 - GitHub Actions CI workflow (test + vet on push/PR)
 - GitHub Actions Release workflow (build binaries, container images, GitHub Release)
-- Container images published to ghcr.io/bmbouter/alcove-{bridge,gate,skiff-base}
+- Container images published to ghcr.io/alcove-ai/alcove-{bridge,gate,skiff-base}
 - Version embedding via ldflags in all binaries
 - Updated to Node.js 24-compatible GitHub Actions
 

--- a/docs/cli-installation.md
+++ b/docs/cli-installation.md
@@ -7,20 +7,20 @@ This guide covers all methods for installing the Alcove CLI on different platfor
 ### Linux and macOS
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.sh | bash
 ```
 
 ### Windows (PowerShell)
 
 ```powershell
-iex (iwr -useb 'https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.ps1').Content
+iex (iwr -useb 'https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.ps1').Content
 ```
 
 ## Manual Installation
 
 ### Download Binaries
 
-Visit the [GitHub Releases page](https://github.com/bmbouter/alcove/releases/latest) and download the appropriate binary for your platform:
+Visit the [GitHub Releases page](https://github.com/alcove-ai/alcove/releases/latest) and download the appropriate binary for your platform:
 
 | Platform | Architecture | Binary Name |
 |----------|--------------|-------------|
@@ -35,10 +35,10 @@ Visit the [GitHub Releases page](https://github.com/bmbouter/alcove/releases/lat
 1. Download the binary:
    ```bash
    # Linux AMD64
-   wget https://github.com/bmbouter/alcove/releases/latest/download/alcove-linux-amd64
+   wget https://github.com/alcove-ai/alcove/releases/latest/download/alcove-linux-amd64
 
    # macOS ARM64 (Apple Silicon)
-   wget https://github.com/bmbouter/alcove/releases/latest/download/alcove-darwin-arm64
+   wget https://github.com/alcove-ai/alcove/releases/latest/download/alcove-darwin-arm64
    ```
 
 2. Make it executable:
@@ -73,7 +73,7 @@ Visit the [GitHub Releases page](https://github.com/bmbouter/alcove/releases/lat
 Set the `INSTALL_DIR` environment variable before running the installation script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.sh | INSTALL_DIR="$HOME/bin" bash
+curl -fsSL https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.sh | INSTALL_DIR="$HOME/bin" bash
 ```
 
 Common installation directories:
@@ -87,7 +87,7 @@ Set the `INSTALL_DIR` environment variable:
 
 ```powershell
 $env:INSTALL_DIR = "C:\tools"
-iex (iwr -useb 'https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.ps1').Content
+iex (iwr -useb 'https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.ps1').Content
 ```
 
 ## Verification
@@ -111,7 +111,7 @@ The installation scripts automatically verify checksums when possible. For manua
 
 1. Download the checksums file:
    ```bash
-   wget https://github.com/bmbouter/alcove/releases/latest/download/checksums-sha256.txt
+   wget https://github.com/alcove-ai/alcove/releases/latest/download/checksums-sha256.txt
    ```
 
 2. Verify your binary:
@@ -220,10 +220,10 @@ To update to the latest version, simply run the installation script again:
 
 ```bash
 # Linux/macOS
-curl -fsSL https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.sh | bash
 
 # Windows
-iex (iwr -useb 'https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.ps1').Content
+iex (iwr -useb 'https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.ps1').Content
 ```
 
 The installer will automatically replace the existing binary with the latest version.
@@ -267,7 +267,7 @@ Package manager support is planned for future releases:
 If you prefer to build from source:
 
 ```bash
-git clone https://github.com/bmbouter/alcove.git
+git clone https://github.com/alcove-ai/alcove.git
 cd alcove
 make build-cli-all
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -11,18 +11,18 @@ alcove [command] [flags]
 ### One-Line Install (Linux/macOS)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.sh | bash
 ```
 
 ### Windows (PowerShell)
 
 ```powershell
-iex (iwr -useb 'https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.ps1').Content
+iex (iwr -useb 'https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.ps1').Content
 ```
 
 ### Manual Download
 
-Download platform-specific binaries from [GitHub Releases](https://github.com/bmbouter/alcove/releases/latest):
+Download platform-specific binaries from [GitHub Releases](https://github.com/alcove-ai/alcove/releases/latest):
 
 - **Linux AMD64**: `alcove-linux-amd64`
 - **Linux ARM64**: `alcove-linux-arm64`  
@@ -34,10 +34,10 @@ Download platform-specific binaries from [GitHub Releases](https://github.com/bm
 
 ```bash
 # Linux/macOS with custom directory
-curl -fsSL https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.sh | INSTALL_DIR="$HOME/bin" bash
+curl -fsSL https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.sh | INSTALL_DIR="$HOME/bin" bash
 
 # Windows with custom directory
-$env:INSTALL_DIR = "C:\tools"; iex (iwr -useb 'https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.ps1').Content
+$env:INSTALL_DIR = "C:\tools"; iex (iwr -useb 'https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.ps1').Content
 ```
 
 ### Verify Installation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,8 +159,8 @@ can also be set in `alcove.yaml` (see [alcove.yaml](#alcoveyaml) above).
 | `VERTEX_PROJECT` | string | _(unset)_ | Google Cloud project ID. Registers the `vertex` provider when set. |
 | `VERTEX_API_KEY` | string | _(unset)_ | API key for Google Vertex AI. Auto-migrated to credential store on startup. |
 | `VERTEX_MODEL` | string | `claude-sonnet-4-20250514` | Default model for the Vertex AI provider. |
-| `SKIFF_IMAGE` | string | `ghcr.io/bmbouter/alcove-skiff-base:latest` | Container image for Skiff workers. |
-| `GATE_IMAGE` | string | `ghcr.io/bmbouter/alcove-gate:latest` | Container image for Gate sidecars. |
+| `SKIFF_IMAGE` | string | `ghcr.io/alcove-ai/alcove-skiff-base:latest` | Container image for Skiff workers. |
+| `GATE_IMAGE` | string | `ghcr.io/alcove-ai/alcove-gate:latest` | Container image for Gate sidecars. |
 | `ALCOVE_NETWORK` | string | `alcove-internal` | Podman network name for internal container networking (created with `--internal` flag, no external access). |
 | `ALCOVE_EXTERNAL_NETWORK` | string | `alcove-external` | External podman network for Gate egress. Gate bridges both networks; Skiff is attached only to the internal network. |
 | `BRIDGE_URL` | string | `http://alcove-bridge:<port>` | URL where Bridge can be reached by Skiff/Gate containers. |

--- a/docs/design/implementation-status.md
+++ b/docs/design/implementation-status.md
@@ -106,7 +106,7 @@ alcove/
 │       └── security-profiles-and-system-llm.md  ✅ Security profiles and system LLM design
 ├── Makefile                    ✅ build, build-images, up, down, logs, dev-up, dev-infra, dev-down, dev-logs, dev-reset, test, lint
 ├── LICENSE                     ✅ Apache-2.0
-├── go.mod                      ✅ github.com/bmbouter/alcove (Go 1.25)
+├── go.mod                      ✅ github.com/alcove-ai/alcove (Go 1.25)
 └── go.sum                      ✅ Dependencies resolved
 ```
 
@@ -281,7 +281,7 @@ alcove/
     Jobs and NetworkPolicies.
 
 22. **CI/CD** — GitHub Actions workflows for testing (`ci.yml`) and releasing
-    (`release.yml`). Container images published to `ghcr.io/bmbouter`.
+    (`release.yml`). Container images published to `ghcr.io/alcove-ai`.
     v0.1.0 released.
 
 23. **YAML Security Profiles** — Security profiles defined in
@@ -405,8 +405,8 @@ LEDGER_DATABASE_URL="postgres://alcove:alcove@localhost:5432/alcove?sslmode=disa
 HAIL_URL="nats://localhost:4222" \
 RUNTIME=podman \
 BRIDGE_PORT=8080 \
-SKIFF_IMAGE="ghcr.io/bmbouter/alcove-skiff-base:latest" \
-GATE_IMAGE="ghcr.io/bmbouter/alcove-gate:latest" \
+SKIFF_IMAGE="ghcr.io/alcove-ai/alcove-skiff-base:latest" \
+GATE_IMAGE="ghcr.io/alcove-ai/alcove-gate:latest" \
 ./bin/bridge
 
 # 4. In another terminal, use the CLI or curl
@@ -475,8 +475,8 @@ See the full roadmap in [architecture-decisions.md](architecture-decisions.md#ro
 | `HAIL_URL` | (required) | NATS server URL |
 | `RUNTIME` | `podman` | Container runtime (`podman` or `kubernetes`) |
 | `BRIDGE_PORT` | `8080` | HTTP server port |
-| `SKIFF_IMAGE` | `ghcr.io/bmbouter/alcove-skiff-base:latest` | Skiff container image |
-| `GATE_IMAGE` | `ghcr.io/bmbouter/alcove-gate:latest` | Gate container image |
+| `SKIFF_IMAGE` | `ghcr.io/alcove-ai/alcove-skiff-base:latest` | Skiff container image |
+| `GATE_IMAGE` | `ghcr.io/alcove-ai/alcove-gate:latest` | Gate container image |
 | `ALCOVE_NETWORK` | `alcove-internal` | Podman internal network name |
 | `ALCOVE_EXTERNAL_NETWORK` | `alcove-external` | Podman external network name (Gate egress) |
 | `AUTH_BACKEND` | `memory` | Auth backend: `memory`, `postgres`, or `rh-identity` |

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -230,8 +230,8 @@ Bridge reads these environment variables:
 | `LEDGER_DATABASE_URL` | PostgreSQL connection string | `postgres://alcove:alcove@localhost:5432/alcove?sslmode=disable` |
 | `HAIL_URL` | NATS server URL | `nats://localhost:4222` |
 | `RUNTIME` | Container runtime to use | `podman` or `kubernetes` |
-| `SKIFF_IMAGE` | Skiff container image | `ghcr.io/bmbouter/alcove-skiff-base:latest` |
-| `GATE_IMAGE` | Gate container image | `ghcr.io/bmbouter/alcove-gate:latest` |
+| `SKIFF_IMAGE` | Skiff container image | `ghcr.io/alcove-ai/alcove-skiff-base:latest` |
+| `GATE_IMAGE` | Gate container image | `ghcr.io/alcove-ai/alcove-gate:latest` |
 | `ALCOVE_WEB_DIR` | Path to dashboard static files | `/web` or `./web` |
 | `ALCOVE_NETWORK` | Podman internal network name | `alcove-internal` |
 | `ALCOVE_EXTERNAL_NETWORK` | Podman external network for Gate egress | `alcove-external` |
@@ -816,7 +816,7 @@ or `dev` if not in a git repository.
 
 ### Publishing to GitHub Container Registry
 
-Pre-built images are available at `ghcr.io/bmbouter/alcove-<component>`.
+Pre-built images are available at `ghcr.io/alcove-ai/alcove-<component>`.
 
 **Pulling images:**
 
@@ -849,9 +849,9 @@ git push origin v0.1.0
 
 | Image | Registry Path |
 |-------|-------------|
-| Bridge | `ghcr.io/bmbouter/alcove-bridge:<version>` |
-| Gate | `ghcr.io/bmbouter/alcove-gate:<version>` |
-| Skiff | `ghcr.io/bmbouter/alcove-skiff-base:<version>` |
+| Bridge | `ghcr.io/alcove-ai/alcove-bridge:<version>` |
+| Gate | `ghcr.io/alcove-ai/alcove-gate:<version>` |
+| Skiff | `ghcr.io/alcove-ai/alcove-skiff-base:<version>` |
 
 Each push also updates the `latest` tag.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,7 @@ This pulls all three images and tags them locally. Then use `make dev-up`
 ### 1. Clone
 
 ```bash
-git clone https://github.com/bmbouter/alcove.git
+git clone https://github.com/alcove-ai/alcove.git
 cd alcove
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bmbouter/alcove
+module github.com/alcove-ai/alcove
 
 go 1.25.0
 

--- a/internal/bridge/agentdef.go
+++ b/internal/bridge/agentdef.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"gopkg.in/yaml.v3"

--- a/internal/bridge/agentdef_test.go
+++ b/internal/bridge/agentdef_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 )
 
 func TestResolvePluginBundles(t *testing.T) {

--- a/internal/bridge/api.go
+++ b/internal/bridge/api.go
@@ -34,8 +34,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
-	"github.com/bmbouter/alcove/internal/auth"
+	"github.com/alcove-ai/alcove/internal"
+	"github.com/alcove-ai/alcove/internal/auth"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go"
 )

--- a/internal/bridge/cigate.go
+++ b/internal/bridge/cigate.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 

--- a/internal/bridge/config.go
+++ b/internal/bridge/config.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -26,8 +26,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
-	"github.com/bmbouter/alcove/internal/runtime"
+	"github.com/alcove-ai/alcove/internal"
+	"github.com/alcove-ai/alcove/internal/runtime"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go"
@@ -118,7 +118,7 @@ type TaskRequest struct {
 	// Task metadata — set by dispatch code paths, stored in sessions table.
 	TaskName    string `json:"-"` // Schedule/agent definition name
 	TriggerType string `json:"-"` // "event", "cron", "manual", "webhook"
-	TriggerRef  string `json:"-"` // e.g., "bmbouter/alcove#107" for GitHub events
+	TriggerRef  string `json:"-"` // e.g., "alcove-ai/alcove#107" for GitHub events
 }
 
 // ToolConfig specifies per-tool configuration in a task request.
@@ -717,8 +717,8 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 	// Start Skiff pod via Runtime.
 	spec := runtime.TaskSpec{
 		TaskID:         taskID,
-		Image:          envOrDefault("SKIFF_IMAGE", "ghcr.io/bmbouter/alcove-skiff-base:latest"),
-		GateImage:      envOrDefault("GATE_IMAGE", "ghcr.io/bmbouter/alcove-gate:latest"),
+		Image:          envOrDefault("SKIFF_IMAGE", "ghcr.io/alcove-ai/alcove-skiff-base:latest"),
+		GateImage:      envOrDefault("GATE_IMAGE", "ghcr.io/alcove-ai/alcove-gate:latest"),
 		Env:            skiffEnv,
 		GateEnv:        gateEnv,
 		Timeout:        int64(timeout),

--- a/internal/bridge/policyrules.go
+++ b/internal/bridge/policyrules.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"gopkg.in/yaml.v3"

--- a/internal/bridge/poller.go
+++ b/internal/bridge/poller.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 

--- a/internal/bridge/reconcile_test.go
+++ b/internal/bridge/reconcile_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bmbouter/alcove/internal/runtime"
+	"github.com/alcove-ai/alcove/internal/runtime"
 )
 
 // mockRuntime is a minimal Runtime implementation for testing reconciliation.

--- a/internal/bridge/repogroup.go
+++ b/internal/bridge/repogroup.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"gopkg.in/yaml.v3"

--- a/internal/bridge/runtime.go
+++ b/internal/bridge/runtime.go
@@ -17,7 +17,7 @@ package bridge
 import (
 	"fmt"
 
-	"github.com/bmbouter/alcove/internal/runtime"
+	"github.com/alcove-ai/alcove/internal/runtime"
 )
 
 // NewRuntime creates a Runtime implementation based on the type string.

--- a/internal/bridge/scheduler.go
+++ b/internal/bridge/scheduler.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )

--- a/internal/bridge/security.go
+++ b/internal/bridge/security.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"gopkg.in/yaml.v3"

--- a/internal/bridge/workflow.go
+++ b/internal/bridge/workflow.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"gopkg.in/yaml.v3"

--- a/internal/bridge/workflow_engine.go
+++ b/internal/bridge/workflow_engine.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
-	"github.com/bmbouter/alcove/internal/bridge/condition"
+	"github.com/alcove-ai/alcove/internal"
+	"github.com/alcove-ai/alcove/internal/bridge/condition"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )

--- a/internal/gate/mitm.go
+++ b/internal/gate/mitm.go
@@ -35,7 +35,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 )
 
 const certCacheMaxSize = 256

--- a/internal/gate/mitm_test.go
+++ b/internal/gate/mitm_test.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 )
 
 func mustGenerateTestCA(t *testing.T) ([]byte, []byte) {

--- a/internal/gate/policy.go
+++ b/internal/gate/policy.go
@@ -19,7 +19,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 )
 
 // CheckPolicyRules evaluates an HTTP request against resolved policy rules.

--- a/internal/gate/policy_test.go
+++ b/internal/gate/policy_test.go
@@ -17,7 +17,7 @@ package gate
 import (
 	"testing"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 )
 
 func TestMatchPathGlob(t *testing.T) {

--- a/internal/gate/proxy.go
+++ b/internal/gate/proxy.go
@@ -31,7 +31,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 )
 
 // DomainAllowlist contains hosts that are allowed for general HTTP access

--- a/internal/gate/proxy_test.go
+++ b/internal/gate/proxy_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 )
 
 // --------------------------------------------------------------------

--- a/internal/gate/scope.go
+++ b/internal/gate/scope.go
@@ -29,7 +29,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 )
 
 // issueKeyRegexp matches JIRA issue keys like PROJ-123, ABC-1, MYPROJECT-999.

--- a/internal/hail/client.go
+++ b/internal/hail/client.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 )
 
 // Client wraps a NATS connection for Alcove-specific messaging patterns.

--- a/internal/ledger/client.go
+++ b/internal/ledger/client.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/bmbouter/alcove/internal"
+	"github.com/alcove-ai/alcove/internal"
 )
 
 // Client communicates with the Ledger HTTP API.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,15 +5,15 @@
 # for your platform from the latest GitHub release.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.sh | bash
 #   
 # Or with custom installation directory:
-#   curl -fsSL https://raw.githubusercontent.com/bmbouter/alcove/main/scripts/install.sh | INSTALL_DIR="$HOME/bin" bash
+#   curl -fsSL https://raw.githubusercontent.com/alcove-ai/alcove/main/scripts/install.sh | INSTALL_DIR="$HOME/bin" bash
 
 set -e
 
 # Configuration
-REPO="bmbouter/alcove"
+REPO="alcove-ai/alcove"
 BINARY_NAME="alcove"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 GITHUB_URL="https://api.github.com/repos/${REPO}"

--- a/scripts/test-agent-repos.sh
+++ b/scripts/test-agent-repos.sh
@@ -42,7 +42,7 @@ ADMIN_TOKEN=$(curl -s -X POST "$BRIDGE_URL/api/v1/auth/login" \
   -H "Content-Type: application/json" \
   -d "{\"username\":\"admin\",\"password\":\"${ADMIN_PASSWORD}\"}" | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")
 
-ALCOVE_TESTING_URL="https://github.com/bmbouter/alcove-testing.git"
+ALCOVE_TESTING_URL="https://github.com/alcove-ai/alcove-testing.git"
 
 # =====================================================================
 # Group 1: User Task Repo CRUD

--- a/scripts/test-fixture-sync.sh
+++ b/scripts/test-fixture-sync.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # test-fixture-sync.sh — Comprehensive test of agent repo sync with known fixtures.
 #
-# Syncs bmbouter/alcove-tests and verifies all agent definitions, security
+# Syncs alcove-ai/alcove-tests and verifies all agent definitions, security
 # profiles, and workflows are parsed and stored correctly.
 #
 # Prerequisites:
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 BRIDGE_URL="${BRIDGE_URL:-http://localhost:8080}"
-ALCOVE_TESTS_URL="https://github.com/bmbouter/alcove-tests.git"
+ALCOVE_TESTS_URL="https://github.com/alcove-ai/alcove-tests.git"
 PASS=0
 FAIL=0
 

--- a/scripts/test-gate-real.sh
+++ b/scripts/test-gate-real.sh
@@ -11,7 +11,7 @@
 # Prerequisites:
 #   - Bridge running at localhost:8080 with AUTH_BACKEND=postgres
 #   - A GitHub PAT registered as credential "github" in the credential store
-#   - The repo bmbouter/alcove-testing exists on GitHub
+#   - The repo alcove-ai/alcove-testing exists on GitHub
 #   - Container images built (make build-images)
 #
 # Usage:
@@ -21,7 +21,7 @@ set -euo pipefail
 
 BRIDGE_URL="${BRIDGE_URL:-http://localhost:8080}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin123}"
-TEST_REPO="bmbouter/alcove-testing"
+TEST_REPO="alcove-ai/alcove-testing"
 PROFILE_NAME="gate-test-readonly-$$"
 TEST_IMAGE="localhost/alcove-skiff-base:dev"
 INTERNAL_NET="alcove-internal"

--- a/scripts/test-simplified-agents.sh
+++ b/scripts/test-simplified-agents.sh
@@ -68,7 +68,7 @@ curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ALICE_TOKEN" \
   -H "Content-Type: application/json" \
   -H "X-Alcove-Team: $ALICE_TEAM_ID" \
-  -d "{\"repos\":[{\"url\":\"https://github.com/bmbouter/alcove/\",\"ref\":\"${ALCOVE_TEST_REF:-main}\",\"name\":\"alcove\"},{\"url\":\"https://github.com/bmbouter/alcove-testing.git\",\"ref\":\"main\",\"name\":\"alcove-testing\"}]}" > /dev/null
+  -d "{\"repos\":[{\"url\":\"https://github.com/alcove-ai/alcove/\",\"ref\":\"${ALCOVE_TEST_REF:-main}\",\"name\":\"alcove\"},{\"url\":\"https://github.com/alcove-ai/alcove-testing.git\",\"ref\":\"main\",\"name\":\"alcove-testing\"}]}" > /dev/null
 
 curl -s -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
   -H "Authorization: Bearer $ALICE_TOKEN" \

--- a/scripts/test-teams.sh
+++ b/scripts/test-teams.sh
@@ -639,7 +639,7 @@ curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ALICE_TOKEN" \
   -H "Content-Type: application/json" \
   -H "X-Alcove-Team: $PERSONAL_TEAM_ID" \
-  -d "{\"repos\":[{\"url\":\"https://github.com/bmbouter/alcove/\",\"ref\":\"${ALCOVE_TEST_REF:-main}\",\"name\":\"alcove\"}]}" > /dev/null
+  -d "{\"repos\":[{\"url\":\"https://github.com/alcove-ai/alcove/\",\"ref\":\"${ALCOVE_TEST_REF:-main}\",\"name\":\"alcove\"}]}" > /dev/null
 
 curl -s -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
   -H "Authorization: Bearer $ALICE_TOKEN" \
@@ -705,7 +705,7 @@ curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ALICE_TOKEN" \
   -H "Content-Type: application/json" \
   -H "X-Alcove-Team: $PERSONAL_TEAM_ID" \
-  -d "{\"repos\":[{\"url\":\"https://github.com/bmbouter/alcove/\",\"ref\":\"${ALCOVE_TEST_REF:-main}\",\"name\":\"alcove\"}]}" > /dev/null
+  -d "{\"repos\":[{\"url\":\"https://github.com/alcove-ai/alcove/\",\"ref\":\"${ALCOVE_TEST_REF:-main}\",\"name\":\"alcove\"}]}" > /dev/null
 
 curl -s -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
   -H "Authorization: Bearer $ALICE_TOKEN" \

--- a/scripts/test-workflow-definitions.sh
+++ b/scripts/test-workflow-definitions.sh
@@ -70,7 +70,7 @@ curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ALICE_TOKEN" \
   -H "Content-Type: application/json" \
   -H "X-Alcove-Team: $ALICE_TEAM_ID" \
-  -d '{"repos":[{"url":"https://github.com/bmbouter/alcove/","ref":"'"${ALCOVE_TEST_REF:-main}"'","name":"alcove"}]}' > /dev/null
+  -d '{"repos":[{"url":"https://github.com/alcove-ai/alcove/","ref":"'"${ALCOVE_TEST_REF:-main}"'","name":"alcove"}]}' > /dev/null
 
 curl -s -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
   -H "Authorization: Bearer $ALICE_TOKEN" \

--- a/scripts/test-workflow-graph-v2.sh
+++ b/scripts/test-workflow-graph-v2.sh
@@ -205,7 +205,7 @@ curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \
   -H "Authorization: Bearer $ALICE_TOKEN" \
   -H "Content-Type: application/json" \
   -H "X-Alcove-Team: $ALICE_TEAM_ID" \
-  -d '{"repos":[{"url":"https://github.com/bmbouter/alcove-testing.git","name":"alcove-testing"}]}' > /dev/null
+  -d '{"repos":[{"url":"https://github.com/alcove-ai/alcove-testing.git","name":"alcove-testing"}]}' > /dev/null
 
 curl -s -X POST "$BRIDGE_URL/api/v1/agent-definitions/sync" \
   -H "Authorization: Bearer $ALICE_TOKEN" \
@@ -312,7 +312,7 @@ log "  Workflows with conditions: $VALID_CONDITION_WFS"
 VALIDATE_VALID=$(curl -s -w "\n%{http_code}" -X POST "$BRIDGE_URL/api/v1/agent-repos/validate" \
   -H "Authorization: Bearer $ALICE_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"url":"https://github.com/bmbouter/alcove-testing.git"}')
+  -d '{"url":"https://github.com/alcove-ai/alcove-testing.git"}')
 VALIDATE_CODE=$(echo "$VALIDATE_VALID" | tail -1)
 VALIDATE_BODY=$(echo "$VALIDATE_VALID" | sed '$d')
 

--- a/scripts/test-yaml-security-profiles.sh
+++ b/scripts/test-yaml-security-profiles.sh
@@ -36,7 +36,7 @@ ADMIN_TOKEN=$(curl -s -X POST "$BRIDGE_URL/api/v1/auth/login" \
   -H "Content-Type: application/json" \
   -d "{\"username\":\"admin\",\"password\":\"${ADMIN_PASSWORD}\"}" | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")
 
-ALCOVE_TESTING_URL="https://github.com/bmbouter/alcove-testing.git"
+ALCOVE_TESTING_URL="https://github.com/alcove-ai/alcove-testing.git"
 
 # Clear any existing repos first to start clean
 curl -s -X PUT "$BRIDGE_URL/api/v1/user/settings/agent-repos" \

--- a/web/index.html
+++ b/web/index.html
@@ -98,8 +98,8 @@
                 <div class="rh-identity-banner-icon">ℹ️</div>
                 <div class="rh-identity-banner-text">
                     <strong>Welcome to Alcove!</strong> This is an experiment in automated software development lifecycle.
-                    <a href="https://github.com/bmbouter/alcove/issues" target="_blank">File issues or provide feedback</a> •
-                    <a href="https://github.com/bmbouter/alcove#security-principles" target="_blank">Security principles</a>
+                    <a href="https://github.com/alcove-ai/alcove/issues" target="_blank">File issues or provide feedback</a> •
+                    <a href="https://github.com/alcove-ai/alcove#security-principles" target="_blank">Security principles</a>
                 </div>
                 <button id="rh-identity-banner-dismiss" class="rh-identity-banner-dismiss" title="Dismiss for this session">×</button>
             </div>


### PR DESCRIPTION
## Summary
All repos transferred to the `alcove-ai` GitHub organization. This PR updates every reference:

- Go module path: `github.com/bmbouter/alcove` → `github.com/alcove-ai/alcove`
- Container images: `ghcr.io/bmbouter/alcove-*` → `ghcr.io/alcove-ai/alcove-*`
- Agent/workflow YAML repo URLs
- Docs, deploy templates, GitHub Actions, CLI skills

65 files, pure find-and-replace. No logic changes.

## Post-merge
- app-interface deploy-alcove.yml needs image path update
- alcove-testing agent YAMLs referencing bmbouter/alcove-testing need updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)