### PR TITLE
Add routing test workflows with synthetic agents

### DIFF
--- a/.alcove/agents/test-always-pass.yml
+++ b/.alcove/agents/test-always-pass.yml
@@ -1,0 +1,34 @@
+name: Test Always Pass
+description: |
+  Deterministic test agent that writes hardcoded success outputs.
+  Part of the routing test suite for validating workflow engine routing.
+
+prompt: |
+  Run this exact command with no modifications. Do not add any other
+  output or commentary. Your only task is to execute this exact script:
+
+  python3 - <<'PYEOF'
+  import json
+  output = {
+      "summary": "test pass",
+      "verdict": "pass",
+      "fixes_required": "",
+      "code_issues": "",
+      "approved": "true",
+      "comments": "test approval",
+      "issues": ""
+  }
+  with open("/tmp/alcove-outputs.json", "w") as f:
+      json.dump(output, f)
+  PYEOF
+
+timeout: 120
+
+outputs:
+  - summary
+  - verdict
+  - fixes_required
+  - code_issues
+  - approved
+  - comments
+  - issues

--- a/.alcove/agents/test-fail-verify-exit0.yml
+++ b/.alcove/agents/test-fail-verify-exit0.yml
@@ -1,0 +1,28 @@
+name: Test Fail Verify Exit0
+description: |
+  Deterministic test agent that writes verdict=fail and exits 0.
+  Tests: does the engine route to patch when output says fail but exit code is 0?
+
+prompt: |
+  Run this exact command with no modifications. Do not add any other
+  output or commentary. Your only task is to execute this exact script:
+
+  python3 - <<'PYEOF'
+  import json
+  output = {
+      "verdict": "fail",
+      "fixes_required": "fix the broken test in test_group_visibility",
+      "code_issues": "test calls .groups.add() on user_context which has no groups attribute"
+  }
+  with open("/tmp/alcove-outputs.json", "w") as f:
+      json.dump(output, f)
+  PYEOF
+
+  Do NOT exit with a non-zero code. Do NOT add error handling or try/except.
+
+timeout: 120
+
+outputs:
+  - verdict
+  - fixes_required
+  - code_issues

--- a/.alcove/agents/test-fail-verify-exit1.yml
+++ b/.alcove/agents/test-fail-verify-exit1.yml
@@ -1,0 +1,28 @@
+name: Test Fail Verify Exit1
+description: |
+  Deterministic test agent that writes verdict=fail and calls sys.exit(1).
+  Documents: Claude Code sessions don't propagate command exit codes.
+  Expected: session completes as "success" despite sys.exit(1).
+
+prompt: |
+  Run this exact command with no modifications. Do not add any other
+  output or commentary. Your only task is to execute this exact script:
+
+  python3 - <<'PYEOF'
+  import json, sys
+  output = {
+      "verdict": "fail",
+      "fixes_required": "fix the broken test in test_group_visibility",
+      "code_issues": "test calls .groups.add() on user_context which has no groups attribute"
+  }
+  with open("/tmp/alcove-outputs.json", "w") as f:
+      json.dump(output, f)
+  sys.exit(1)
+  PYEOF
+
+timeout: 120
+
+outputs:
+  - verdict
+  - fixes_required
+  - code_issues

--- a/.alcove/agents/test-no-outputs.yml
+++ b/.alcove/agents/test-no-outputs.yml
@@ -1,0 +1,17 @@
+name: Test No Outputs
+description: |
+  Deterministic test agent that produces no /tmp/alcove-outputs.json.
+  Tests: how does the engine handle a step with declared outputs but no output file?
+
+prompt: |
+  Run this exact command with no modifications. Do not add any other
+  output or commentary. Your only task is to execute this exact script:
+
+  python3 -c "print('done - no outputs written')"
+
+timeout: 120
+
+outputs:
+  - verdict
+  - fixes_required
+  - code_issues

