### PR TITLE
GitLab/JIRA parity: rebase, merge lock, workflow templates

### DIFF
--- a/.alcove/workflows/gitlab-feature-pipeline.yml
+++ b/.alcove/workflows/gitlab-feature-pipeline.yml
@@ -1,0 +1,100 @@
+name: GitLab SDLC Pipeline
+trigger:
+  gitlab:
+    events: [issue]
+    actions: [update]
+    labels: [ready-for-dev]
+    delivery_mode: polling
+
+workflow:
+  - id: claim-issue
+    type: bridge
+    action: update-issue
+    inputs:
+      project: "{{trigger.gitlab_project}}"
+      issue: "{{trigger.issue_iid}}"
+      add_labels: ["in-progress"]
+      remove_labels: ["ready-for-dev"]
+
+  - id: implement
+    type: agent
+    agent: Autonomous Developer
+    depends: "claim-issue.Succeeded"
+    max_retries: 3
+    inputs:
+      branch: "issue-{{trigger.issue_iid}}-fix"
+      issue_number: "{{trigger.issue_iid}}"
+      repo: "{{trigger.gitlab_project}}"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_description}}"
+      issue_url: "{{trigger.issue_url}}"
+    outputs: [summary]
+
+  - id: create-mr
+    type: bridge
+    action: create-merge-request
+    depends: "implement.Succeeded"
+    inputs:
+      project: "{{trigger.gitlab_project}}"
+      branch: "{{steps.implement.inputs.branch}}"
+      title: "Fix #{{trigger.issue_iid}}"
+      base: main
+      body: |
+        Closes #{{trigger.issue_iid}}
+
+        ## {{trigger.issue_title}}
+
+        ## Summary
+
+        {{steps.implement.outputs.summary}}
+
+  - id: await-ci
+    type: bridge
+    action: await-checks
+    depends: "create-mr.Succeeded || ci-fix.Succeeded || rebase.Succeeded"
+    max_iterations: 4
+    inputs:
+      project: "{{trigger.gitlab_project}}"
+      mr: "{{steps.create-mr.outputs.mr_iid}}"
+
+  - id: ci-fix
+    type: agent
+    agent: Autonomous Developer
+    depends: "await-ci.Failed"
+    max_iterations: 3
+    inputs:
+      branch: "{{steps.implement.inputs.branch}}"
+      issue_number: "{{trigger.issue_iid}}"
+      repo: "{{trigger.gitlab_project}}"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_description}}"
+      issue_url: "{{trigger.issue_url}}"
+      ci_logs: "{{steps.await-ci.outputs.failure_logs}}"
+    outputs: [summary]
+
+  - id: code-review
+    type: agent
+    agent: PR Reviewer
+    depends: "await-ci.Succeeded"
+    max_iterations: 3
+    inputs:
+      mr: "{{steps.create-mr.outputs.mr_iid}}"
+      project: "{{trigger.gitlab_project}}"
+    outputs: [approved, comments]
+
+  - id: rebase
+    type: bridge
+    action: rebase
+    depends: "code-review.Succeeded"
+    max_iterations: 3
+    inputs:
+      project: "{{trigger.gitlab_project}}"
+      mr: "{{steps.create-mr.outputs.mr_iid}}"
+
+  - id: merge
+    type: bridge
+    action: merge
+    depends: "rebase.Succeeded"
+    inputs:
+      project: "{{trigger.gitlab_project}}"
+      mr: "{{steps.create-mr.outputs.mr_iid}}"

