### PR TITLE
Fix SDLC agents to write /tmp/alcove-outputs.json

### DIFF
--- a/.alcove/agents/autonomous-dev.yml
+++ b/.alcove/agents/autonomous-dev.yml
@@ -69,7 +69,10 @@ prompt: |
 
   Use a team of specialist agents working in parallel for independent work streams.
 
-  Output: {"summary": "what you implemented"}
+  CRITICAL — YOUR VERY LAST ACTION must be writing outputs. The workflow
+  engine reads this file to determine what happened. Run this command:
+    echo '{"summary": "<brief description of what you implemented>"}' > /tmp/alcove-outputs.json
+  Replace the summary value with your actual summary. Do NOT skip this step.
 
 repos:
   - url: https://github.com/alcove-ai/alcove.git

--- a/.alcove/agents/reviewer.yml
+++ b/.alcove/agents/reviewer.yml
@@ -14,11 +14,10 @@ prompt: |
 
   Post your review via the GitHub API. If requesting changes, be specific about what needs to change and why.
 
-  If _retry_reason is provided, your previous attempt failed output validation.
-  Fix the issue described in _retry_reason and ensure your output matches the
-  expected format.
-
-  Output: {"approved": true/false, "comments": "summary of review"}
+  CRITICAL — YOUR VERY LAST ACTION must be writing outputs. The workflow
+  engine reads this file to determine what happened. Run this command:
+    echo '{"approved": "<true or false>", "comments": "<summary of your review>"}' > /tmp/alcove-outputs.json
+  Replace the values with your actual review findings. Do NOT skip this step.
 
 repos:
   - url: https://github.com/alcove-ai/alcove.git

--- a/.alcove/agents/security-reviewer.yml
+++ b/.alcove/agents/security-reviewer.yml
@@ -16,11 +16,10 @@ prompt: |
 
   Post your review via the GitHub API.
 
-  If _retry_reason is provided, your previous attempt failed output validation.
-  Fix the issue described in _retry_reason and ensure your output matches the
-  expected format.
-
-  Output: {"approved": true/false, "comments": "security findings"}
+  CRITICAL — YOUR VERY LAST ACTION must be writing outputs. The workflow
+  engine reads this file to determine what happened. Run this command:
+    echo '{"approved": "<true or false>", "comments": "<security findings summary>"}' > /tmp/alcove-outputs.json
+  Replace the values with your actual findings. Do NOT skip this step.
 
 repos:
   - url: https://github.com/alcove-ai/alcove.git


### PR DESCRIPTION
## Summary

All three SDLC agent definitions told the agent what output format to produce but never instructed it to write `/tmp/alcove-outputs.json`. The workflow engine's output contract validation found no outputs and marked every step as failed — **100% SDLC pipeline failure rate** across all issues (#616-#632).

- **autonomous-dev.yml**: Add CRITICAL output file instructions
- **reviewer.yml**: Add CRITICAL output file instructions, remove duplicated `_retry_reason` paragraph
- **security-reviewer.yml**: Add CRITICAL output file instructions, remove duplicated `_retry_reason` paragraph

## Test plan

- [ ] Merge this PR
- [ ] Label an issue `ready-for-dev` on alcove-ai/alcove
- [ ] Monitor the SDLC pipeline — agent sessions should now exit with code 0 and produce outputs
- [ ] Verify the workflow progresses through implement → create-pr → await-ci → code-review → security-review → merge

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)