### PR TITLE
Inject JIRA env vars for agent sessions

### DIFF
--- a/internal/bridge/dispatcher.go
+++ b/internal/bridge/dispatcher.go
@@ -457,14 +457,18 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 			servicesNeeded["gitlab"] = true
 		}
 	}
+	scmAPIHosts := make(map[string]string)
 	for service := range servicesNeeded {
 		if service == "github" || service == "gitlab" || service == "jira" || service == "splunk" {
-			realToken, _, err := d.credStore.AcquireSCMTokenForOwner(ctx, service, activeTeamID)
+			realToken, apiHost, err := d.credStore.AcquireSCMTokenForOwner(ctx, service, activeTeamID)
 			if err != nil {
 				log.Printf("warning: no credential for %s: %v", service, err)
 				continue
 			}
 			scmCredentials[service] = realToken
+			if apiHost != "" {
+				scmAPIHosts[service] = apiHost
+			}
 			dummyToken := "alcove-session-" + uuid.New().String()
 			scmDummyTokens[service] = dummyToken
 			// Ensure the service is in scope so Gate's MITM handler knows to intercept it.
@@ -595,6 +599,11 @@ func (d *Dispatcher) DispatchTask(ctx context.Context, req TaskRequest, submitte
 	}
 	if token, ok := scmDummyTokens["jira"]; ok {
 		skiffEnv["JIRA_TOKEN"] = token
+		skiffEnv["JIRA_API_TOKEN"] = token
+		skiffEnv["JIRA_USERNAME"] = "alcove-proxy-user"
+		if host, ok := scmAPIHosts["jira"]; ok {
+			skiffEnv["JIRA_URL"] = strings.TrimRight(host, "/")
+		}
 	}
 	if token, ok := scmDummyTokens["splunk"]; ok {
 		skiffEnv["SPLUNK_TOKEN"] = token


### PR DESCRIPTION
## Summary
When JIRA is in scope, inject `JIRA_URL`, `JIRA_USERNAME`, and `JIRA_API_TOKEN` into Skiff env so agents can use `curl` to hit JIRA through Gate's MITM proxy.

Previously only `JIRA_TOKEN` was set — MCP servers and standard JIRA tools don't recognize it.

## How it works
- `JIRA_URL` = real Atlassian instance URL from credential's `api_host` field
- `JIRA_USERNAME` = dummy placeholder (Gate replaces the entire auth header via MITM)
- `JIRA_API_TOKEN` = dummy session token (Gate replaces with real `email:token` Basic auth)

Agents can now do: `curl -u "$JIRA_USERNAME:$JIRA_API_TOKEN" $JIRA_URL/rest/api/2/issue/PROJ-123`

## Verified locally
- [x] `go build && go test && go vet` — all clean
- [x] Dispatched session with JIRA in scope — all 4 env vars present in env snapshot
- [x] `JIRA_URL` correctly reads from credential's `api_host`

🤖 Generated with [Claude Code](https://claude.com/claude-code)