--- a/.alcove/workflows/jira-feature-pipeline.yml
+++ b/.alcove/workflows/jira-feature-pipeline.yml
@@ -1,0 +1,113 @@
+name: JIRA SDLC Pipeline
+trigger:
+  jira:
+    projects: []  # Configure with your JIRA project key
+    labels: [ready-for-dev]
+
+workflow:
+  - id: claim-issue
+    type: bridge
+    action: jira-transition-issue
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      transition: "In Progress"
+
+  - id: implement
+    type: agent
+    agent: Autonomous Developer
+    depends: "claim-issue.Succeeded"
+    max_retries: 3
+    inputs:
+      branch: "{{trigger.issue_key}}"
+      issue_number: "{{trigger.issue_key}}"
+      repo: "{{trigger.repo}}"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_description}}"
+      issue_url: "{{trigger.issue_url}}"
+    outputs: [summary]
+
+  - id: create-pr
+    type: bridge
+    action: create-merge-request
+    depends: "implement.Succeeded"
+    inputs:
+      repo: "{{trigger.repo}}"
+      branch: "{{steps.implement.inputs.branch}}"
+      title: "{{trigger.issue_key}}: {{trigger.issue_title}}"
+      base: main
+      body: |
+        JIRA: {{trigger.issue_url}}
+
+        ## {{trigger.issue_title}}
+
+        ## Summary
+
+        {{steps.implement.outputs.summary}}
+
+  - id: await-ci
+    type: bridge
+    action: await-checks
+    depends: "create-pr.Succeeded || ci-fix.Succeeded || rebase.Succeeded"
+    max_iterations: 4
+    inputs:
+      repo: "{{trigger.repo}}"
+      pr: "{{steps.create-pr.outputs.pr_number}}"
+
+  - id: ci-fix
+    type: agent
+    agent: Autonomous Developer
+    depends: "await-ci.Failed"
+    max_iterations: 3
+    inputs:
+      branch: "{{steps.implement.inputs.branch}}"
+      issue_number: "{{trigger.issue_key}}"
+      repo: "{{trigger.repo}}"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_description}}"
+      issue_url: "{{trigger.issue_url}}"
+      ci_logs: "{{steps.await-ci.outputs.failure_logs}}"
+    outputs: [summary]
+
+  - id: code-review
+    type: agent
+    agent: PR Reviewer
+    depends: "await-ci.Succeeded"
+    max_iterations: 3
+    inputs:
+      pr: "{{steps.create-pr.outputs.pr_number}}"
+      repo: "{{trigger.repo}}"
+    outputs: [approved, comments]
+
+  - id: rebase
+    type: bridge
+    action: rebase
+    depends: "code-review.Succeeded"
+    max_iterations: 3
+    inputs:
+      repo: "{{trigger.repo}}"
+      pr: "{{steps.create-pr.outputs.pr_number}}"
+      update_method: merge
+
+  - id: merge
+    type: bridge
+    action: merge
+    depends: "rebase.Succeeded"
+    inputs:
+      repo: "{{trigger.repo}}"
+      pr: "{{steps.create-pr.outputs.pr_number}}"
+
+  - id: close-jira
+    type: bridge
+    action: jira-transition-issue
+    depends: "merge.Succeeded"
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      transition: "Done"
+
+  - id: comment-jira
+    type: bridge
+    action: jira-add-comment
+    depends: "merge.Succeeded"
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      body: "Implemented and merged via SDLC pipeline. PR: {{steps.create-pr.outputs.pr_url}}"