--- a/.alcove/agents/test-not-automatable.yml
+++ b/.alcove/agents/test-not-automatable.yml
@@ -1,0 +1,34 @@
+name: Test Not Automatable
+description: |
+  Deterministic test agent that writes automatable=false.
+  Tests: does the condition gate prevent the plan step from running?
+
+prompt: |
+  Run this exact command with no modifications. Do not add any other
+  output or commentary. Your only task is to execute this exact script:
+
+  python3 - <<'PYEOF'
+  import json
+  output = {
+      "complexity": "large",
+      "target_area": "test area",
+      "candidate_files": "test.py",
+      "approach": "requires human architectural decisions",
+      "risks": "too complex for automated implementation",
+      "automatable": "false",
+      "reviewers_needed": "django, security"
+  }
+  with open("/tmp/alcove-outputs.json", "w") as f:
+      json.dump(output, f)
+  PYEOF
+
+timeout: 120
+
+outputs:
+  - complexity
+  - target_area
+  - candidate_files
+  - approach
+  - risks
+  - automatable
+  - reviewers_needed

--- a/.alcove/agents/test-reject-review-exit0.yml
+++ b/.alcove/agents/test-reject-review-exit0.yml
@@ -1,0 +1,28 @@
+name: Test Reject Review Exit0
+description: |
+  Deterministic test agent that writes approved=false and exits 0.
+  Tests: does the engine route to revision when output says rejected but exit code is 0?
+
+prompt: |
+  Run this exact command with no modifications. Do not add any other
+  output or commentary. Your only task is to execute this exact script:
+
+  python3 - <<'PYEOF'
+  import json
+  output = {
+      "approved": "false",
+      "comments": "Test rejection: found critical issues in the implementation",
+      "issues": "CRITICAL: broken test pattern; MAJOR: missing error handling"
+  }
+  with open("/tmp/alcove-outputs.json", "w") as f:
+      json.dump(output, f)
+  PYEOF
+
+  Do NOT exit with a non-zero code. Do NOT add error handling or try/except.
+
+timeout: 120
+
+outputs:
+  - approved
+  - comments
+  - issues

--- a/.alcove/workflows/test-routing-no-outputs.yml
+++ b/.alcove/workflows/test-routing-no-outputs.yml
@@ -1,0 +1,46 @@
+name: Test Routing - No Outputs
+description: |
+  Tests engine behavior when an agent produces no /tmp/alcove-outputs.json.
+  Documents: missing outputs are silently treated as success today.
+  With output contracts: contract violation caught, step retried then failed.
+
+trigger:
+  github:
+    events: [issues]
+    actions: [labeled]
+    labels: [routing-test-no-outputs]
+    repos: [alcove-ai/alcove]
+    delivery_mode: polling
+
+workflow:
+  - id: implement
+    type: agent
+    agent: Test Always Pass
+    outputs: [summary]
+
+  - id: verify
+    type: agent
+    agent: Test No Outputs
+    depends: "implement.Succeeded"
+    max_iterations: 2
+    max_retries: 1
+    outputs: [verdict, fixes_required, code_issues]
+    output_contract:
+      required: [verdict]
+      allowed_values:
+        verdict: ["pass", "fail"]
+      routing_field: verdict
+      success_value: "pass"
+
+  - id: patch
+    type: agent
+    agent: Test Always Pass
+    depends: "verify.Failed"
+    max_iterations: 2
+    outputs: [summary]
+
+  - id: review
+    type: agent
+    agent: Test Always Pass
+    depends: "verify.Succeeded"
+    outputs: [approved, comments, issues]

