### PR TITLE
SDLC pipeline: claim issue before starting work

### DIFF
--- a/.alcove/workflows/feature-pipeline.yml
+++ b/.alcove/workflows/feature-pipeline.yml
@@ -8,9 +8,19 @@ trigger:
     delivery_mode: polling
 
 workflow:
+  - id: claim-issue
+    type: bridge
+    action: update-issue
+    inputs:
+      repo: alcove-ai/alcove
+      issue: "{{trigger.issue_number}}"
+      add_assignees: ["alcove-bot"]
+      remove_labels: ["ready-for-dev"]
+
   - id: implement
     type: agent
     agent: Autonomous Developer
+    depends: "claim-issue.Succeeded"
     max_retries: 3
     inputs:
       branch: "issue-{{trigger.issue_number}}-fix"


### PR DESCRIPTION
Uses the new update-issue bridge action to assign alcove-bot and remove ready-for-dev when the pipeline starts.