### PR TITLE
Fix orphaned cleanup: scope schedule deletion to removed repo

### DIFF
--- a/internal/bridge/tasksync.go
+++ b/internal/bridge/tasksync.go
@@ -260,7 +260,7 @@ func (s *AgentRepoSyncer) SyncAll(ctx context.Context) error {
 				_ = s.workflowStore.DeleteWorkflowsByRepo(ctx, sourceRepo, teamID)
 				_ = s.repoGroupStore.DeleteRepoGroupsByRepo(ctx, sourceRepo, teamID)
 				// Also clean up schedules from this repo.
-				s.db.Exec(ctx, `DELETE FROM schedules WHERE source_key LIKE $1 AND team_id = $2`, username+"::%", teamID)
+				s.db.Exec(ctx, `DELETE FROM schedules WHERE source_key LIKE $1 AND team_id = $2`, username+"::"+sourceRepo+"::%", teamID)
 				removedRepos[sourceRepo] = true
 			}
 		}

--- a/internal/bridge/tasksync_orphaned_test.go
+++ b/internal/bridge/tasksync_orphaned_test.go
@@ -167,6 +167,96 @@ func TestOrphanedWorkflowCleanup(t *testing.T) {
 	assert.NotContains(t, profileRepos, oldRepoURL)
 }
 
+// TestOrphanedCleanupDoesNotDeleteSchedulesFromOtherRepos verifies that
+// the schedule cleanup LIKE pattern is scoped to the orphaned repo's source_key
+// prefix, not to all schedules for the user. This guards against a regression
+// where the LIKE pattern was `username::%` instead of `username::sourceRepo::%`,
+// which would delete schedules from repos that were still configured.
+func TestOrphanedCleanupDoesNotDeleteSchedulesFromOtherRepos(t *testing.T) {
+	ctx := context.Background()
+
+	db := setupTestDB(t)
+	defer teardownTestDB(t, db)
+
+	teamID := createTestTeam(t, db, "test-team-schedules", false)
+	username := "testuser"
+	createTestUser(t, db, username, teamID)
+
+	defStore := NewAgentDefStore(db)
+	workflowStore := NewWorkflowStore(db)
+	profileStore := NewProfileStore(db)
+	policyRuleStore := NewPolicyRuleStore(db)
+	repoGroupStore := NewRepoGroupStore(db)
+	settingsStore := NewSettingsStore(db)
+	syncer := NewAgentRepoSyncer(db, settingsStore, nil, defStore, nil, profileStore, policyRuleStore, workflowStore, repoGroupStore)
+
+	keepRepoURL := "https://github.com/keep-org/repo"
+	removeRepoURL := "https://github.com/remove-org/repo"
+
+	// Configure both repos
+	enabled := true
+	repos := []SkillRepo{{URL: keepRepoURL, Enabled: &enabled}, {URL: removeRepoURL, Enabled: &enabled}}
+	reposJSON, _ := json.Marshal(repos)
+	_, err := db.Exec(ctx, `
+		INSERT INTO team_settings (team_id, key, value)
+		VALUES ($1, 'agent_repos', $2)
+		ON CONFLICT (team_id, key) DO UPDATE SET value = EXCLUDED.value
+	`, teamID, reposJSON)
+	require.NoError(t, err)
+
+	// Create agent definitions in both repos
+	keepAgent := &AgentDefinition{
+		ID: uuid.New().String(), Name: "keep-agent", SourceRepo: keepRepoURL,
+		SourceFile: "keep-agent.yml", SourceKey: username + "::" + keepRepoURL + "::keep-agent.yml",
+		TeamID: teamID, Prompt: "Keep agent",
+	}
+	removeAgent := &AgentDefinition{
+		ID: uuid.New().String(), Name: "remove-agent", SourceRepo: removeRepoURL,
+		SourceFile: "remove-agent.yml", SourceKey: username + "::" + removeRepoURL + "::remove-agent.yml",
+		TeamID: teamID, Prompt: "Remove agent",
+	}
+	require.NoError(t, defStore.UpsertAgentDefinition(ctx, keepAgent))
+	require.NoError(t, defStore.UpsertAgentDefinition(ctx, removeAgent))
+
+	// Create schedules for both repos (simulating what reconcileSchedule would do)
+	_, err = db.Exec(ctx, `
+		INSERT INTO schedules (id, name, cron, prompt, provider, scope_preset, timeout, enabled, created_at, team_id, source, source_key, trigger_type)
+		VALUES ($1, 'keep-schedule', '0 0 * * *', 'test', '', '', 0, true, NOW(), $2, 'yaml', $3, 'cron')
+	`, uuid.New().String(), teamID, username+"::"+keepRepoURL+"::keep-agent.yml")
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO schedules (id, name, cron, prompt, provider, scope_preset, timeout, enabled, created_at, team_id, source, source_key, trigger_type)
+		VALUES ($1, 'remove-schedule', '0 0 * * *', 'test', '', '', 0, true, NOW(), $2, 'yaml', $3, 'cron')
+	`, uuid.New().String(), teamID, username+"::"+removeRepoURL+"::remove-agent.yml")
+	require.NoError(t, err)
+
+	// Remove one repo from configuration
+	repos = []SkillRepo{{URL: keepRepoURL, Enabled: &enabled}}
+	reposJSON, _ = json.Marshal(repos)
+	_, err = db.Exec(ctx, `
+		UPDATE team_settings SET value = $1 WHERE team_id = $2 AND key = 'agent_repos'
+	`, reposJSON, teamID)
+	require.NoError(t, err)
+
+	// Run sync
+	require.NoError(t, syncer.SyncAll(ctx))
+
+	// Verify: schedule for kept repo should still exist
+	var keepCount int
+	err = db.QueryRow(ctx, `SELECT COUNT(*) FROM schedules WHERE source_key = $1 AND team_id = $2`,
+		username+"::"+keepRepoURL+"::keep-agent.yml", teamID).Scan(&keepCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, keepCount, "schedule for kept repo should survive cleanup")
+
+	// Verify: schedule for removed repo should be deleted
+	var removeCount int
+	err = db.QueryRow(ctx, `SELECT COUNT(*) FROM schedules WHERE source_key = $1 AND team_id = $2`,
+		username+"::"+removeRepoURL+"::remove-agent.yml", teamID).Scan(&removeCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removeCount, "schedule for removed repo should be deleted")
+}
+
 // Helper functions for test setup
 func setupTestDB(t *testing.T) *pgxpool.Pool {
 	// This would connect to a test database


### PR DESCRIPTION
The schedule cleanup LIKE pattern was too broad — removing one repo deleted schedules from all repos. Now scoped to the orphaned repo only. Includes regression test.