--- a/.alcove/workflows/test-routing-parallel-review.yml
+++ b/.alcove/workflows/test-routing-parallel-review.yml
@@ -1,0 +1,62 @@
+name: Test Routing - Parallel Review (one rejects)
+description: |
+  Tests compound dependency routing with parallel reviewers.
+  review-a approves, review-b rejects. Tests OR-dependency (revision) and AND-dependency.
+  Before output contracts: BROKEN (revision skipped). After contracts: FIXED.
+
+trigger:
+  github:
+    events: [issues]
+    actions: [labeled]
+    labels: [routing-test-parallel-review]
+    repos: [alcove-ai/alcove]
+    delivery_mode: polling
+
+workflow:
+  - id: implement
+    type: agent
+    agent: Test Always Pass
+    outputs: [summary]
+
+  - id: verify
+    type: agent
+    agent: Test Always Pass
+    depends: "implement.Succeeded"
+    outputs: [verdict, fixes_required, code_issues]
+
+  - id: review-a
+    type: agent
+    agent: Test Always Pass
+    depends: "verify.Succeeded"
+    max_iterations: 2
+    outputs: [approved, comments, issues]
+    output_contract:
+      allowed_values:
+        approved: ["true", "false"]
+      routing_field: approved
+      success_value: "true"
+
+  - id: review-b
+    type: agent
+    agent: Test Reject Review Exit0
+    depends: "verify.Succeeded"
+    max_iterations: 2
+    outputs: [approved, comments, issues]
+    output_contract:
+      allowed_values:
+        approved: ["true", "false"]
+      routing_field: approved
+      success_value: "true"
+
+  - id: revision
+    type: agent
+    agent: Test Always Pass
+    depends: "review-a.Failed || review-b.Failed"
+    max_iterations: 2
+    outputs: [summary]
+
+  - id: done
+    type: agent
+    agent: Test Always Pass
+    depends: "review-a.Succeeded && review-b.Succeeded"
+    outputs: [summary]

--- a/.alcove/workflows/test-routing-review-exit0.yml
+++ b/.alcove/workflows/test-routing-review-exit0.yml
@@ -1,0 +1,43 @@
+name: Test Routing - Review Reject (exit 0)
+description: |
+  Tests review->revision routing when reviewer outputs approved=false but exits 0.
+  Before output contracts: BROKEN (revision skipped). After contracts: FIXED.
+
+trigger:
+  github:
+    events: [issues]
+    actions: [labeled]
+    labels: [routing-test-review-exit0]
+    repos: [alcove-ai/alcove]
+    delivery_mode: polling
+
+workflow:
+  - id: implement
+    type: agent
+    agent: Test Always Pass
+    outputs: [summary]
+
+  - id: verify
+    type: agent
+    agent: Test Always Pass
+    depends: "implement.Succeeded"
+    outputs: [verdict, fixes_required, code_issues]
+
+  - id: review
+    type: agent
+    agent: Test Reject Review Exit0
+    depends: "verify.Succeeded"
+    max_iterations: 2
+    outputs: [approved, comments, issues]
+    output_contract:
+      allowed_values:
+        approved: ["true", "false"]
+      routing_field: approved
+      success_value: "true"
+
+  - id: revision
+    type: agent
+    agent: Test Always Pass
+    depends: "review.Failed"
+    max_iterations: 2
+    outputs: [summary]

--- a/.alcove/workflows/test-routing-triage.yml
+++ b/.alcove/workflows/test-routing-triage.yml
@@ -1,0 +1,31 @@
+name: Test Routing - Triage Not Automatable
+description: |
+  Tests condition gate when triage outputs automatable=false.
+  Expected: plan skipped due to condition evaluation. Should work today.
+
+trigger:
+  github:
+    events: [issues]
+    actions: [labeled]
+    labels: [routing-test-triage]
+    repos: [alcove-ai/alcove]
+    delivery_mode: polling
+
+workflow:
+  - id: triage
+    type: agent
+    agent: Test Not Automatable
+    outputs: [complexity, target_area, candidate_files, approach, risks, automatable, reviewers_needed]
+
+  - id: plan
+    type: agent
+    agent: Test Always Pass
+    depends: "triage.Succeeded"
+    condition: "steps.triage.outputs.automatable == 'true'"
+    outputs: [summary]
+
+  - id: implement
+    type: agent
+    agent: Test Always Pass
+    depends: "plan.Succeeded"
+    outputs: [summary]

