### PR TITLE
ci: add golangci-lint (incl. staticcheck) PR gate + opt-in pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,29 @@ jobs:
         env:
           GOPROXY: direct
 
+  # Lint — runs on every PR. Fast static analysis via golangci-lint, which bundles
+  # staticcheck, govet, errcheck, ineffassign, and unused (config in .golangci.yml).
+  # `only-new-issues` gates issues a PR *introduces* without blocking on the existing
+  # lint debt, so the check can be adopted now and tightened as the baseline is cleaned.
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
+          only-new-issues: true
+
   # Everything below only runs on pushes to main (post-merge) or manual workflow dispatch.
   # These are heavier tests that validate the full stack but don't block PRs.
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+# golangci-lint configuration (config schema v2 — golangci-lint >= 2.x).
+#
+# Adoption strategy for an existing codebase with pre-existing lint debt:
+# CI runs golangci-lint with `only-new-issues: true` (see
+# .github/workflows/ci.yml) and `make pre-commit` runs it with
+# `--new-from-merge-base=main`. Both gate only the issues a change *introduces*,
+# never the historical baseline — so linting can land now and be tightened
+# incrementally as the existing debt is paid down. golangci-lint bundles
+# staticcheck, govet, errcheck, ineffassign, and unused, so a single
+# golangci-lint run covers the checks the standalone `make lint` target runs
+# plus more.
+version: "2"
+
+linters:
+  enable:
+    - errcheck
+    - gocritic
+    - gosec
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@ make build                    # Build all Go binaries to bin/
 make build-images             # Build container images with podman (smart rebuild via stamps)
 make build-tooling            # Build heavy skiff-tooling base image (only when tools change)
 make test                     # Run tests
+make pre-commit               # Run go vet + golangci-lint (issues new since main) before committing
+make install-hooks            # Install the opt-in git pre-commit hook (runs 'make pre-commit')
 
 # Infrastructure
 make dev-infra                # Start only NATS + PostgreSQL on podman

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GATE_SOURCES := $(shell find cmd/gate/ -name '*.go' -type f 2>/dev/null) build/C
 SKIFF_SOURCES := $(shell find cmd/skiff-init/ -name '*.go' -type f 2>/dev/null) build/Containerfile.skiff-base build/alcove-credential-helper
 
 .PHONY: all build build-cli-all build-images build-image-bridge build-image-gate build-image-skiff-base build-skiff build-dev \
-        test test-network test-ledger test-isolation test-schedules test-credentials test-security-profiles test-yaml-security-profiles test-gate-real lint clean clean-stamps \
+        test test-network test-ledger test-isolation test-schedules test-credentials test-security-profiles test-yaml-security-profiles test-gate-real lint pre-commit install-hooks clean clean-stamps \
         up down logs watch dev-config dev-up dev-down dev-logs dev-reset dev-infra help \
         login-registry push pull up-pull build-tooling push-tooling \
         k3s-setup k3s-up k3s-watch k3s-down k3s-reset k3s-status
@@ -411,6 +411,16 @@ lint: ## Run linters (go vet + staticcheck)
 	$(GO) vet ./...
 	@which staticcheck >/dev/null 2>&1 && staticcheck ./... || \
 		echo "staticcheck not installed; run: go install honnef.co/go/tools/cmd/staticcheck@latest"
+
+pre-commit: ## Run pre-commit checks (go vet + golangci-lint on issues new since main)
+	$(GO) vet ./...
+	@which golangci-lint >/dev/null 2>&1 && golangci-lint run --new-from-merge-base=main || \
+		echo "golangci-lint not installed; run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest"
+
+install-hooks: ## Install the opt-in git pre-commit hook (runs 'make pre-commit')
+	@cp scripts/git-hooks/pre-commit .git/hooks/pre-commit
+	@chmod +x .git/hooks/pre-commit
+	@echo "Installed .git/hooks/pre-commit — it runs 'make pre-commit' on every commit."
 
 ##@ Cleanup
 

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Alcove git pre-commit hook (opt-in — install with `make install-hooks`).
+#
+# Runs the same static-analysis gate as CI on the changes being committed:
+# go vet plus golangci-lint (only issues new since main). Exits non-zero to
+# abort the commit if the checks fail.
+exec make pre-commit


### PR DESCRIPTION
## Summary

Adds a `lint` CI job backed by golangci-lint (staticcheck bundled), a `.golangci.yml`, and opt-in pre-commit tooling.

## Changes

- `.github/workflows/ci.yml` (+23) — a `lint` job on `pull_request` only, avoiding a perpetually-ambiguous post-merge `only-new-issues` run
- `.golangci.yml` (+22)
- `Makefile` (+11/−1) — `make pre-commit` / `make install-hooks`
- `scripts/git-hooks/pre-commit` (+7) — tracked hook script, copied at 0755 by `install-hooks` rather than echoing an inline script
- `CLAUDE.md` (+2) — the quick-command lines

## Testing

`make build` ✓, `go vet ./...` ✓, `go test -short ./...` ✓, `golangci-lint config verify` ✓, `golangci-lint run --new-from-merge-base=main` → 0 issues, `actionlint` → zero findings in the new job, `make pre-commit` ✓.

The gate is verified non-vacuous: a deliberately-injected ineffassign is flagged (rc=1), and the branch itself runs clean.

The 4 `TestJiraPoller_*` DB-integration failures on my box are a stray local Postgres on :5432 defeating their skip guard — they skip in CI's serviceless job. The 49 shellcheck warnings from actionlint are pre-existing elsewhere in `ci.yml`.

## Follow-ups / Known Limitations

Four deviations from the issue's literal spec, each forced by the current tree — happy to rework any of them:

1. **v2 config, `golangci-lint-action@v8`** — latest golangci-lint is 2.12.2 and the issue's config/action pin are v1-era (`linters-settings`, `@v6` won't parse or run a v2 config). Adapted the schema; dropped `exclude-dirs: [vendor]` since there is no vendor dir.
2. **staticcheck runs bundled inside golangci-lint, no separate step** — the option the issue itself suggests. A standalone `staticcheck ./...` step would be red on ~32 pre-existing findings.
3. **`only-new-issues: true` (CI) / `--new-from-merge-base=main` (pre-commit)** — the issue's full linter set flags 187 pre-existing issues (errcheck 50, gosec 29, staticcheck 32, gocritic 11, unused 10, ineffassign 5, plus ~50 from `govet: enable-all`), several risky or behavioral to "just fix" such as swallowed errors and deprecated APIs. Per the issue's own "start conservative — expand once the baseline is clean", the gate is diff-based: new code is linted hard, the debt doesn't block unrelated PRs. Paying the 187 down incrementally and then tightening would make a good follow-up series.
4. **Dropped `govet: enable-all`** — fieldalignment/shadow are ~50 of that baseline; kept default govet.

Fixes #694

## Footer

Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (implementation)