--- a/internal/bridge/bridge_actions.go
+++ b/internal/bridge/bridge_actions.go
@@ -76,6 +76,7 @@ func RegisterBridgeActions() map[string]BridgeActionHandler {
 		"update-gl-issue":   bridgeActionUpdateGLIssue,
 		"create-gl-issue":   bridgeActionCreateGLIssue,
 		"search-gl-issues": bridgeActionSearchGLIssues,
+		"rebase-mr":        bridgeActionRebaseMR,
 
 		// JIRA-specific actions.
 		"jira-create-issue":     bridgeActionJiraCreateIssue,
@@ -95,9 +96,12 @@ func RegisterBridgeActionsWithDB(db *pgxpool.Pool) map[string]BridgeActionHandle
 	serializedMergePR := createSerializedMergeAction(db, bridgeActionMergePR)
 	serializedUnifiedMerge := createSerializedMergeAction(db, bridgeActionUnifiedMerge)
 
+	serializedMergeMR := createSerializedMergeAction(db, bridgeActionMergeMR)
+
 	actions := RegisterBridgeActions()
 	// Override merge actions with serialized versions
 	actions["merge-pr"] = serializedMergePR
+	actions["merge-mr"] = serializedMergeMR
 	actions["merge"] = serializedUnifiedMerge
 
 	return actions
@@ -811,11 +815,7 @@ func bridgeActionUnifiedRebase(ctx context.Context, inputs map[string]interface{
 	scm := detectSCM(inputs)
 	switch scm {
 	case "gitlab":
-		// GitLab rebase will be implemented in Step 3
-		return &BridgeActionResult{
-			Status: "failed",
-			Error:  "GitLab rebase is not yet implemented (see implementation plan Step 3)",
-		}, nil
+		return bridgeActionRebaseMR(ctx, inputs, credStore, teamID)
 	case "github":
 		return bridgeActionRebasePR(ctx, inputs, credStore, teamID)
 	default:

--- a/internal/bridge/bridge_actions_gitlab.go
+++ b/internal/bridge/bridge_actions_gitlab.go
@@ -224,6 +224,100 @@ func bridgeActionAwaitPipeline(ctx context.Context, inputs map[string]interface{
 	return &BridgeActionResult{Status: "failed", Error: fmt.Sprintf("timed out after %d seconds", timeout)}, nil
 }
 
+// bridgeActionRebaseMR rebases a merge request branch on GitLab.
+func bridgeActionRebaseMR(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
+	project := getStringInput(inputs, "project")
+	mr := getIntInput(inputs, "mr")
+
+	if project == "" || mr == 0 {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  "missing required inputs: project, mr",
+		}, nil
+	}
+
+	token, apiHost, err := credStore.AcquireSCMTokenForOwner(ctx, "gitlab", teamID)
+	if err != nil {
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  fmt.Sprintf("failed to acquire GitLab token: %v", err),
+		}, nil
+	}
+	if apiHost == "" {
+		apiHost = "https://gitlab.com"
+	}
+
+	encodedProject := strings.ReplaceAll(project, "/", "%2F")
+
+	// Call GitLab's rebase API
+	url := fmt.Sprintf("%s/api/v4/projects/%s/merge_requests/%d/rebase", apiHost, encodedProject, mr)
+	_, err = gitlabRequest(ctx, token, "PUT", url, nil)
+	if err != nil {
+		if strings.Contains(err.Error(), "409") || strings.Contains(err.Error(), "conflict") {
+			log.Printf("bridge-action rebase-mr: conflicts detected for MR !%d in %s", mr, project)
+			return &BridgeActionResult{
+				Status: "failed",
+				Outputs: map[string]interface{}{
+					"status": "conflict",
+				},
+				Error: "Merge conflicts detected during rebase",
+			}, nil
+		}
+		return &BridgeActionResult{
+			Status: "failed",
+			Error:  fmt.Sprintf("GitLab API error rebasing MR: %v", err),
+		}, nil
+	}
+
+	// Poll for rebase completion — GitLab rebase is async
+	for i := 0; i < 30; i++ {
+		mrURL := fmt.Sprintf("%s/api/v4/projects/%s/merge_requests/%d", apiHost, encodedProject, mr)
+		mrData, err := gitlabRequest(ctx, token, "GET", mrURL, nil)
+		if err != nil {
+			return &BridgeActionResult{
+				Status: "failed",
+				Error:  fmt.Sprintf("error checking rebase status: %v", err),
+			}, nil
+		}
+
+		var mrInfo struct {
+			RebaseInProgress bool   `json:"rebase_in_progress"`
+			MergeError       string `json:"merge_error"`
+			SHA              string `json:"sha"`
+			DiffHeadSHA      string `json:"diff_refs.head_sha"`
+		}
+		json.Unmarshal(mrData, &mrInfo)
+
+		if mrInfo.MergeError != "" {
+			return &BridgeActionResult{
+				Status: "failed",
+				Outputs: map[string]interface{}{
+					"status": "conflict",
+				},
+				Error: fmt.Sprintf("Rebase failed: %s", mrInfo.MergeError),
+			}, nil
+		}
+
+		if !mrInfo.RebaseInProgress {
+			log.Printf("bridge-action rebase-mr: MR !%d in %s rebased successfully (SHA: %s)", mr, project, mrInfo.SHA)
+			return &BridgeActionResult{
+				Status: "succeeded",
+				Outputs: map[string]interface{}{
+					"status":       "rebased",
+					"new_head_sha": mrInfo.SHA,
+				},
+			}, nil
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+
+	return &BridgeActionResult{
+		Status: "failed",
+		Error:  "rebase timed out after 150 seconds",
+	}, nil
+}
+
 // bridgeActionMergeMR merges a merge request on GitLab.
 func bridgeActionMergeMR(ctx context.Context, inputs map[string]interface{}, credStore *CredentialStore, teamID string) (*BridgeActionResult, error) {
 	project := getStringInput(inputs, "project")

--- a/internal/bridge/workflow.go
+++ b/internal/bridge/workflow.go
@@ -139,6 +139,7 @@ var validBridgeActions = map[string]bool{
 	// Rebase actions.
 	"rebase":    true,
 	"rebase-pr": true,
+	"rebase-mr": true,
 	// Multi-repo actions.
 	"create-prs": true,
 }


### PR DESCRIPTION
## Summary
- Implement `rebase-mr` bridge action for GitLab (async rebase with polling)
- Wire into unified `rebase` router (was stub)
- Add advisory lock merge serialization to `merge-mr` (was only on `merge-pr`)
- Add `gitlab-feature-pipeline.yml` workflow template
- Add `jira-feature-pipeline.yml` workflow template with JIRA close + comment steps

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/bridge/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)