### PR TITLE
Fix template: remove hardcoded ${NAMESPACE} from NetworkPolicy

### DIFF
--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -27,8 +27,6 @@ parameters:
   value: ""
 - name: BRIDGE_LLM_REGION
   value: ""
-- name: NAMESPACE
-  value: ${NAMESPACE}
 - name: CREATE_ROUTE
   description: Whether to create an OpenShift Route for alcove-bridge
   value: "true"
@@ -371,7 +369,6 @@ objects:
   kind: NetworkPolicy
   metadata:
     name: alcove-allow-direct-outbound
-    namespace: ${NAMESPACE}
     labels:
       app.kubernetes.io/part-of: alcove
   spec:


### PR DESCRIPTION
Fixes recurring deploy error: `namespace from the provided object \"${NAMESPACE}\" does not match`. Removed explicit namespace field — inherits from deployment target like all other resources.