### PR TITLE
Fix migration 037: remove CONCURRENTLY (breaks staging)

### DIFF
--- a/internal/bridge/migrations/037_workflow_runs_indexes.sql
+++ b/internal/bridge/migrations/037_workflow_runs_indexes.sql
@@ -1,13 +1,13 @@
 -- Add database indexes for workflow runs pagination and filtering.
 
 -- Composite index for (team_id, created_at) for date-based filtering with pagination
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_workflow_runs_team_created
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_team_created
 ON workflow_runs(team_id, created_at);
 
 -- Index for (team_id, trigger_ref) for trigger ref search
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_workflow_runs_team_trigger_ref
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_team_trigger_ref
 ON workflow_runs(team_id, trigger_ref);
 
 -- Composite index for (team_id, status, created_at) for status filtering with date ordering
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_workflow_runs_team_status_created
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_team_status_created
 ON workflow_runs(team_id, status, created_at);


### PR DESCRIPTION
Staging is crash-looping because CREATE INDEX CONCURRENTLY can't run in a transaction. Removes CONCURRENTLY keyword.