### PR TITLE
fix: use 'gitlab_project' key in GitLab trigger context

### DIFF
--- a/internal/bridge/enrichment_gitlab.go
+++ b/internal/bridge/enrichment_gitlab.go
@@ -370,7 +370,7 @@ func (e *GitLabEnricher) ExtractGitLabIssueContext(ctx context.Context, token, a
 		"issue_author":      issue.Author.Username,
 		"issue_assignees":   strings.Join(assigneeNames, ","),
 		"issue_labels":      strings.Join(issue.Labels, ","),
-		"project":           project,
+		"gitlab_project":           project,
 	}
 }
 
@@ -423,7 +423,7 @@ func (e *GitLabEnricher) ExtractGitLabMRContext(ctx context.Context, token, apiH
 		"mr_target_branch": mr.TargetBranch,
 		"mr_labels":       strings.Join(mr.Labels, ","),
 		"mr_assignees":    strings.Join(assigneeNames, ","),
-		"project":         project,
+		"gitlab_project":         project,
 	}
 }
 

--- a/internal/bridge/gitlab_poller.go
+++ b/internal/bridge/gitlab_poller.go
@@ -488,7 +488,7 @@ func (gp *GitLabPoller) pollProject(ctx context.Context, token, apiHost, project
 				triggerContext := map[string]interface{}{
 					"event_type":       eventType,
 					"action":           action,
-					"project":          projectPath,
+					"gitlab_project":          projectPath,
 					"branch":           branch,
 					"enriched_context": enrichedContext,
 				}


### PR DESCRIPTION
Fixes #703

- Updated `internal/bridge/gitlab_poller.go` to use `gitlab_project` instead of `project`.
- Updated `ExtractGitLabIssueContext` and `ExtractGitLabMRContext` in `internal/bridge/enrichment_gitlab.go` to match.