### PR TITLE
Fix workflow validation: add rebase and create-prs to valid actions

### DIFF
--- a/internal/bridge/workflow.go
+++ b/internal/bridge/workflow.go
@@ -133,6 +133,11 @@ var validBridgeActions = map[string]bool{
 	// Search actions.
 	"search-gh-issues": true,
 	"search-issues":    true,
+	// Rebase actions.
+	"rebase":    true,
+	"rebase-pr": true,
+	// Multi-repo actions.
+	"create-prs": true,
 }
 
 // validateWorkflowSteps performs comprehensive validation on workflow steps.


### PR DESCRIPTION
The feature pipeline is broken on staging because `rebase` isn't in `validBridgeActions`. Also adds `rebase-pr` and `create-prs` which were similarly missing.