### PR TITLE
Fix orphaned workflow delete: cascade through FK constraints

### DIFF
--- a/internal/bridge/tasksync.go
+++ b/internal/bridge/tasksync.go
@@ -257,7 +257,9 @@ func (s *AgentRepoSyncer) SyncAll(ctx context.Context) error {
 				_ = s.defStore.DeleteAgentDefinitionsByRepo(ctx, sourceRepo, teamID)
 				_ = s.profileStore.DeleteYAMLProfilesByRepo(ctx, sourceRepo, teamID)
 				_ = s.policyRuleStore.DeleteByRepo(ctx, sourceRepo, teamID)
-				_ = s.workflowStore.DeleteWorkflowsByRepo(ctx, sourceRepo, teamID)
+				if err := s.workflowStore.DeleteWorkflowsByRepo(ctx, sourceRepo, teamID); err != nil {
+					log.Printf("agent-repo-syncer: error deleting workflows from %s: %v", sourceRepo, err)
+				}
 				_ = s.repoGroupStore.DeleteRepoGroupsByRepo(ctx, sourceRepo, teamID)
 				// Also clean up schedules from this repo.
 				s.db.Exec(ctx, `DELETE FROM schedules WHERE source_key LIKE $1 AND team_id = $2`, username+"::"+sourceRepo+"::%", teamID)

--- a/internal/bridge/workflow.go
+++ b/internal/bridge/workflow.go
@@ -677,7 +677,44 @@ func (s *WorkflowStore) ListWorkflowsByRepo(ctx context.Context, repoURL, teamID
 
 // DeleteWorkflowsByRepo removes all workflow definitions from a given repo URL and owner.
 func (s *WorkflowStore) DeleteWorkflowsByRepo(ctx context.Context, repoURL, teamID string) error {
-	_, err := s.db.Exec(ctx, `DELETE FROM workflows WHERE source_repo = $1 AND team_id = $2`, repoURL, teamID)
+	// Nullify session FK references to run steps and runs being deleted.
+	_, err := s.db.Exec(ctx, `
+		UPDATE sessions SET workflow_run_step_id = NULL WHERE workflow_run_step_id IN (
+			SELECT wrs.id FROM workflow_run_steps wrs
+			JOIN workflow_runs wr ON wrs.run_id = wr.id
+			JOIN workflows w ON wr.workflow_id = w.id
+			WHERE w.source_repo = $1 AND w.team_id = $2
+		)`, repoURL, teamID)
+	if err != nil {
+		return fmt.Errorf("nullifying session step refs for repo %s: %w", repoURL, err)
+	}
+	_, err = s.db.Exec(ctx, `
+		UPDATE sessions SET workflow_run_id = NULL WHERE workflow_run_id IN (
+			SELECT wr.id FROM workflow_runs wr
+			JOIN workflows w ON wr.workflow_id = w.id
+			WHERE w.source_repo = $1 AND w.team_id = $2
+		)`, repoURL, teamID)
+	if err != nil {
+		return fmt.Errorf("nullifying session step refs for repo %s: %w", repoURL, err)
+	}
+	// Delete run steps, then runs, then workflows (FK order).
+	_, err = s.db.Exec(ctx, `
+		DELETE FROM workflow_run_steps WHERE run_id IN (
+			SELECT wr.id FROM workflow_runs wr
+			JOIN workflows w ON wr.workflow_id = w.id
+			WHERE w.source_repo = $1 AND w.team_id = $2
+		)`, repoURL, teamID)
+	if err != nil {
+		return fmt.Errorf("deleting workflow run steps for repo %s: %w", repoURL, err)
+	}
+	_, err = s.db.Exec(ctx, `
+		DELETE FROM workflow_runs WHERE workflow_id IN (
+			SELECT id FROM workflows WHERE source_repo = $1 AND team_id = $2
+		)`, repoURL, teamID)
+	if err != nil {
+		return fmt.Errorf("deleting workflow runs for repo %s: %w", repoURL, err)
+	}
+	_, err = s.db.Exec(ctx, `DELETE FROM workflows WHERE source_repo = $1 AND team_id = $2`, repoURL, teamID)
 	if err != nil {
 		return fmt.Errorf("deleting workflows for repo %s: %w", repoURL, err)
 	}


### PR DESCRIPTION
## Root cause
`DeleteWorkflowsByRepo` did a simple `DELETE FROM workflows WHERE ...` which failed silently due to FK constraints from `workflow_runs` and `workflow_run_steps`. The error was discarded with `_ =`.

## Fix
Cascade delete in FK order: nullify session refs → delete run steps → delete runs → delete workflows. Also log errors instead of discarding.

## Verified locally
- Reproduced: orphaned workflows survived cleanup (FK error)
- Fixed: orphaned workflows now deleted successfully
- All 12 test packages pass