--- a/.alcove/workflows/test-routing-verify-exit0.yml
+++ b/.alcove/workflows/test-routing-verify-exit0.yml
@@ -1,0 +1,43 @@
+name: Test Routing - Verify Fail (exit 0)
+description: |
+  Tests verify->patch routing when verify outputs verdict=fail but exits 0.
+  Before output contracts: BROKEN (patch skipped). After contracts: FIXED.
+
+trigger:
+  github:
+    events: [issues]
+    actions: [labeled]
+    labels: [routing-test-verify-exit0]
+    repos: [alcove-ai/alcove]
+    delivery_mode: polling
+
+workflow:
+  - id: implement
+    type: agent
+    agent: Test Always Pass
+    outputs: [summary]
+
+  - id: verify
+    type: agent
+    agent: Test Fail Verify Exit0
+    depends: "implement.Succeeded"
+    max_iterations: 2
+    outputs: [verdict, fixes_required, code_issues]
+    output_contract:
+      allowed_values:
+        verdict: ["pass", "fail"]
+      routing_field: verdict
+      success_value: "pass"
+
+  - id: patch
+    type: agent
+    agent: Test Always Pass
+    depends: "verify.Failed"
+    max_iterations: 2
+    outputs: [summary]
+
+  - id: review
+    type: agent
+    agent: Test Always Pass
+    depends: "verify.Succeeded"
+    outputs: [approved, comments, issues]

--- a/.alcove/workflows/test-routing-verify-exit1.yml
+++ b/.alcove/workflows/test-routing-verify-exit1.yml
@@ -1,0 +1,44 @@
+name: Test Routing - Verify Fail (exit 1)
+description: |
+  Documents that sys.exit(1) in Claude Code sessions does NOT propagate as step failure.
+  Expected: behaves identically to exit0 test — patch skipped.
+  With output contracts: contract routing overrides exit code — patch triggered.
+
+trigger:
+  github:
+    events: [issues]
+    actions: [labeled]
+    labels: [routing-test-verify-exit1]
+    repos: [alcove-ai/alcove]
+    delivery_mode: polling
+
+workflow:
+  - id: implement
+    type: agent
+    agent: Test Always Pass
+    outputs: [summary]
+
+  - id: verify
+    type: agent
+    agent: Test Fail Verify Exit1
+    depends: "implement.Succeeded"
+    max_iterations: 2
+    outputs: [verdict, fixes_required, code_issues]
+    output_contract:
+      allowed_values:
+        verdict: ["pass", "fail"]
+      routing_field: verdict
+      success_value: "pass"
+
+  - id: patch
+    type: agent
+    agent: Test Always Pass
+    depends: "verify.Failed"
+    max_iterations: 2
+    outputs: [summary]
+
+  - id: review
+    type: agent
+    agent: Test Always Pass
+    depends: "verify.Succeeded"
+    outputs: [approved, comments, issues]


### PR DESCRIPTION
## Summary

- 6 test workflows and 6 synthetic agents that validate workflow engine routing behavior
- Each workflow tests one critical routing path using deterministic agents with hardcoded outputs
- Tests the output contract system (#616-#618) with real workflow execution

## Test workflows

| Workflow | What it tests | Expected result |
|---|---|---|
| `test-routing-verify-exit0` | verify outputs `verdict=fail`, exits 0 | Contract routes to patch (not review) |
| `test-routing-verify-exit1` | verify outputs `verdict=fail`, exits 1 | Documents exit code limitation in Claude Code |
| `test-routing-review-exit0` | reviewer outputs `approved=false`, exits 0 | Contract routes to revision (not create-pr) |
| `test-routing-triage` | triage outputs `automatable=false` | Condition gate skips plan step |
| `test-routing-parallel-review` | one reviewer approves, one rejects | OR-dep triggers revision, AND-dep blocks done |
| `test-routing-no-outputs` | agent produces no output file | Contract violation caught, step retried then failed |

## How to run

Apply the corresponding label to any issue on this repo:
- `routing-test-verify-exit0`
- `routing-test-verify-exit1`
- `routing-test-review-exit0`
- `routing-test-triage`
- `routing-test-parallel-review`
- `routing-test-no-outputs`

Then export the run for analysis:
```bash
alcove workflows export <run-id>
```

## Context

- Milestone: [Workflow Output Contract Validation](https://github.com/alcove-ai/alcove/milestone/4)
- Design spec: `docs/superpowers/specs/2026-05-13-routing-test-workflows-design.md` (in agent-project)
- Background: Run `0215a51a` showed verify outputting `verdict: fail` but routing to reviews instead of patch

## Test plan

- [ ] Verify all 6 workflows are synced by Bridge (check dashboard)
- [ ] Run each workflow via label trigger
- [ ] Export runs and verify step statuses match expected results
- [ ] Feed exports to RAKI for contract conformance analysis

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>