### PR TITLE
Fix workflow engine: trust session status over exit code

### DIFF
--- a/internal/bridge/workflow_engine.go
+++ b/internal/bridge/workflow_engine.go
@@ -590,7 +590,7 @@ func (we *WorkflowEngine) OnStepCompletion(ctx context.Context, sessionID string
 	// Update step status
 	now := time.Now().UTC()
 	stepStatus := "completed"
-	if status != "completed" || (exitCode != nil && *exitCode != 0) {
+	if status != "completed" {
 		stepStatus = "failed"
 	}
 


### PR DESCRIPTION
## Root cause
`OnStepCompletion` in workflow_engine.go line 593 checked `exitCode != 0` even when `status == "completed"`. Claude Code exits 1 when any tool error occurs during the session, but skiff-init correctly sets status to "completed" when the result event indicates success. The exit code check overrode this, marking the step as "failed".

## Evidence chain
1. Claude Code exits 1 (tool errors during session)
2. skiff-init sets outcome="completed" (sawSuccessResult=true)
3. Workflow engine sees status="completed" BUT exitCode=1 → marks step "failed"
4. create-pr depends on implement.Succeeded → never runs
5. Code sits on branches with no PRs

## Fix
Remove the exit code override. Trust the session status that skiff-init already computed correctly.

## Impact
5 SDLC pipeline runs (#542-#546) were stuck because of this. All pushed code but no PRs were created.